### PR TITLE
mcp-server: Standardize get_relationships error responses (#131)

### DIFF
--- a/memory-hub-mcp/src/tools/get_relationships.py
+++ b/memory-hub-mcp/src/tools/get_relationships.py
@@ -1,11 +1,15 @@
 """Get graph relationships for a memory node, with optional provenance tracing."""
 
+import logging
 import uuid
 from types import SimpleNamespace
 from typing import Annotated, Any
 
 from fastmcp import Context
+from fastmcp.exceptions import ToolError
 from pydantic import Field
+
+logger = logging.getLogger(__name__)
 
 from src.core.app import mcp
 from src.core.authz import (
@@ -85,34 +89,27 @@ async def get_relationships(
     try:
         claims = get_claims_from_context()
     except AuthenticationError as exc:
-        return {"error": True, "message": str(exc)}
+        raise ToolError(str(exc)) from exc
     tenant = get_tenant_filter(claims)
 
     try:
         parsed_node_id = uuid.UUID(node_id)
     except ValueError:
-        return {
-            "error": True,
-            "message": f"Invalid node_id format: {node_id!r}. Must be a valid UUID.",
-        }
+        raise ToolError(
+            f"Invalid node_id format: {node_id!r}. Must be a valid UUID."
+        )
 
     if direction not in _VALID_DIRECTIONS:
-        return {
-            "error": True,
-            "message": (
-                f"Invalid direction {direction!r}. "
-                f"Must be one of: {', '.join(_VALID_DIRECTIONS)}."
-            ),
-        }
+        raise ToolError(
+            f"Invalid direction {direction!r}. "
+            f"Must be one of: {', '.join(_VALID_DIRECTIONS)}."
+        )
 
     if relationship_type is not None and relationship_type not in _VALID_TYPES:
-        return {
-            "error": True,
-            "message": (
-                f"Invalid relationship_type {relationship_type!r}. "
-                f"Must be one of: {', '.join(_VALID_TYPES)}."
-            ),
-        }
+        raise ToolError(
+            f"Invalid relationship_type {relationship_type!r}. "
+            f"Must be one of: {', '.join(_VALID_TYPES)}."
+        )
 
     gen = None
     try:
@@ -173,16 +170,18 @@ async def get_relationships(
 
         return result
 
+    except ToolError:
+        raise
     except MemoryNotFoundError as exc:
-        return {
-            "error": True,
-            "message": (
-                f"Memory node {exc.memory_id} not found. "
-                "Verify the node_id refers to an existing memory node."
-            ),
-        }
+        raise ToolError(
+            f"Memory node {exc.memory_id} not found. "
+            "Verify the node_id refers to an existing memory node."
+        ) from exc
     except Exception as exc:
-        return {"error": True, "message": f"Failed to get relationships: {exc}"}
+        logger.error("Failed to get relationships for %s: %s", node_id, exc, exc_info=True)
+        raise ToolError(
+            f"Failed to get relationships for node {node_id}. See server logs for details."
+        ) from exc
     finally:
         if gen is not None:
             await release_db_session(gen)

--- a/memory-hub-mcp/tests/test_tenant_isolation.py
+++ b/memory-hub-mcp/tests/test_tenant_isolation.py
@@ -1103,11 +1103,9 @@ async def test_get_relationships_cross_tenant_returns_not_found():
             "src.tools.get_relationships.get_relationships_service",
             new=AsyncMock(side_effect=_fake_get_rels),
         ),
+        pytest.raises(ToolError, match="not found"),
     ):
-        result = await get_relationships(node_id=str(src_id))
-
-    assert result.get("error") is True
-    assert "not found" in result["message"].lower()
+        await get_relationships(node_id=str(src_id))
 
 
 @pytest.mark.asyncio

--- a/memory-hub-mcp/tests/tools/test_get_relationships.py
+++ b/memory-hub-mcp/tests/tools/test_get_relationships.py
@@ -5,6 +5,7 @@ import uuid
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from fastmcp.exceptions import ToolError
 
 import src.tools.auth as auth_mod
 from src.tools.get_relationships import get_relationships
@@ -48,40 +49,37 @@ def test_get_relationships_default_values():
 
 @pytest.mark.asyncio
 async def test_get_relationships_requires_auth():
-    """Unauthenticated calls return an error."""
+    """Unauthenticated calls raise ToolError."""
     auth_mod._current_session = None
-    result = await get_relationships(node_id=str(uuid.uuid4()))
-    assert result["error"] is True
+    with pytest.raises(ToolError):
+        await get_relationships(node_id=str(uuid.uuid4()))
 
 
 @pytest.mark.asyncio
 async def test_get_relationships_invalid_uuid():
-    """Bad UUID format returns a clear error."""
-    result = await get_relationships(node_id="not-a-uuid")
-    assert result["error"] is True
-    assert "Invalid node_id format" in result["message"]
+    """Bad UUID format raises ToolError with a clear message."""
+    with pytest.raises(ToolError, match="Invalid node_id format"):
+        await get_relationships(node_id="not-a-uuid")
 
 
 @pytest.mark.asyncio
 async def test_get_relationships_invalid_direction():
-    """Invalid direction returns an error with valid options."""
-    result = await get_relationships(
-        node_id=str(uuid.uuid4()),
-        direction="sideways",
-    )
-    assert result["error"] is True
-    assert "outgoing" in result["message"]
+    """Invalid direction raises ToolError listing valid options."""
+    with pytest.raises(ToolError, match="outgoing"):
+        await get_relationships(
+            node_id=str(uuid.uuid4()),
+            direction="sideways",
+        )
 
 
 @pytest.mark.asyncio
 async def test_get_relationships_invalid_type():
-    """Invalid relationship_type returns an error."""
-    result = await get_relationships(
-        node_id=str(uuid.uuid4()),
-        relationship_type="bad_type",
-    )
-    assert result["error"] is True
-    assert "derived_from" in result["message"]
+    """Invalid relationship_type raises ToolError listing valid types."""
+    with pytest.raises(ToolError, match="derived_from"):
+        await get_relationships(
+            node_id=str(uuid.uuid4()),
+            relationship_type="bad_type",
+        )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Converts error-dict returns in get_relationships to raise ToolError
- Updates tests to use pytest.raises(ToolError)

## Test plan
- [x] Full test suite passes

Closes #131
Part of #97