### PR TITLE
mcp-server: Wire campaign_ids into read-path tools (#162)

### DIFF
--- a/memory-hub-mcp/src/tools/create_relationship.py
+++ b/memory-hub-mcp/src/tools/create_relationship.py
@@ -20,6 +20,7 @@ from src.core.authz import (
 from src.tools._deps import get_db_session, release_db_session
 
 from memoryhub_core.models.schemas import RelationshipCreate, RelationshipType
+from memoryhub_core.services.campaign import get_campaigns_for_project
 from memoryhub_core.services.exceptions import MemoryNotFoundError
 from memoryhub_core.services.graph import create_relationship as create_relationship_service
 from memoryhub_core.services.memory import read_memory as _read_memory
@@ -55,6 +56,16 @@ async def create_relationship(
     metadata: Annotated[
         dict[str, Any] | None,
         Field(description="Optional key-value pairs to attach to the relationship edge."),
+    ] = None,
+    project_id: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Your project identifier. Required when either memory node has "
+                "campaign scope — used to verify your project is enrolled in "
+                "the campaign."
+            ),
+        ),
     ] = None,
     ctx: Context = None,
 ) -> dict[str, Any]:
@@ -107,6 +118,10 @@ async def create_relationship(
     try:
         session, gen = await get_db_session()
 
+        # Resolve campaign membership once — used for both nodes if either
+        # is campaign-scoped.
+        campaign_ids: set[str] | None = None
+
         # Verify read access to both nodes. The tenant filter on
         # read_memory makes a cross-tenant ID indistinguishable from a
         # nonexistent row, so a cross-tenant relationship attempt is
@@ -117,7 +132,14 @@ async def create_relationship(
                 node = await _read_memory(node_id, session, tenant_id=tenant)
             except MemoryNotFoundError:
                 raise ToolError(f"Memory node {node_id} not found.")
-            if not authorize_read(claims, node):
+            if node.scope == "campaign" and campaign_ids is None:
+                if not project_id:
+                    raise ToolError(
+                        f"project_id is required when {label} is a campaign-scoped memory. "
+                        "Set it to your project identifier so enrollment can be verified."
+                    )
+                campaign_ids = await get_campaigns_for_project(session, project_id, tenant)
+            if not authorize_read(claims, node, campaign_ids=campaign_ids):
                 raise ToolError(f"Not authorized to access {label} ({node_id}).")
 
         try:

--- a/memory-hub-mcp/src/tools/delete_memory.py
+++ b/memory-hub-mcp/src/tools/delete_memory.py
@@ -16,6 +16,7 @@ from fastmcp import Context
 from fastmcp.exceptions import ToolError
 from pydantic import Field
 
+from memoryhub_core.services.campaign import get_campaigns_for_project
 from memoryhub_core.services.exceptions import (
     MemoryAccessDeniedError,
     MemoryAlreadyDeletedError,
@@ -56,6 +57,15 @@ async def delete_memory(
             )
         ),
     ],
+    project_id: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Your project identifier. Required when deleting a campaign-scoped "
+                "memory — used to verify your project is enrolled in the campaign."
+            ),
+        ),
+    ] = None,
     ctx: Context = None,
 ) -> dict[str, Any]:
     """Soft-delete a memory and its entire version chain.
@@ -114,7 +124,17 @@ async def delete_memory(
         # service call (race condition).
         existing = await _read_memory(parsed_id, session, tenant_id=tenant)
 
-        is_owner = authorize_write(claims, existing.scope, existing.owner_id, existing.tenant_id)
+        # Resolve campaign membership when deleting a campaign-scoped memory.
+        campaign_ids: set[str] | None = None
+        if existing.scope == "campaign":
+            if not project_id:
+                raise ToolError(
+                    "project_id is required when deleting a campaign-scoped memory. "
+                    "Set it to your project identifier so enrollment can be verified."
+                )
+            campaign_ids = await get_campaigns_for_project(session, project_id, tenant)
+
+        is_owner = authorize_write(claims, existing.scope, existing.owner_id, existing.tenant_id, campaign_ids=campaign_ids)
         is_admin = "memory:admin" in claims.get("scopes", [])
         if not (is_owner or is_admin):
             raise ToolError(

--- a/memory-hub-mcp/src/tools/get_memory_history.py
+++ b/memory-hub-mcp/src/tools/get_memory_history.py
@@ -16,6 +16,7 @@ from src.core.authz import (
 )
 from src.tools._deps import get_db_session, release_db_session
 
+from memoryhub_core.services.campaign import get_campaigns_for_project
 from memoryhub_core.services.exceptions import MemoryNotFoundError
 from memoryhub_core.services.memory import get_memory_history as _get_memory_history
 from memoryhub_core.services.memory import read_memory as _read_memory
@@ -54,6 +55,16 @@ async def get_memory_history(
             ge=0,
         ),
     ] = 0,
+    project_id: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Your project identifier. Required when the target memory has "
+                "campaign scope — used to verify your project is enrolled in "
+                "the campaign."
+            ),
+        ),
+    ] = None,
     ctx: Context = None,
 ) -> dict:
     """Get the version history of a memory with pagination.
@@ -89,7 +100,18 @@ async def get_memory_history(
         # caller's tenant so a cross-tenant ID is indistinguishable from
         # a nonexistent row.
         memory_node = await _read_memory(parsed_id, session, tenant_id=tenant)
-        if not authorize_read(claims, memory_node):
+
+        # Resolve campaign membership when accessing a campaign-scoped memory.
+        campaign_ids: set[str] | None = None
+        if memory_node.scope == "campaign":
+            if not project_id:
+                raise ToolError(
+                    "project_id is required when viewing history of a campaign-scoped memory. "
+                    "Set it to your project identifier so enrollment can be verified."
+                )
+            campaign_ids = await get_campaigns_for_project(session, project_id, tenant)
+
+        if not authorize_read(claims, memory_node, campaign_ids=campaign_ids):
             raise ToolError(f"Not authorized to view history for memory {memory_id}.")
 
         history_result = await _get_memory_history(

--- a/memory-hub-mcp/src/tools/get_relationships.py
+++ b/memory-hub-mcp/src/tools/get_relationships.py
@@ -21,6 +21,7 @@ from src.core.authz import (
 from src.tools._deps import get_db_session, release_db_session
 
 from memoryhub_core.models.schemas import RelationshipType
+from memoryhub_core.services.campaign import get_campaigns_for_project
 from memoryhub_core.services.exceptions import MemoryNotFoundError
 from memoryhub_core.services.graph import (
     get_relationships as get_relationships_service,
@@ -72,6 +73,15 @@ async def get_relationships(
             ),
         ),
     ] = False,
+    project_id: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Your project identifier. Required when the queried node or any "
+                "related node has campaign scope — used to verify enrollment."
+            ),
+        ),
+    ] = None,
     ctx: Context = None,
 ) -> dict[str, Any]:
     """Get all graph relationships for a memory node.
@@ -128,6 +138,11 @@ async def get_relationships(
             "count": len(rels),
         }
 
+        # Resolve campaign membership once for all RBAC checks below.
+        campaign_ids: set[str] | None = None
+        if project_id:
+            campaign_ids = await get_campaigns_for_project(session, project_id, tenant)
+
         # Post-fetch RBAC filter on related nodes
         original_rels = result["relationships"]
         accessible_rels = []
@@ -140,7 +155,7 @@ async def get_relationships(
                         owner_id=node_data.get("owner_id", ""),
                         tenant_id=node_data.get("tenant_id", "default"),
                     )
-                    if not authorize_read(claims, proxy):
+                    if not authorize_read(claims, proxy, campaign_ids=campaign_ids):
                         break
             else:
                 accessible_rels.append(rel)
@@ -160,7 +175,7 @@ async def get_relationships(
                     owner_id=node_dump.get("owner_id", ""),
                     tenant_id=node_dump.get("tenant_id", "default"),
                 )
-                if authorize_read(claims, proxy):
+                if authorize_read(claims, proxy, campaign_ids=campaign_ids):
                     accessible_steps.append({
                         "hop": step["hop"],
                         "node": node_dump,

--- a/memory-hub-mcp/src/tools/get_similar_memories.py
+++ b/memory-hub-mcp/src/tools/get_similar_memories.py
@@ -19,6 +19,7 @@ from src.core.authz import (
 )
 from src.tools._deps import get_db_session, release_db_session
 
+from memoryhub_core.services.campaign import get_campaigns_for_project
 from memoryhub_core.services.curation.similarity import get_similar_memories as get_similar_memories_service
 from memoryhub_core.services.exceptions import MemoryNotFoundError
 from memoryhub_core.services.memory import read_memory as read_memory_service
@@ -56,6 +57,16 @@ async def get_similar_memories(
         int,
         Field(description="Pagination offset. Default: 0.", ge=0),
     ] = 0,
+    project_id: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Your project identifier. Required when the target memory has "
+                "campaign scope — used to verify your project is enrolled in "
+                "the campaign."
+            ),
+        ),
+    ] = None,
     ctx: Context = None,
 ) -> dict[str, Any]:
     """Get memories similar to a given memory, with similarity scores.
@@ -93,7 +104,19 @@ async def get_similar_memories(
         source = await read_memory_service(
             parsed_memory_id, session, tenant_id=tenant
         )
-        if not authorize_read(claims, source):
+
+        # Resolve campaign membership when accessing a campaign-scoped memory.
+        campaign_ids: set[str] | None = None
+        if source.scope == "campaign":
+            if not project_id:
+                raise ToolError(
+                    "project_id is required when finding similar memories for a "
+                    "campaign-scoped memory. Set it to your project identifier "
+                    "so enrollment can be verified."
+                )
+            campaign_ids = await get_campaigns_for_project(session, project_id, tenant)
+
+        if not authorize_read(claims, source, campaign_ids=campaign_ids):
             raise ToolError(f"Not authorized to read memory {memory_id}.")
 
         result = await get_similar_memories_service(

--- a/memory-hub-mcp/src/tools/read_memory.py
+++ b/memory-hub-mcp/src/tools/read_memory.py
@@ -19,6 +19,7 @@ from src.core.authz import (
 )
 from src.tools._deps import get_db_session, release_db_session
 
+from memoryhub_core.services.campaign import get_campaigns_for_project
 from memoryhub_core.services.exceptions import MemoryNotFoundError
 from memoryhub_core.services.memory import get_memory_history, read_memory as _read_memory
 
@@ -44,6 +45,16 @@ async def read_memory(
             ),
         ),
     ] = False,
+    project_id: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Your project identifier. Required when the target memory has "
+                "campaign scope — used to verify your project is enrolled in "
+                "the campaign."
+            ),
+        ),
+    ] = None,
     ctx: Context = None,
 ) -> dict[str, Any]:
     """Retrieve a memory by ID.
@@ -79,7 +90,17 @@ async def read_memory(
 
         node = await _read_memory(parsed_id, session, tenant_id=tenant)
 
-        if not authorize_read(claims, node):
+        # Resolve campaign membership when accessing a campaign-scoped memory.
+        campaign_ids: set[str] | None = None
+        if node.scope == "campaign":
+            if not project_id:
+                raise ToolError(
+                    "project_id is required when reading a campaign-scoped memory. "
+                    "Set it to your project identifier so enrollment can be verified."
+                )
+            campaign_ids = await get_campaigns_for_project(session, project_id, tenant)
+
+        if not authorize_read(claims, node, campaign_ids=campaign_ids):
             raise ToolError(f"Not authorized to read memory {memory_id}.")
 
         result = node.model_dump(mode="json")

--- a/memory-hub-mcp/src/tools/report_contradiction.py
+++ b/memory-hub-mcp/src/tools/report_contradiction.py
@@ -16,6 +16,7 @@ from src.core.authz import (
 )
 from src.tools._deps import get_db_session, release_db_session
 
+from memoryhub_core.services.campaign import get_campaigns_for_project
 from memoryhub_core.services.exceptions import MemoryNotFoundError
 from memoryhub_core.services.memory import (
     read_memory as _read_memory,
@@ -62,6 +63,16 @@ async def report_contradiction(
             ),
         ),
     ] = 0.7,
+    project_id: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Your project identifier. Required when the target memory has "
+                "campaign scope — used to verify your project is enrolled in "
+                "the campaign."
+            ),
+        ),
+    ] = None,
     ctx: Context = None,
 ) -> dict:
     """Signal that observed behavior contradicts a stored memory.
@@ -104,7 +115,19 @@ async def report_contradiction(
         # filter makes a cross-tenant ID indistinguishable from a
         # nonexistent row.
         target_memory = await _read_memory(parsed_id, session, tenant_id=tenant)
-        if not authorize_read(claims, target_memory):
+
+        # Resolve campaign membership when accessing a campaign-scoped memory.
+        campaign_ids: set[str] | None = None
+        if target_memory.scope == "campaign":
+            if not project_id:
+                raise ToolError(
+                    "project_id is required when reporting a contradiction against a "
+                    "campaign-scoped memory. Set it to your project identifier "
+                    "so enrollment can be verified."
+                )
+            campaign_ids = await get_campaigns_for_project(session, project_id, tenant)
+
+        if not authorize_read(claims, target_memory, campaign_ids=campaign_ids):
             raise ToolError(f"Not authorized to access memory {memory_id}.")
 
         contradiction_count = await _report_contradiction(

--- a/memory-hub-mcp/src/tools/suggest_merge.py
+++ b/memory-hub-mcp/src/tools/suggest_merge.py
@@ -20,6 +20,7 @@ from src.core.authz import (
 from src.tools._deps import get_db_session, release_db_session
 
 from memoryhub_core.models.schemas import RelationshipCreate
+from memoryhub_core.services.campaign import get_campaigns_for_project
 from memoryhub_core.services.exceptions import MemoryNotFoundError
 from memoryhub_core.services.graph import create_relationship as create_relationship_service
 from memoryhub_core.services.memory import read_memory as _read_memory
@@ -45,6 +46,16 @@ async def suggest_merge(
         str,
         Field(description="Why these memories should be merged. Be specific."),
     ],
+    project_id: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Your project identifier. Required when either memory has "
+                "campaign scope — used to verify your project is enrolled in "
+                "the campaign."
+            ),
+        ),
+    ] = None,
     ctx: Context = None,
 ) -> dict[str, Any]:
     """Suggest that two memories should be merged into one.
@@ -89,6 +100,10 @@ async def suggest_merge(
     try:
         session, gen = await get_db_session()
 
+        # Resolve campaign membership once — used for both memories if either
+        # is campaign-scoped.
+        campaign_ids: set[str] | None = None
+
         # Verify read access to both memories. The tenant filter on
         # read_memory makes a cross-tenant ID indistinguishable from a
         # nonexistent row.
@@ -97,7 +112,14 @@ async def suggest_merge(
                 mem = await _read_memory(mid, session, tenant_id=tenant)
             except MemoryNotFoundError:
                 raise ToolError(f"Memory {mid} not found.")
-            if not authorize_read(claims, mem):
+            if mem.scope == "campaign" and campaign_ids is None:
+                if not project_id:
+                    raise ToolError(
+                        f"project_id is required when {label} is a campaign-scoped memory. "
+                        "Set it to your project identifier so enrollment can be verified."
+                    )
+                campaign_ids = await get_campaigns_for_project(session, project_id, tenant)
+            if not authorize_read(claims, mem, campaign_ids=campaign_ids):
                 raise ToolError(f"Not authorized to access {label} ({mid}).")
 
         rel_create = RelationshipCreate(

--- a/memory-hub-mcp/tests/tools/test_campaign_read_path.py
+++ b/memory-hub-mcp/tests/tools/test_campaign_read_path.py
@@ -1,0 +1,588 @@
+"""Tests for #162: campaign_ids wired into read-path tools.
+
+Each tool that calls authorize_read or authorize_write must resolve
+campaign_ids when the target memory has campaign scope. Without
+project_id, campaign-scoped memories should return a helpful ToolError
+(not a generic "Not authorized"). With project_id, campaign membership
+is resolved and passed to the authz check.
+"""
+
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastmcp.exceptions import ToolError
+
+# --- Shared fixtures ---
+
+CAMPAIGN_UUID = str(uuid.uuid4())
+MEMORY_UUID = str(uuid.uuid4())
+
+
+def _campaign_claims():
+    """Claims with campaign read/write access."""
+    return {
+        "sub": "wjackson",
+        "identity_type": "user",
+        "tenant_id": "default",
+        "scopes": [
+            "memory:read:user", "memory:write:user",
+            "memory:read:campaign", "memory:write:campaign",
+        ],
+    }
+
+
+def _fake_campaign_node(**overrides):
+    """Build a campaign-scoped MemoryNodeRead."""
+    import datetime as _dt
+    from memoryhub_core.models.schemas import MemoryNodeRead, MemoryScope, StorageType
+
+    defaults = dict(
+        id=uuid.UUID(MEMORY_UUID),
+        parent_id=None,
+        content="campaign memory content",
+        stub="campaign memory stub",
+        storage_type=StorageType.INLINE,
+        content_ref=None,
+        weight=0.7,
+        scope=MemoryScope.CAMPAIGN,
+        branch_type=None,
+        owner_id=CAMPAIGN_UUID,
+        tenant_id="default",
+        is_current=True,
+        version=1,
+        previous_version_id=None,
+        metadata=None,
+        created_at=_dt.datetime.now(_dt.UTC),
+        updated_at=_dt.datetime.now(_dt.UTC),
+        expires_at=None,
+        has_children=False,
+        has_rationale=False,
+        branch_count=0,
+    )
+    defaults.update(overrides)
+    return MemoryNodeRead(**defaults)
+
+
+# --- read_memory ---
+
+
+@pytest.mark.asyncio
+async def test_read_memory_campaign_requires_project_id():
+    """Campaign-scoped memory without project_id raises a helpful ToolError."""
+    from src.tools.read_memory import read_memory
+
+    fake_node = _fake_campaign_node()
+    mock_session = AsyncMock()
+    mock_gen = AsyncMock()
+
+    with (
+        patch("src.tools.read_memory.get_claims_from_context", return_value=_campaign_claims()),
+        patch("src.tools.read_memory.get_db_session", return_value=(mock_session, mock_gen)),
+        patch("src.tools.read_memory.release_db_session", new_callable=AsyncMock),
+        patch("src.tools.read_memory._read_memory", new_callable=AsyncMock, return_value=fake_node),
+        pytest.raises(ToolError, match="project_id is required"),
+    ):
+        await read_memory(memory_id=MEMORY_UUID)
+
+
+@pytest.mark.asyncio
+async def test_read_memory_campaign_with_project_id():
+    """Campaign-scoped memory succeeds when project_id resolves enrollment."""
+    from src.tools.read_memory import read_memory
+
+    fake_node = _fake_campaign_node()
+    mock_session = AsyncMock()
+    mock_gen = AsyncMock()
+
+    with (
+        patch("src.tools.read_memory.get_claims_from_context", return_value=_campaign_claims()),
+        patch("src.tools.read_memory.get_db_session", return_value=(mock_session, mock_gen)),
+        patch("src.tools.read_memory.release_db_session", new_callable=AsyncMock),
+        patch("src.tools.read_memory._read_memory", new_callable=AsyncMock, return_value=fake_node),
+        patch(
+            "src.tools.read_memory.get_campaigns_for_project",
+            new_callable=AsyncMock,
+            return_value={CAMPAIGN_UUID},
+        ),
+    ):
+        result = await read_memory(memory_id=MEMORY_UUID, project_id="my-project")
+
+    assert result["scope"] == "campaign"
+    assert result["owner_id"] == CAMPAIGN_UUID
+
+
+# --- get_memory_history ---
+
+
+@pytest.mark.asyncio
+async def test_get_memory_history_campaign_requires_project_id():
+    from src.tools.get_memory_history import get_memory_history
+
+    fake_node = _fake_campaign_node()
+    mock_session = AsyncMock()
+    mock_gen = AsyncMock()
+
+    with (
+        patch("src.tools.get_memory_history.get_claims_from_context", return_value=_campaign_claims()),
+        patch("src.tools.get_memory_history.get_db_session", return_value=(mock_session, mock_gen)),
+        patch("src.tools.get_memory_history.release_db_session", new_callable=AsyncMock),
+        patch("src.tools.get_memory_history._read_memory", new_callable=AsyncMock, return_value=fake_node),
+        pytest.raises(ToolError, match="project_id is required"),
+    ):
+        await get_memory_history(memory_id=MEMORY_UUID)
+
+
+@pytest.mark.asyncio
+async def test_get_memory_history_campaign_with_project_id():
+    from src.tools.get_memory_history import get_memory_history
+
+    fake_node = _fake_campaign_node()
+    mock_session = AsyncMock()
+    mock_gen = AsyncMock()
+
+    with (
+        patch("src.tools.get_memory_history.get_claims_from_context", return_value=_campaign_claims()),
+        patch("src.tools.get_memory_history.get_db_session", return_value=(mock_session, mock_gen)),
+        patch("src.tools.get_memory_history.release_db_session", new_callable=AsyncMock),
+        patch("src.tools.get_memory_history._read_memory", new_callable=AsyncMock, return_value=fake_node),
+        patch(
+            "src.tools.get_memory_history.get_campaigns_for_project",
+            new_callable=AsyncMock,
+            return_value={CAMPAIGN_UUID},
+        ),
+        patch(
+            "src.tools.get_memory_history._get_memory_history",
+            new_callable=AsyncMock,
+            return_value={
+                "versions": [fake_node],
+                "total_versions": 1,
+                "has_more": False,
+                "offset": 0,
+            },
+        ),
+    ):
+        result = await get_memory_history(memory_id=MEMORY_UUID, project_id="my-project")
+
+    assert result["total_versions"] == 1
+
+
+# --- get_similar_memories ---
+
+
+@pytest.mark.asyncio
+async def test_get_similar_memories_campaign_requires_project_id():
+    from src.tools.get_similar_memories import get_similar_memories
+
+    fake_source = SimpleNamespace(scope="campaign", owner_id=CAMPAIGN_UUID, tenant_id="default")
+    mock_session = AsyncMock()
+    mock_gen = AsyncMock()
+
+    with (
+        patch("src.tools.get_similar_memories.get_claims_from_context", return_value=_campaign_claims()),
+        patch("src.tools.get_similar_memories.get_db_session", return_value=(mock_session, mock_gen)),
+        patch("src.tools.get_similar_memories.release_db_session", new_callable=AsyncMock),
+        patch("src.tools.get_similar_memories.read_memory_service", new_callable=AsyncMock, return_value=fake_source),
+        pytest.raises(ToolError, match="project_id is required"),
+    ):
+        await get_similar_memories(memory_id=MEMORY_UUID)
+
+
+@pytest.mark.asyncio
+async def test_get_similar_memories_campaign_with_project_id():
+    from src.tools.get_similar_memories import get_similar_memories
+
+    fake_source = SimpleNamespace(scope="campaign", owner_id=CAMPAIGN_UUID, tenant_id="default")
+    mock_session = AsyncMock()
+    mock_gen = AsyncMock()
+
+    with (
+        patch("src.tools.get_similar_memories.get_claims_from_context", return_value=_campaign_claims()),
+        patch("src.tools.get_similar_memories.get_db_session", return_value=(mock_session, mock_gen)),
+        patch("src.tools.get_similar_memories.release_db_session", new_callable=AsyncMock),
+        patch("src.tools.get_similar_memories.read_memory_service", new_callable=AsyncMock, return_value=fake_source),
+        patch(
+            "src.tools.get_similar_memories.get_campaigns_for_project",
+            new_callable=AsyncMock,
+            return_value={CAMPAIGN_UUID},
+        ),
+        patch(
+            "src.tools.get_similar_memories.get_similar_memories_service",
+            new_callable=AsyncMock,
+            return_value={"results": [], "total": 0, "has_more": False},
+        ),
+    ):
+        result = await get_similar_memories(memory_id=MEMORY_UUID, project_id="my-project")
+
+    assert result["total"] == 0
+
+
+# --- report_contradiction ---
+
+
+@pytest.mark.asyncio
+async def test_report_contradiction_campaign_requires_project_id():
+    from src.tools.report_contradiction import report_contradiction
+
+    fake_node = _fake_campaign_node()
+    mock_session = AsyncMock()
+    mock_gen = AsyncMock()
+
+    with (
+        patch("src.tools.report_contradiction.get_claims_from_context", return_value=_campaign_claims()),
+        patch("src.tools.report_contradiction.get_db_session", return_value=(mock_session, mock_gen)),
+        patch("src.tools.report_contradiction.release_db_session", new_callable=AsyncMock),
+        patch("src.tools.report_contradiction._read_memory", new_callable=AsyncMock, return_value=fake_node),
+        pytest.raises(ToolError, match="project_id is required"),
+    ):
+        await report_contradiction(
+            memory_id=MEMORY_UUID,
+            observed_behavior="user used Docker instead of Podman",
+        )
+
+
+@pytest.mark.asyncio
+async def test_report_contradiction_campaign_with_project_id():
+    from src.tools.report_contradiction import report_contradiction
+
+    fake_node = _fake_campaign_node()
+    mock_session = AsyncMock()
+    mock_gen = AsyncMock()
+
+    with (
+        patch("src.tools.report_contradiction.get_claims_from_context", return_value=_campaign_claims()),
+        patch("src.tools.report_contradiction.get_db_session", return_value=(mock_session, mock_gen)),
+        patch("src.tools.report_contradiction.release_db_session", new_callable=AsyncMock),
+        patch("src.tools.report_contradiction._read_memory", new_callable=AsyncMock, return_value=fake_node),
+        patch(
+            "src.tools.report_contradiction.get_campaigns_for_project",
+            new_callable=AsyncMock,
+            return_value={CAMPAIGN_UUID},
+        ),
+        patch(
+            "src.tools.report_contradiction._report_contradiction",
+            new_callable=AsyncMock,
+            return_value=1,
+        ),
+    ):
+        result = await report_contradiction(
+            memory_id=MEMORY_UUID,
+            observed_behavior="user used Docker instead of Podman",
+            project_id="my-project",
+        )
+
+    assert result["contradiction_count"] == 1
+
+
+# --- create_relationship ---
+
+
+@pytest.mark.asyncio
+async def test_create_relationship_campaign_requires_project_id():
+    from src.tools.create_relationship import create_relationship
+
+    fake_node = _fake_campaign_node()
+    target_uuid = str(uuid.uuid4())
+    mock_session = AsyncMock()
+    mock_gen = AsyncMock()
+
+    with (
+        patch("src.tools.create_relationship.get_claims_from_context", return_value=_campaign_claims()),
+        patch("src.tools.create_relationship.get_db_session", return_value=(mock_session, mock_gen)),
+        patch("src.tools.create_relationship.release_db_session", new_callable=AsyncMock),
+        patch("src.tools.create_relationship._read_memory", new_callable=AsyncMock, return_value=fake_node),
+        pytest.raises(ToolError, match="project_id is required"),
+    ):
+        await create_relationship(
+            source_id=MEMORY_UUID,
+            target_id=target_uuid,
+            relationship_type="related_to",
+        )
+
+
+@pytest.mark.asyncio
+async def test_create_relationship_campaign_with_project_id():
+    from src.tools.create_relationship import create_relationship
+
+    fake_source = _fake_campaign_node()
+    target_id = uuid.uuid4()
+    fake_target = _fake_campaign_node(id=target_id)
+    mock_session = AsyncMock()
+    mock_gen = AsyncMock()
+
+    # Mock return value for the relationship creation
+    fake_rel = SimpleNamespace()
+    fake_rel.model_dump = lambda mode="json": {
+        "id": str(uuid.uuid4()),
+        "source_id": MEMORY_UUID,
+        "target_id": str(target_id),
+        "relationship_type": "related_to",
+    }
+
+    with (
+        patch("src.tools.create_relationship.get_claims_from_context", return_value=_campaign_claims()),
+        patch("src.tools.create_relationship.get_db_session", return_value=(mock_session, mock_gen)),
+        patch("src.tools.create_relationship.release_db_session", new_callable=AsyncMock),
+        patch("src.tools.create_relationship._read_memory", new_callable=AsyncMock, return_value=fake_source),
+        patch(
+            "src.tools.create_relationship.get_campaigns_for_project",
+            new_callable=AsyncMock,
+            return_value={CAMPAIGN_UUID},
+        ),
+        patch(
+            "src.tools.create_relationship.create_relationship_service",
+            new_callable=AsyncMock,
+            return_value=fake_rel,
+        ),
+    ):
+        result = await create_relationship(
+            source_id=MEMORY_UUID,
+            target_id=str(target_id),
+            relationship_type="related_to",
+            project_id="my-project",
+        )
+
+    assert result["relationship_type"] == "related_to"
+
+
+# --- suggest_merge ---
+
+
+@pytest.mark.asyncio
+async def test_suggest_merge_campaign_requires_project_id():
+    from src.tools.suggest_merge import suggest_merge
+
+    fake_mem = _fake_campaign_node()
+    other_uuid = str(uuid.uuid4())
+    mock_session = AsyncMock()
+    mock_gen = AsyncMock()
+
+    with (
+        patch("src.tools.suggest_merge.get_claims_from_context", return_value=_campaign_claims()),
+        patch("src.tools.suggest_merge.get_db_session", return_value=(mock_session, mock_gen)),
+        patch("src.tools.suggest_merge.release_db_session", new_callable=AsyncMock),
+        patch("src.tools.suggest_merge._read_memory", new_callable=AsyncMock, return_value=fake_mem),
+        pytest.raises(ToolError, match="project_id is required"),
+    ):
+        await suggest_merge(
+            memory_a_id=MEMORY_UUID,
+            memory_b_id=other_uuid,
+            reasoning="These cover the same topic",
+        )
+
+
+@pytest.mark.asyncio
+async def test_suggest_merge_campaign_with_project_id():
+    from src.tools.suggest_merge import suggest_merge
+
+    fake_mem_a = _fake_campaign_node()
+    mem_b_id = uuid.uuid4()
+    fake_mem_b = _fake_campaign_node(id=mem_b_id)
+    mock_session = AsyncMock()
+    mock_gen = AsyncMock()
+
+    fake_rel = SimpleNamespace()
+    fake_rel.model_dump = lambda mode="json": {
+        "id": str(uuid.uuid4()),
+        "source_id": MEMORY_UUID,
+        "target_id": str(mem_b_id),
+        "relationship_type": "conflicts_with",
+    }
+
+    with (
+        patch("src.tools.suggest_merge.get_claims_from_context", return_value=_campaign_claims()),
+        patch("src.tools.suggest_merge.get_db_session", return_value=(mock_session, mock_gen)),
+        patch("src.tools.suggest_merge.release_db_session", new_callable=AsyncMock),
+        patch("src.tools.suggest_merge._read_memory", new_callable=AsyncMock, return_value=fake_mem_a),
+        patch(
+            "src.tools.suggest_merge.get_campaigns_for_project",
+            new_callable=AsyncMock,
+            return_value={CAMPAIGN_UUID},
+        ),
+        patch(
+            "src.tools.suggest_merge.create_relationship_service",
+            new_callable=AsyncMock,
+            return_value=fake_rel,
+        ),
+    ):
+        result = await suggest_merge(
+            memory_a_id=MEMORY_UUID,
+            memory_b_id=str(mem_b_id),
+            reasoning="These cover the same topic",
+            project_id="my-project",
+        )
+
+    assert "relationship" in result
+
+
+# --- delete_memory ---
+
+
+@pytest.mark.asyncio
+async def test_delete_memory_campaign_requires_project_id():
+    from src.tools.delete_memory import delete_memory
+
+    fake_node = _fake_campaign_node()
+    mock_session = AsyncMock()
+    mock_gen = AsyncMock()
+
+    with (
+        patch("src.tools.delete_memory.get_claims_from_context", return_value=_campaign_claims()),
+        patch("src.tools.delete_memory.get_db_session", return_value=(mock_session, mock_gen)),
+        patch("src.tools.delete_memory.release_db_session", new_callable=AsyncMock),
+        patch("src.tools.delete_memory._read_memory", new_callable=AsyncMock, return_value=fake_node),
+        pytest.raises(ToolError, match="project_id is required"),
+    ):
+        await delete_memory(memory_id=MEMORY_UUID)
+
+
+@pytest.mark.asyncio
+async def test_delete_memory_campaign_with_project_id():
+    from src.tools.delete_memory import delete_memory
+
+    fake_node = _fake_campaign_node()
+    mock_session = AsyncMock()
+    mock_gen = AsyncMock()
+
+    with (
+        patch("src.tools.delete_memory.get_claims_from_context", return_value=_campaign_claims()),
+        patch("src.tools.delete_memory.get_db_session", return_value=(mock_session, mock_gen)),
+        patch("src.tools.delete_memory.release_db_session", new_callable=AsyncMock),
+        patch("src.tools.delete_memory._read_memory", new_callable=AsyncMock, return_value=fake_node),
+        patch(
+            "src.tools.delete_memory.get_campaigns_for_project",
+            new_callable=AsyncMock,
+            return_value={CAMPAIGN_UUID},
+        ),
+        patch(
+            "src.tools.delete_memory.svc_delete_memory",
+            new_callable=AsyncMock,
+            return_value={
+                "deleted_id": MEMORY_UUID,
+                "versions_deleted": 1,
+                "branches_deleted": 0,
+                "total_deleted": 1,
+            },
+        ),
+        patch("src.tools.delete_memory.broadcast_after_write", new_callable=AsyncMock),
+    ):
+        result = await delete_memory(memory_id=MEMORY_UUID, project_id="my-project")
+
+    assert result["total_deleted"] == 1
+
+
+# --- get_relationships (post-fetch RBAC) ---
+
+
+@pytest.mark.asyncio
+async def test_get_relationships_campaign_nodes_filtered_without_project_id():
+    """Without project_id, campaign-scoped related nodes are silently filtered."""
+    from src.tools.get_relationships import get_relationships
+
+    mock_session = AsyncMock()
+    mock_gen = AsyncMock()
+
+    # Build a relationship where source_node is campaign-scoped
+    fake_rel = SimpleNamespace()
+    fake_rel.model_dump = lambda mode="json": {
+        "id": str(uuid.uuid4()),
+        "source_node": {
+            "scope": "campaign",
+            "owner_id": CAMPAIGN_UUID,
+            "tenant_id": "default",
+        },
+        "target_node": {
+            "scope": "user",
+            "owner_id": "wjackson",
+            "tenant_id": "default",
+        },
+    }
+
+    with (
+        patch("src.tools.get_relationships.get_claims_from_context", return_value=_campaign_claims()),
+        patch("src.tools.get_relationships.get_db_session", return_value=(mock_session, mock_gen)),
+        patch("src.tools.get_relationships.release_db_session", new_callable=AsyncMock),
+        patch(
+            "src.tools.get_relationships.get_relationships_service",
+            new_callable=AsyncMock,
+            return_value=[fake_rel],
+        ),
+    ):
+        result = await get_relationships(node_id=MEMORY_UUID)
+
+    # Without project_id, campaign_ids is None → campaign node filtered out
+    assert result["count"] == 0
+    assert result["omitted_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_get_relationships_campaign_nodes_accessible_with_project_id():
+    """With project_id, campaign-scoped related nodes pass the RBAC filter."""
+    from src.tools.get_relationships import get_relationships
+
+    mock_session = AsyncMock()
+    mock_gen = AsyncMock()
+
+    fake_rel = SimpleNamespace()
+    fake_rel.model_dump = lambda mode="json": {
+        "id": str(uuid.uuid4()),
+        "source_node": {
+            "scope": "campaign",
+            "owner_id": CAMPAIGN_UUID,
+            "tenant_id": "default",
+        },
+        "target_node": {
+            "scope": "user",
+            "owner_id": "wjackson",
+            "tenant_id": "default",
+        },
+    }
+
+    with (
+        patch("src.tools.get_relationships.get_claims_from_context", return_value=_campaign_claims()),
+        patch("src.tools.get_relationships.get_db_session", return_value=(mock_session, mock_gen)),
+        patch("src.tools.get_relationships.release_db_session", new_callable=AsyncMock),
+        patch(
+            "src.tools.get_relationships.get_relationships_service",
+            new_callable=AsyncMock,
+            return_value=[fake_rel],
+        ),
+        patch(
+            "src.tools.get_relationships.get_campaigns_for_project",
+            new_callable=AsyncMock,
+            return_value={CAMPAIGN_UUID},
+        ),
+    ):
+        result = await get_relationships(node_id=MEMORY_UUID, project_id="my-project")
+
+    assert result["count"] == 1
+    assert "omitted_count" not in result
+
+
+# --- Signature tests ---
+
+@pytest.mark.parametrize("tool_module,tool_name", [
+    ("src.tools.read_memory", "read_memory"),
+    ("src.tools.get_memory_history", "get_memory_history"),
+    ("src.tools.get_similar_memories", "get_similar_memories"),
+    ("src.tools.report_contradiction", "report_contradiction"),
+    ("src.tools.create_relationship", "create_relationship"),
+    ("src.tools.suggest_merge", "suggest_merge"),
+    ("src.tools.delete_memory", "delete_memory"),
+    ("src.tools.get_relationships", "get_relationships"),
+])
+def test_tool_has_project_id_parameter(tool_module, tool_name):
+    """All read-path tools must expose project_id for campaign enrollment."""
+    import importlib
+    import inspect
+
+    mod = importlib.import_module(tool_module)
+    tool_fn = getattr(mod, tool_name)
+    sig = inspect.signature(tool_fn)
+    assert "project_id" in sig.parameters, (
+        f"{tool_name} must have a project_id parameter for campaign enrollment (#162)"
+    )
+    assert sig.parameters["project_id"].default is None, (
+        f"{tool_name}.project_id must default to None"
+    )


### PR DESCRIPTION
## Summary

- 8 tools now resolve `campaign_ids` via `get_campaigns_for_project` before authz checks, fixing 403 on direct lookup of campaign-scoped memories
- Each tool accepts an optional `project_id` parameter; when the target memory has `scope="campaign"`, the tool requires it and returns a helpful error if missing
- `get_relationships` uses eager resolution with silent omit (consistent with its existing post-fetch RBAC filter behavior)

## Test plan

- [x] 24 new tests in `test_campaign_read_path.py` (signature, error path, success path for all 8 tools)
- [x] Full suite: 246 tests passing
- [x] Deployed to OpenShift sandbox, 15/15 tools verified via mcp-test-mcp
- [x] Migrations 009+010 applied to deployed DB (were missing — sandbox had drifted to 008)
- [x] `search_memory` confirmed working end-to-end post-deploy (domains column error resolved)

Closes #162