### PR TITLE
auth: Enforce openshift_allowed_group in PKCE callback (#179)

### DIFF
--- a/memoryhub-auth/CLAUDE.md
+++ b/memoryhub-auth/CLAUDE.md
@@ -55,6 +55,14 @@ The admin API at `/admin/clients` manages OAuth client registrations. All OAuthC
 - Run: `cd memoryhub-auth && .venv/bin/python -m pytest tests/ -x -q`
 - OpenShift HTTP calls in callback tests are mocked (patch `_exchange_openshift_code` and `_resolve_openshift_user`)
 
+### E2e tests are mandatory for OpenShift API changes
+
+Any change that touches the OpenShift OAuth redirect chain or calls an OpenShift API (groups, users, tokens) **must** be validated with `tests/integration/test_pkce_e2e.py` against the live cluster before merging. Unit tests with mocked HTTP responses cannot catch encoding conventions, permission models, or response shape surprises from the real APIs. Three bugs were invisible to unit tests but caught by e2e:
+
+1. Wrong user-info URL (returned HTML instead of JSON)
+2. IDP selection page not handled (multi-IDP clusters show a picker)
+3. b64-encoded usernames in Groups API (`kube:admin` stored as `b64:a3ViZTphZG1pbg==` — the `in` check silently fails)
+
 ## Key Files
 
 | File | What |

--- a/memoryhub-auth/openshift.yaml
+++ b/memoryhub-auth/openshift.yaml
@@ -150,6 +150,10 @@ spec:
           value: "true"
         - name: AUTH_OPENSHIFT_CA_BUNDLE
           value: "/etc/pki/combined-ca/ca-bundle.crt"
+        # Group-based access control — leave empty to allow all
+        # authenticated OpenShift users, or set to a group name to restrict.
+        - name: AUTH_OPENSHIFT_ALLOWED_GROUP
+          value: "memoryhub-users"
         - name: AUTH_OPENSHIFT_OAUTH_CLIENT_ID
           value: "memoryhub-auth-broker"
         - name: AUTH_OPENSHIFT_OAUTH_CLIENT_SECRET

--- a/memoryhub-auth/src/routes/openshift_callback.py
+++ b/memoryhub-auth/src/routes/openshift_callback.py
@@ -111,6 +111,50 @@ async def _resolve_openshift_user(opaque_token: str) -> str:
     return username
 
 
+async def _check_group_membership(opaque_token: str, username: str) -> None:
+    """Verify the user belongs to the required OpenShift group.
+
+    If ``settings.openshift_allowed_group`` is empty the check is skipped
+    (all authenticated users are allowed).  Otherwise the OpenShift Groups
+    API is queried with the user's opaque token and the username must appear
+    in the group's ``.users`` list.
+    """
+    group_name = settings.openshift_allowed_group
+    if not group_name:
+        return
+
+    groups_url = (
+        f"https://kubernetes.default.svc/apis/user.openshift.io/v1/groups/{group_name}"
+    )
+    try:
+        async with httpx.AsyncClient(verify=_openshift_tls_verify(), timeout=10.0) as client:
+            resp = await client.get(
+                groups_url,
+                headers={"Authorization": f"Bearer {opaque_token}"},
+            )
+    except httpx.RequestError as exc:
+        log.error("OpenShift group lookup network error: group=%s err=%s", group_name, exc)
+        raise OAuthError(502, "server_error", "Failed to verify group membership")
+
+    if resp.status_code != 200:
+        log.error(
+            "OpenShift group lookup failed: group=%s status=%d body=%s",
+            group_name,
+            resp.status_code,
+            resp.text[:200],
+        )
+        raise OAuthError(502, "server_error", "Failed to verify group membership")
+
+    members = resp.json().get("users") or []
+    if username not in members:
+        log.warning(
+            "User %s is not a member of required group %s", username, group_name
+        )
+        raise OAuthError(403, "access_denied", "User is not a member of the required group")
+
+    log.info("Group check passed: %s is member of %s", username, group_name)
+
+
 @router.get("/oauth/openshift/callback")
 async def openshift_callback(
     code: str = Query(...),
@@ -139,11 +183,14 @@ async def openshift_callback(
     # --- exchange OpenShift code for opaque token ---
     opaque_token = await _exchange_openshift_code(code)
 
-    # --- resolve OpenShift username (opaque token discarded after this) ---
+    # --- resolve OpenShift username ---
     username = await _resolve_openshift_user(opaque_token)
-    # opaque_token goes out of scope here — NEVER persisted
 
     log.info("Resolved OpenShift user: %s for session %s", username, state[:8])
+
+    # --- enforce group membership (if configured) ---
+    await _check_group_membership(opaque_token, username)
+    # opaque_token goes out of scope here — NEVER persisted
 
     # --- mint MemoryHub authorization code ---
     raw_code = secrets.token_urlsafe(32)  # 256-bit

--- a/memoryhub-auth/src/routes/openshift_callback.py
+++ b/memoryhub-auth/src/routes/openshift_callback.py
@@ -5,6 +5,7 @@ token, resolves the OpenShift username, mints a MemoryHub authorization code,
 and redirects the user back to the original client (e.g., LibreChat).
 """
 
+import base64
 import hashlib
 import logging
 import os
@@ -111,6 +112,26 @@ async def _resolve_openshift_user(opaque_token: str) -> str:
     return username
 
 
+def _decode_group_member(entry: str) -> str:
+    """Decode an OpenShift group member entry.
+
+    OpenShift encodes usernames containing ':' with a ``b64:`` prefix in
+    the Group ``.users`` list (e.g. ``b64:a3ViZTphZG1pbg==`` for
+    ``kube:admin``).  Plain usernames are returned as-is.
+    """
+    if entry.startswith("b64:"):
+        try:
+            return base64.b64decode(entry[4:]).decode("utf-8")
+        except Exception:
+            return entry
+    return entry
+
+
+def _user_in_group_members(username: str, members: list[str]) -> bool:
+    """Check if *username* appears in *members*, decoding b64-prefixed entries."""
+    return any(_decode_group_member(m) == username for m in members)
+
+
 async def _check_group_membership(opaque_token: str, username: str) -> None:
     """Verify the user belongs to the required OpenShift group.
 
@@ -146,7 +167,7 @@ async def _check_group_membership(opaque_token: str, username: str) -> None:
         raise OAuthError(502, "server_error", "Failed to verify group membership")
 
     members = resp.json().get("users") or []
-    if username not in members:
+    if not _user_in_group_members(username, members):
         log.warning(
             "User %s is not a member of required group %s", username, group_name
         )

--- a/memoryhub-auth/tests/test_openshift_callback.py
+++ b/memoryhub-auth/tests/test_openshift_callback.py
@@ -199,6 +199,36 @@ class TestCallbackValidation:
 
 
 # ---------------------------------------------------------------------------
+# b64-encoded username helpers
+# ---------------------------------------------------------------------------
+
+
+class TestDecodeGroupMember:
+    """Unit tests for _decode_group_member and _user_in_group_members."""
+
+    def test_plain_username(self):
+        from src.routes.openshift_callback import _decode_group_member
+        assert _decode_group_member("rdwj") == "rdwj"
+
+    def test_b64_encoded_username(self):
+        from src.routes.openshift_callback import _decode_group_member
+        # "kube:admin" base64-encoded
+        assert _decode_group_member("b64:a3ViZTphZG1pbg==") == "kube:admin"
+
+    def test_invalid_b64_returns_original(self):
+        from src.routes.openshift_callback import _decode_group_member
+        assert _decode_group_member("b64:!!!invalid!!!") == "b64:!!!invalid!!!"
+
+    def test_user_in_mixed_members(self):
+        from src.routes.openshift_callback import _user_in_group_members
+        members = ["b64:a3ViZTphZG1pbg==", "rdwj", "alice"]
+        assert _user_in_group_members("kube:admin", members)
+        assert _user_in_group_members("rdwj", members)
+        assert _user_in_group_members("alice", members)
+        assert not _user_in_group_members("bob", members)
+
+
+# ---------------------------------------------------------------------------
 # Group membership checks — unit tests for _check_group_membership
 # ---------------------------------------------------------------------------
 
@@ -252,6 +282,23 @@ class TestCheckGroupMembership:
         call_args = mock_client_instance.get.call_args
         assert "memoryhub-users" in call_args[0][0]
         assert call_args[1]["headers"]["Authorization"] == "Bearer opaque-token"
+
+    async def test_user_in_group_b64_encoded(self, monkeypatch):
+        """Group API returns b64-encoded username (colon in name) — succeeds."""
+        monkeypatch.setattr(settings, "openshift_allowed_group", "memoryhub-users")
+        from src.routes.openshift_callback import _check_group_membership
+
+        # OpenShift encodes "kube:admin" as "b64:a3ViZTphZG1pbg==" in groups
+        mock_client_instance = AsyncMock()
+        mock_client_instance.get.return_value = _mock_group_response(
+            200, ["b64:a3ViZTphZG1pbg==", "rdwj"]
+        )
+        mock_client_ctx = AsyncMock()
+        mock_client_ctx.__aenter__ = AsyncMock(return_value=mock_client_instance)
+        mock_client_ctx.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("src.routes.openshift_callback.httpx.AsyncClient", return_value=mock_client_ctx):
+            await _check_group_membership("opaque-token", "kube:admin")
 
     async def test_user_not_in_group_raises_403(self, monkeypatch):
         """Group API returns 200 but user is NOT in .users — 403."""

--- a/memoryhub-auth/tests/test_openshift_callback.py
+++ b/memoryhub-auth/tests/test_openshift_callback.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+from unittest.mock import MagicMock
 from src.config import settings
 from src.models import AuthSession
 
@@ -195,3 +196,178 @@ class TestCallbackValidation:
             )
 
         assert resp.status_code == 502
+
+
+# ---------------------------------------------------------------------------
+# Group membership checks — unit tests for _check_group_membership
+# ---------------------------------------------------------------------------
+
+
+def _mock_group_response(status_code: int, users: list[str] | None = None):
+    """Build a mock httpx response for the Groups API.
+
+    Uses MagicMock (not AsyncMock) because httpx Response.json() and .text
+    are synchronous — AsyncMock would return a coroutine.
+    """
+    mock_resp = MagicMock()
+    mock_resp.status_code = status_code
+    mock_resp.text = '{"users": []}'
+    if users is not None:
+        mock_resp.json.return_value = {"users": users}
+    else:
+        mock_resp.json.return_value = {"users": []}
+    return mock_resp
+
+
+@pytest.mark.asyncio
+class TestCheckGroupMembership:
+    """Unit tests for _check_group_membership."""
+
+    async def test_no_group_configured_skips_check(self, monkeypatch):
+        """When openshift_allowed_group is empty, no HTTP call is made."""
+        monkeypatch.setattr(settings, "openshift_allowed_group", "")
+        from src.routes.openshift_callback import _check_group_membership
+
+        # If the function tried to make an HTTP call with no group configured,
+        # it would fail because we haven't mocked httpx.  The fact that it
+        # returns without error proves the short-circuit works.
+        await _check_group_membership("some-token", "alice")
+
+    async def test_user_in_group_succeeds(self, monkeypatch):
+        """Group API returns 200 with user in .users — no error raised."""
+        monkeypatch.setattr(settings, "openshift_allowed_group", "memoryhub-users")
+        from src.routes.openshift_callback import _check_group_membership
+
+        mock_client_instance = AsyncMock()
+        mock_client_instance.get.return_value = _mock_group_response(200, ["alice", "bob"])
+        mock_client_ctx = AsyncMock()
+        mock_client_ctx.__aenter__ = AsyncMock(return_value=mock_client_instance)
+        mock_client_ctx.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("src.routes.openshift_callback.httpx.AsyncClient", return_value=mock_client_ctx):
+            await _check_group_membership("opaque-token", "alice")
+
+        # Verify the correct URL and auth header were used
+        mock_client_instance.get.assert_awaited_once()
+        call_args = mock_client_instance.get.call_args
+        assert "memoryhub-users" in call_args[0][0]
+        assert call_args[1]["headers"]["Authorization"] == "Bearer opaque-token"
+
+    async def test_user_not_in_group_raises_403(self, monkeypatch):
+        """Group API returns 200 but user is NOT in .users — 403."""
+        monkeypatch.setattr(settings, "openshift_allowed_group", "memoryhub-users")
+        from src.routes.openshift_callback import _check_group_membership
+        from src.errors import OAuthError
+
+        mock_client_instance = AsyncMock()
+        mock_client_instance.get.return_value = _mock_group_response(200, ["bob", "carol"])
+        mock_client_ctx = AsyncMock()
+        mock_client_ctx.__aenter__ = AsyncMock(return_value=mock_client_instance)
+        mock_client_ctx.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("src.routes.openshift_callback.httpx.AsyncClient", return_value=mock_client_ctx):
+            with pytest.raises(OAuthError) as exc_info:
+                await _check_group_membership("opaque-token", "alice")
+
+        assert exc_info.value.status_code == 403
+        assert exc_info.value.error == "access_denied"
+
+    async def test_group_api_failure_raises_502(self, monkeypatch):
+        """Group API returns non-200 (e.g. 404) — 502 server_error."""
+        monkeypatch.setattr(settings, "openshift_allowed_group", "nonexistent-group")
+        from src.routes.openshift_callback import _check_group_membership
+        from src.errors import OAuthError
+
+        mock_client_instance = AsyncMock()
+        mock_client_instance.get.return_value = _mock_group_response(404)
+        mock_client_ctx = AsyncMock()
+        mock_client_ctx.__aenter__ = AsyncMock(return_value=mock_client_instance)
+        mock_client_ctx.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("src.routes.openshift_callback.httpx.AsyncClient", return_value=mock_client_ctx):
+            with pytest.raises(OAuthError) as exc_info:
+                await _check_group_membership("opaque-token", "alice")
+
+        assert exc_info.value.status_code == 502
+        assert exc_info.value.error == "server_error"
+
+    async def test_empty_users_list_raises_403(self, monkeypatch):
+        """Group API returns 200 with empty .users list — 403."""
+        monkeypatch.setattr(settings, "openshift_allowed_group", "memoryhub-users")
+        from src.routes.openshift_callback import _check_group_membership
+        from src.errors import OAuthError
+
+        mock_client_instance = AsyncMock()
+        mock_client_instance.get.return_value = _mock_group_response(200, [])
+        mock_client_ctx = AsyncMock()
+        mock_client_ctx.__aenter__ = AsyncMock(return_value=mock_client_instance)
+        mock_client_ctx.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("src.routes.openshift_callback.httpx.AsyncClient", return_value=mock_client_ctx):
+            with pytest.raises(OAuthError) as exc_info:
+                await _check_group_membership("opaque-token", "anyone")
+
+        assert exc_info.value.status_code == 403
+        assert exc_info.value.error == "access_denied"
+
+
+@pytest.mark.asyncio
+class TestCallbackGroupIntegration:
+    """Callback-level tests verifying group membership wiring."""
+
+    async def test_callback_succeeds_with_group_check_passing(
+        self, client, sample_client, db_engine
+    ):
+        """Group check passes — callback completes and redirects."""
+        factory = async_sessionmaker(db_engine, class_=AsyncSession, expire_on_commit=False)
+        async with factory() as sess:
+            auth_sess = _create_pending_session()
+            sess.add(auth_sess)
+            await sess.commit()
+            session_id = auth_sess.session_id
+
+        with patch("src.routes.openshift_callback._exchange_openshift_code", new_callable=AsyncMock) as mock_exchange, \
+             patch("src.routes.openshift_callback._resolve_openshift_user", new_callable=AsyncMock) as mock_resolve, \
+             patch("src.routes.openshift_callback._check_group_membership", new_callable=AsyncMock) as mock_group:
+            mock_exchange.return_value = "opaque-token"
+            mock_resolve.return_value = "alice"
+            # _check_group_membership mock returns None (no error) by default
+
+            resp = await client.get(
+                "/oauth/openshift/callback",
+                params={"code": "os-code", "state": session_id},
+                follow_redirects=False,
+            )
+
+        assert resp.status_code == 302
+        mock_group.assert_awaited_once_with("opaque-token", "alice")
+
+    async def test_callback_returns_403_when_user_not_in_group(
+        self, client, sample_client, db_engine
+    ):
+        """Group check rejects user — callback surfaces the 403."""
+        factory = async_sessionmaker(db_engine, class_=AsyncSession, expire_on_commit=False)
+        async with factory() as sess:
+            auth_sess = _create_pending_session()
+            sess.add(auth_sess)
+            await sess.commit()
+            session_id = auth_sess.session_id
+
+        from src.errors import OAuthError
+
+        with patch("src.routes.openshift_callback._exchange_openshift_code", new_callable=AsyncMock) as mock_exchange, \
+             patch("src.routes.openshift_callback._resolve_openshift_user", new_callable=AsyncMock) as mock_resolve, \
+             patch("src.routes.openshift_callback._check_group_membership", new_callable=AsyncMock) as mock_group:
+            mock_exchange.return_value = "opaque-token"
+            mock_resolve.return_value = "alice"
+            mock_group.side_effect = OAuthError(
+                403, "access_denied", "User is not a member of the required group"
+            )
+
+            resp = await client.get(
+                "/oauth/openshift/callback",
+                params={"code": "os-code", "state": session_id},
+            )
+
+        assert resp.status_code == 403
+        assert resp.json()["error"] == "access_denied"

--- a/retrospectives/2026-04-13_tls-hardening-and-group-enforcement/RETRO.md
+++ b/retrospectives/2026-04-13_tls-hardening-and-group-enforcement/RETRO.md
@@ -1,0 +1,55 @@
+# Retrospective: TLS Hardening + Group Enforcement
+
+**Date:** 2026-04-13
+**Effort:** Deploy TLS hardening, implement and validate #179 (openshift_allowed_group enforcement)
+**Issues:** #179 (group enforcement), #81 (e2e test, closed)
+**Commits:** fed11dc, c66a42b, 8799caa (3 commits on feat/enforce-allowed-group)
+**PR:** #180
+
+## What We Set Out To Do
+
+Three items from the previous session's handoff:
+1. Deploy the TLS hardening changes (committed but not applied)
+2. Implement #179 — enforce `openshift_allowed_group` in the PKCE callback
+3. Run a retro covering the PKCE broker effort
+
+## What Changed
+
+| Change | Type | Rationale |
+|--------|------|-----------|
+| b64-encoded username handling added to group check | Good pivot (bug found via e2e) | OpenShift stores `kube:admin` as `b64:a3ViZTphZG1pbg==` in groups. Unit tests with plain usernames passed; real cluster e2e would have failed without this fix. |
+| Manifest updated to include `AUTH_OPENSHIFT_ALLOWED_GROUP` | Good pivot | `oc set env` is ephemeral. The IaC checklist from the Apr-08 retro caught this: every env var must be in the manifest so `deploy.sh` reproduces it. |
+| `httpx.RequestError` catch added during review | Good pivot | Review sub-agent identified that network failures (timeout, DNS) would surface as unstructured 500s instead of `OAuthError(502)`. |
+
+## What Went Well
+
+- **TLS hardening deployed first try** — combined CA bundle, init container, internal service URLs all worked. Zero-bug deployment for a significant infrastructure change.
+- **E2e test caught a real bug that unit tests structurally could not.** The b64-encoded username issue is invisible to mocked tests because the mock returns whatever username format you tell it to. Only hitting the real OpenShift Groups API exposed the encoding. This is the third time (user-info URL, IDP selection, now b64 encoding) that e2e has caught something unit tests missed in the auth flow.
+- **Review sub-agent** caught the `httpx.RequestError` gap and the `or []` null guard — both real edge cases, both one-liner fixes.
+- **Full three-scenario e2e validation**: user in group (pass), user NOT in group (403), no group configured (pass). All three verified on the live cluster.
+
+## Gaps Identified
+
+| Gap | Severity | Resolution |
+|-----|----------|------------|
+| `memoryhub-users` group created manually on cluster, not in deploy.sh | Follow-up | The group is a prerequisite for group enforcement. Should be documented or scripted. Low urgency since it's a one-time cluster setup. |
+| Project-scope memory update failed (RBAC error) | Low | Couldn't update the auth service project memory. Not blocking — investigate if it recurs. |
+| #179 PR not yet merged | Pending | PR #180 created, needs review and merge |
+
+## Action Items
+
+- [ ] Merge PR #180
+- [ ] Document `memoryhub-users` group creation in deploy.sh or a prerequisites section
+- [ ] Investigate project-scope memory RBAC if it recurs
+
+## Patterns
+
+**Start:** When implementing anything that touches the OpenShift API (groups, users, tokens), test against the real cluster before calling it done. Mock-based unit tests cannot reveal API encoding conventions (b64 usernames), permission models, or response shape surprises. The cost of an extra deploy+e2e cycle is ~3 minutes; the cost of shipping a broken group check is a security gap.
+
+**Stop:** Nothing new to stop.
+
+**Continue:**
+- Review sub-agents after implementation (4th consecutive retro validating this)
+- E2e tests as the final gate for auth changes (3rd instance of catching real bugs)
+- IaC checklist before calling a feature deployed (manifest + deploy.sh + migrations)
+- Design-doc-first for complex features (the PKCE broker design drove clean implementation across two sessions)


### PR DESCRIPTION
## Summary

- Adds group membership check in the OpenShift OAuth callback — when `AUTH_OPENSHIFT_ALLOWED_GROUP` is set, the callback queries the OpenShift Groups API to verify the user belongs to the configured group before minting an authorization code
- Handles OpenShift's b64-encoded username format for usernames containing `:` (e.g. `kube:admin` stored as `b64:a3ViZTphZG1pbg==`)
- Catches `httpx.RequestError` for network failures and guards against null `.users` field
- Adds env var to `openshift.yaml` manifest (IaC)
- 19 unit tests covering: skip when empty, user in group (plain + b64), user not in group, API failure, empty users list, callback integration

## Validated end-to-end on the cluster

| Scenario | Result |
|----------|--------|
| Group empty (default) | PKCE flow succeeds, all users allowed |
| User in group (b64-encoded `kube:admin` in `memoryhub-users`) | PKCE flow succeeds |
| User NOT in group (`memoryhub-admins-only` without `kube:admin`) | 403 `access_denied` returned |

## Test plan

- [x] 124 unit tests pass (`pytest tests/ --ignore=tests/integration`)
- [x] e2e test passes with group enforcement active (user in group)
- [x] e2e test correctly rejects when user is not in configured group
- [x] e2e test passes with empty group (backward compatibility)
- [x] Deployed and verified on cluster 3 times during validation

Closes #179