### PR TITLE
sdk: Add prefix classifier and typed exception subclasses (#136)

### DIFF
--- a/sdk/src/memoryhub/__init__.py
+++ b/sdk/src/memoryhub/__init__.py
@@ -12,10 +12,14 @@ from memoryhub.config import (
 )
 from memoryhub.exceptions import (
     AuthenticationError,
+    ConflictError,
     ConnectionFailedError,
+    CurationVetoError,
     MemoryHubError,
     NotFoundError,
+    PermissionDeniedError,
     ToolError,
+    ValidationError,
 )
 
 __version__ = "0.1.0"
@@ -25,9 +29,13 @@ __all__ = [
     "MemoryUpdatedCallback",
     "MemoryHubError",
     "AuthenticationError",
-    "NotFoundError",
-    "ToolError",
+    "ConflictError",
     "ConnectionFailedError",
+    "CurationVetoError",
+    "NotFoundError",
+    "PermissionDeniedError",
+    "ToolError",
+    "ValidationError",
     # Project configuration
     "CONFIG_FILENAME",
     "ConfigError",

--- a/sdk/src/memoryhub/client.py
+++ b/sdk/src/memoryhub/client.py
@@ -16,10 +16,15 @@ from fastmcp.client.messages import MessageHandler
 from memoryhub.auth import MemoryHubAuth
 from memoryhub.config import ProjectConfig, load_project_config
 from memoryhub.exceptions import (
+    AuthenticationError,
+    ConflictError,
     ConnectionFailedError,
+    CurationVetoError,
     MemoryHubError,
     NotFoundError,
+    PermissionDeniedError,
     ToolError,
+    ValidationError,
 )
 from memoryhub.models import (
     ContradictionResult,
@@ -242,9 +247,22 @@ class MemoryHubClient:
             if result.content:
                 item = result.content[0]
                 msg = item.text if hasattr(item, "text") else str(item)
-            if "not found" in msg.lower():
+            msg_lower = msg.lower()
+            # Classify by message prefix — order matters (most specific first)
+            if "invalid api key" in msg_lower or "no authenticated session" in msg_lower:
+                raise AuthenticationError(msg)
+            if msg_lower.startswith("curation rule blocked"):
+                raise CurationVetoError(tool_name, msg)
+            if "not found" in msg_lower:
                 memory_id = args.get("memory_id", "unknown")
                 raise NotFoundError(memory_id, msg)
+            if "not authorized" in msg_lower or msg_lower.startswith("access denied:"):
+                raise PermissionDeniedError(tool_name, msg)
+            if "already exists" in msg_lower or "already deleted" in msg_lower:
+                raise ConflictError(tool_name, msg)
+            if (msg_lower.startswith("invalid ") or " must be " in msg_lower
+                    or "cannot be empty" in msg_lower):
+                raise ValidationError(tool_name, msg)
             raise ToolError(tool_name, msg or "Unknown error (empty response)")
 
         # Prefer structured_content (parsed JSON dict)

--- a/sdk/src/memoryhub/exceptions.py
+++ b/sdk/src/memoryhub/exceptions.py
@@ -35,5 +35,21 @@ class ToolError(MemoryHubError):
         super().__init__(f"{tool_name}: {detail}")
 
 
+class PermissionDeniedError(ToolError):
+    """The caller is not authorized to perform this operation."""
+
+
+class ValidationError(ToolError):
+    """Invalid parameter or request shape."""
+
+
+class ConflictError(ToolError):
+    """Conflict with existing state (e.g., already exists, already deleted)."""
+
+
+class CurationVetoError(ToolError):
+    """A curation rule blocked the operation."""
+
+
 class ConnectionFailedError(MemoryHubError):
     """Failed to connect to the MemoryHub MCP server."""

--- a/sdk/tests/test_client.py
+++ b/sdk/tests/test_client.py
@@ -9,7 +9,17 @@ import pytest
 
 from memoryhub.client import MemoryHubClient
 from memoryhub.config import ProjectConfig, RetrievalDefaults
-from memoryhub.exceptions import ConnectionFailedError, MemoryHubError, NotFoundError, ToolError
+from memoryhub.exceptions import (
+    AuthenticationError,
+    ConflictError,
+    ConnectionFailedError,
+    CurationVetoError,
+    MemoryHubError,
+    NotFoundError,
+    PermissionDeniedError,
+    ToolError,
+    ValidationError,
+)
 from memoryhub.models import ContradictionResult, HistoryResult, Memory, SearchResult, WriteResult
 
 # ── Fake MCP response types ──────────────────────────────────────────────────
@@ -577,6 +587,139 @@ async def test_connection_error_without_context_manager():
 
     with pytest.raises(ConnectionFailedError, match="async with client"):
         await c.search("anything")
+
+
+async def test_authentication_error_from_invalid_api_key(client):
+    """_call() classifies 'Invalid API key' messages as AuthenticationError."""
+    c, mock_mcp = client
+    mock_mcp.call_tool.return_value = FakeCallToolResult(
+        is_error=True,
+        content=[FakeContent("Invalid API key. Contact your system administrator.")],
+    )
+    with pytest.raises(AuthenticationError, match="Invalid API key"):
+        await c.search("anything")
+
+
+async def test_authentication_error_from_no_session(client):
+    """_call() classifies 'No authenticated session' messages as AuthenticationError."""
+    c, mock_mcp = client
+    mock_mcp.call_tool.return_value = FakeCallToolResult(
+        is_error=True,
+        content=[FakeContent("No authenticated session. Call register_session first.")],
+    )
+    with pytest.raises(AuthenticationError, match="No authenticated session"):
+        await c.search("anything")
+
+
+async def test_permission_denied_error(client):
+    c, mock_mcp = client
+    mock_mcp.call_tool.return_value = FakeCallToolResult(
+        is_error=True,
+        content=[FakeContent("Not authorized to read memory in scope 'enterprise'")],
+    )
+    with pytest.raises(PermissionDeniedError) as exc_info:
+        await c.read("mem-001")
+    assert exc_info.value.tool_name == "read_memory"
+    assert "Not authorized" in exc_info.value.detail
+
+
+async def test_permission_denied_access_denied_prefix(client):
+    c, mock_mcp = client
+    mock_mcp.call_tool.return_value = FakeCallToolResult(
+        is_error=True,
+        content=[FakeContent("Access denied: insufficient scope for this operation")],
+    )
+    with pytest.raises(PermissionDeniedError):
+        await c.read("mem-001")
+
+
+async def test_validation_error(client):
+    c, mock_mcp = client
+    mock_mcp.call_tool.return_value = FakeCallToolResult(
+        is_error=True,
+        content=[FakeContent("Invalid memory_id: not a valid UUID")],
+    )
+    with pytest.raises(ValidationError) as exc_info:
+        await c.read("bad-id")
+    assert exc_info.value.tool_name == "read_memory"
+
+
+async def test_validation_error_must_be(client):
+    c, mock_mcp = client
+    mock_mcp.call_tool.return_value = FakeCallToolResult(
+        is_error=True,
+        content=[FakeContent("weight must be between 0 and 1")],
+    )
+    with pytest.raises(ValidationError):
+        await c.write("test", scope="user", weight=5.0)
+
+
+async def test_validation_error_cannot_be_empty(client):
+    c, mock_mcp = client
+    mock_mcp.call_tool.return_value = FakeCallToolResult(
+        is_error=True,
+        content=[FakeContent("content cannot be empty")],
+    )
+    with pytest.raises(ValidationError):
+        await c.write("", scope="user")
+
+
+async def test_conflict_error_already_exists(client):
+    c, mock_mcp = client
+    mock_mcp.call_tool.return_value = FakeCallToolResult(
+        is_error=True,
+        content=[FakeContent("Relationship already exists between these memories")],
+    )
+    with pytest.raises(ConflictError) as exc_info:
+        await c._call("create_relationship", {"source_id": "a", "target_id": "b"})
+    assert exc_info.value.tool_name == "create_relationship"
+
+
+async def test_conflict_error_already_deleted(client):
+    c, mock_mcp = client
+    mock_mcp.call_tool.return_value = FakeCallToolResult(
+        is_error=True,
+        content=[FakeContent("Memory mem-001 already deleted")],
+    )
+    with pytest.raises(ConflictError):
+        await c._call("delete_memory", {"memory_id": "mem-001"})
+
+
+async def test_curation_veto_error(client):
+    c, mock_mcp = client
+    mock_mcp.call_tool.return_value = FakeCallToolResult(
+        is_error=True,
+        content=[FakeContent("Curation rule blocked: duplicate content detected")],
+    )
+    with pytest.raises(CurationVetoError) as exc_info:
+        await c.write("duplicate stuff", scope="user")
+    assert exc_info.value.tool_name == "write_memory"
+    assert "Curation rule blocked" in exc_info.value.detail
+
+
+async def test_generic_tool_error_fallback(client):
+    """Messages that don't match any prefix fall through to generic ToolError."""
+    c, mock_mcp = client
+    mock_mcp.call_tool.return_value = FakeCallToolResult(
+        is_error=True,
+        content=[FakeContent("Something completely unexpected happened")],
+    )
+    with pytest.raises(ToolError) as exc_info:
+        await c.search("anything")
+    # Should NOT be a subclass — exactly ToolError
+    assert type(exc_info.value) is ToolError
+
+
+async def test_exception_hierarchy():
+    """New exceptions are subclasses of ToolError and MemoryHubError."""
+    assert issubclass(PermissionDeniedError, ToolError)
+    assert issubclass(ValidationError, ToolError)
+    assert issubclass(ConflictError, ToolError)
+    assert issubclass(CurationVetoError, ToolError)
+    assert issubclass(PermissionDeniedError, MemoryHubError)
+    # AuthenticationError is NOT a subclass of ToolError (it's a sibling)
+    assert not issubclass(AuthenticationError, ToolError)
+    assert issubclass(AuthenticationError, MemoryHubError)
 
 
 # ── None-arg stripping ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Adds `PermissionDeniedError`, `ValidationError`, `ConflictError`, `CurationVetoError` as subclasses of `ToolError` in `sdk/src/memoryhub/exceptions.py`
- Extends `_call()` prefix classifier to map tool error messages to specific exception types
- Updates `__init__.py` exports
- 13 new tests covering each classification branch and hierarchy

## Test plan
- [ ] `cd sdk && pytest tests/ -v` — all tests pass
- [ ] Verify `except ToolError` still catches PermissionDeniedError, ValidationError, ConflictError, CurationVetoError (subclass relationship)
- [ ] Verify `except AuthenticationError` catches "Invalid API key" tool errors (existing class, NOT a ToolError subclass)

Closes #136
Part of #97