### PR TITLE
mcp-server: Standardize set_curation_rule error responses (#132)

### DIFF
--- a/memory-hub-mcp/src/tools/set_curation_rule.py
+++ b/memory-hub-mcp/src/tools/set_curation_rule.py
@@ -1,9 +1,13 @@
 """Create or update a user-layer curation rule."""
 
+import logging
 from typing import Annotated, Any
 
 from fastmcp import Context
+from fastmcp.exceptions import ToolError
 from pydantic import Field
+
+logger = logging.getLogger(__name__)
 from sqlalchemy import and_, select
 
 from src.core.app import mcp
@@ -92,7 +96,7 @@ async def set_curation_rule(
     try:
         claims = get_claims_from_context()
     except AuthenticationError as exc:
-        return {"error": True, "message": str(exc)}
+        raise ToolError(str(exc)) from exc
 
     # Admin operations require memory:admin scope or service identity
     caller_scopes = claims.get("scopes", [])
@@ -103,19 +107,17 @@ async def set_curation_rule(
         pass  # allowed — user-layer rules are scoped to owner_id below
 
     if tier not in _VALID_TIERS:
-        return {
-            "error": True,
-            "message": f"Invalid tier {tier!r}. Must be one of: {', '.join(_VALID_TIERS)}.",
-        }
+        raise ToolError(
+            f"Invalid tier {tier!r}. Must be one of: {', '.join(_VALID_TIERS)}."
+        )
 
     if action not in _VALID_ACTIONS:
-        return {
-            "error": True,
-            "message": f"Invalid action {action!r}. Must be one of: {', '.join(_VALID_ACTIONS)}.",
-        }
+        raise ToolError(
+            f"Invalid action {action!r}. Must be one of: {', '.join(_VALID_ACTIONS)}."
+        )
 
     if not name.strip():
-        return {"error": True, "message": "name cannot be empty."}
+        raise ToolError("name cannot be empty.")
 
     owner_id = claims["sub"]
     tenant_id = get_tenant_filter(claims)
@@ -139,13 +141,10 @@ async def set_curation_rule(
         protected_result = await session.execute(protected_stmt)
         protected_rule = protected_result.scalar_one_or_none()
         if protected_rule is not None:
-            return {
-                "error": True,
-                "message": (
-                    f"Cannot override system rule {name!r} — it is protected "
-                    "by the platform administrator."
-                ),
-            }
+            raise ToolError(
+                f"Cannot override system rule {name!r} — it is protected "
+                "by the platform administrator."
+            )
 
         # Check for existing user rule with this name (upsert). Scope by
         # tenant so tenant A's rule doesn't collide with tenant B's rule of
@@ -200,8 +199,13 @@ async def set_curation_rule(
             "rule": rule_read.model_dump(mode="json"),
         }
 
+    except ToolError:
+        raise
     except Exception as exc:
-        return {"error": True, "message": f"Failed to set curation rule: {exc}"}
+        logger.error("Failed to set curation rule %r: %s", name, exc, exc_info=True)
+        raise ToolError(
+            f"Failed to set curation rule {name!r}. See server logs for details."
+        ) from exc
     finally:
         if gen is not None:
             await release_db_session(gen)

--- a/memory-hub-mcp/tests/tools/test_set_curation_rule.py
+++ b/memory-hub-mcp/tests/tools/test_set_curation_rule.py
@@ -5,6 +5,7 @@ import uuid
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from fastmcp.exceptions import ToolError
 
 import src.tools.auth as auth_mod
 from src.tools.set_curation_rule import set_curation_rule
@@ -51,26 +52,24 @@ def test_set_curation_rule_default_values():
 
 @pytest.mark.asyncio
 async def test_set_curation_rule_requires_auth():
-    """Unauthenticated calls return an error."""
+    """Unauthenticated calls raise ToolError."""
     auth_mod._current_session = None
-    result = await set_curation_rule(name="my_rule")
-    assert result["error"] is True
+    with pytest.raises(ToolError):
+        await set_curation_rule(name="my_rule")
 
 
 @pytest.mark.asyncio
 async def test_set_curation_rule_invalid_tier():
-    """Invalid tier returns an error with valid options."""
-    result = await set_curation_rule(name="my_rule", tier="magic")
-    assert result["error"] is True
-    assert "regex" in result["message"]
+    """Invalid tier raises ToolError with valid options."""
+    with pytest.raises(ToolError, match="regex"):
+        await set_curation_rule(name="my_rule", tier="magic")
 
 
 @pytest.mark.asyncio
 async def test_set_curation_rule_invalid_action():
-    """Invalid action returns an error with valid options."""
-    result = await set_curation_rule(name="my_rule", action="destroy")
-    assert result["error"] is True
-    assert "flag" in result["message"]
+    """Invalid action raises ToolError with valid options."""
+    with pytest.raises(ToolError, match="flag"):
+        await set_curation_rule(name="my_rule", action="destroy")
 
 
 @pytest.mark.asyncio
@@ -88,10 +87,9 @@ async def test_set_curation_rule_protected_system_rule():
     with (
         patch("src.tools.set_curation_rule.get_db_session", return_value=(mock_session, mock_gen)),
         patch("src.tools.set_curation_rule.release_db_session", new_callable=AsyncMock),
+        pytest.raises(ToolError, match="protected"),
     ):
-        result = await set_curation_rule(name="secrets_scan")
-    assert result["error"] is True
-    assert "protected" in result["message"]
+        await set_curation_rule(name="secrets_scan")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Converts 6 error-dict returns in set_curation_rule to raise ToolError
- Adds except-ToolError-raise guard before generic handler
- Scrubs internal details from generic exception messages
- Updates 4 tests to use pytest.raises(ToolError)

## Test plan
- [x] Full test suite: 205 tests pass

Closes #132
Part of #97