### PR TITLE
mcp-server: Standardize get_similar_memories error responses (#130)

### DIFF
--- a/memory-hub-mcp/src/tools/get_similar_memories.py
+++ b/memory-hub-mcp/src/tools/get_similar_memories.py
@@ -1,10 +1,14 @@
 """Get memories similar to a given memory, with similarity scores."""
 
+import logging
 import uuid
 from typing import Annotated, Any
 
 from fastmcp import Context
+from fastmcp.exceptions import ToolError
 from pydantic import Field
+
+logger = logging.getLogger(__name__)
 
 from src.core.app import mcp
 from src.core.authz import (
@@ -66,16 +70,15 @@ async def get_similar_memories(
     try:
         claims = get_claims_from_context()
     except AuthenticationError as exc:
-        return {"error": True, "message": str(exc)}
+        raise ToolError(str(exc)) from exc
     tenant = get_tenant_filter(claims)
 
     try:
         parsed_memory_id = uuid.UUID(memory_id)
     except ValueError:
-        return {
-            "error": True,
-            "message": f"Invalid memory_id format: {memory_id!r}. Must be a valid UUID.",
-        }
+        raise ToolError(
+            f"Invalid memory_id format: {memory_id!r}. Must be a valid UUID."
+        )
 
     gen = None
     try:
@@ -91,10 +94,7 @@ async def get_similar_memories(
             parsed_memory_id, session, tenant_id=tenant
         )
         if not authorize_read(claims, source):
-            return {
-                "error": True,
-                "message": f"Not authorized to read memory {memory_id}.",
-            }
+            raise ToolError(f"Not authorized to read memory {memory_id}.")
 
         result = await get_similar_memories_service(
             parsed_memory_id,
@@ -112,13 +112,15 @@ async def get_similar_memories(
 
         return result
 
+    except ToolError:
+        raise
     except MemoryNotFoundError as exc:
-        return {
-            "error": True,
-            "message": f"Memory {exc.memory_id} not found.",
-        }
+        raise ToolError(f"Memory {exc.memory_id} not found.")
     except Exception as exc:
-        return {"error": True, "message": f"Failed to get similar memories: {exc}"}
+        logger.error("Failed to get similar memories for %s: %s", memory_id, exc, exc_info=True)
+        raise ToolError(
+            f"Failed to get similar memories for {memory_id}. See server logs for details."
+        ) from exc
     finally:
         if gen is not None:
             await release_db_session(gen)

--- a/memory-hub-mcp/tests/test_tenant_isolation.py
+++ b/memory-hub-mcp/tests/test_tenant_isolation.py
@@ -1285,11 +1285,9 @@ async def test_get_similar_memories_cross_tenant_returns_not_found():
             "src.tools.get_similar_memories.get_similar_memories_service",
             new=AsyncMock(side_effect=_fake_similar),
         ),
+        pytest.raises(ToolError, match="(?i)not found"),
     ):
-        result = await get_similar_memories(memory_id=memory_id)
-
-    assert result.get("error") is True
-    assert "not found" in result["message"].lower()
+        await get_similar_memories(memory_id=memory_id)
 
 
 @pytest.mark.asyncio

--- a/memory-hub-mcp/tests/tools/test_get_similar_memories.py
+++ b/memory-hub-mcp/tests/tools/test_get_similar_memories.py
@@ -5,6 +5,7 @@ import uuid
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from fastmcp.exceptions import ToolError
 
 import src.tools.auth as auth_mod
 from src.tools.get_similar_memories import get_similar_memories
@@ -48,18 +49,17 @@ def test_get_similar_memories_default_values():
 
 @pytest.mark.asyncio
 async def test_get_similar_memories_requires_auth():
-    """Unauthenticated calls return an error."""
+    """Unauthenticated calls raise ToolError."""
     auth_mod._current_session = None
-    result = await get_similar_memories(memory_id=str(uuid.uuid4()))
-    assert result["error"] is True
+    with pytest.raises(ToolError):
+        await get_similar_memories(memory_id=str(uuid.uuid4()))
 
 
 @pytest.mark.asyncio
 async def test_get_similar_memories_invalid_uuid():
-    """Bad UUID format returns a clear error."""
-    result = await get_similar_memories(memory_id="not-a-uuid")
-    assert result["error"] is True
-    assert "Invalid memory_id format" in result["message"]
+    """Bad UUID format raises ToolError with a clear message."""
+    with pytest.raises(ToolError, match="Invalid memory_id format"):
+        await get_similar_memories(memory_id="not-a-uuid")
 
 
 @pytest.mark.asyncio
@@ -169,27 +169,25 @@ async def test_get_similar_memories_unauthorized_for_other_owner():
     mock_gen = AsyncMock()
     other_owner_source = SimpleNamespace(scope="user", owner_id="someone-else", tenant_id="default")
 
-    with (
-        patch("src.tools.get_similar_memories.get_db_session", return_value=(mock_session, mock_gen)),
-        patch("src.tools.get_similar_memories.release_db_session", new_callable=AsyncMock),
-        patch(
-            "src.tools.get_similar_memories.read_memory_service",
-            new_callable=AsyncMock,
-            return_value=other_owner_source,
-        ),
-    ):
-        auth_mod._current_session = {
-            "user_id": "wjackson",
-            "scopes": ["user"],
-            "identity_type": "user",
-        }
-        try:
-            result = await get_similar_memories(memory_id=str(uuid.uuid4()))
-        finally:
-            auth_mod._current_session = None
-
-    assert result["error"] is True
-    assert "Not authorized" in result["message"]
+    auth_mod._current_session = {
+        "user_id": "wjackson",
+        "scopes": ["user"],
+        "identity_type": "user",
+    }
+    try:
+        with (
+            patch("src.tools.get_similar_memories.get_db_session", return_value=(mock_session, mock_gen)),
+            patch("src.tools.get_similar_memories.release_db_session", new_callable=AsyncMock),
+            patch(
+                "src.tools.get_similar_memories.read_memory_service",
+                new_callable=AsyncMock,
+                return_value=other_owner_source,
+            ),
+            pytest.raises(ToolError, match="Not authorized"),
+        ):
+            await get_similar_memories(memory_id=str(uuid.uuid4()))
+    finally:
+        auth_mod._current_session = None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Converts error-dict returns in get_similar_memories to raise ToolError
- Updates tests to use pytest.raises(ToolError)

## Test plan
- [x] Full test suite passes

Closes #130
Part of #97