### PR TITLE
sdk: Rework against compacted memory(action=...) tool surface (#210, #208)

### DIFF
--- a/planning/sdk-compacted-tool-rework.md
+++ b/planning/sdk-compacted-tool-rework.md
@@ -1,0 +1,163 @@
+# SDK rework against compacted memory(action=...) tool surface
+
+Status: Proposed — 2026-04-29
+Tracks: (issue to be filed)
+Author: @rdwj (drafted with Claude Code Opus 4.7)
+
+## Why this exists
+
+Issues #198/#201/#202 reduced the MemoryHub MCP server's tool surface from 10
+per-action tools to a single `memory(action=...)` dispatcher (plus
+`register_session`). That work shipped on the `memory-hub-mcp` (primary)
+deployment, which is the only deployment exposing the full operation surface.
+The minimal deployment retains a 4-tool subset for legacy integrations.
+
+Issue #202's scope explicitly called for keeping the per-action tools as
+temporary aliases for a deprecation window. That aliasing step was never
+shipped, and the `memoryhub` Python SDK (currently v0.6.0) still calls the
+old per-action tool names (`search_memory`, `read_memory`, `write_memory`,
+etc.). The result: `MemoryHubClient` cannot talk to the primary deployment
+at all — `register_session` succeeds but every operational method raises
+`ToolError: Unknown tool: '<name>'`.
+
+This was caught when the kagenti-adk integration in
+[kagenti/adk PR #231](https://github.com/kagenti/adk/pull/231) was tested
+against the live primary server. The PR is paused until this is fixed.
+
+## What this rework is
+
+The cutover. We take the SDK forward to the new surface instead of
+back-porting compatibility aliases on the server. Wes confirmed
+2026-04-29: "we did flag the SDK as necessary follow-on work and we
+should have done that very next thing and did not. This is our chance
+to rectify that."
+
+## Scope
+
+1. Rewrite `MemoryHubClient` internals so every method dispatches via
+   `memory(action=..., memory_id=..., query=..., content=..., scope=...,
+   project_id=..., options={...})` instead of calling per-action tool
+   names directly.
+2. Keep all public method signatures stable. The kagenti-adk wrapper
+   already calls `client.search(query, scope=..., project_id=...,
+   max_results=...)`, etc.; that surface must not change. Only the wire
+   format the SDK emits to the MCP server changes.
+3. `register_session` stays a separate tool call — it is unchanged on
+   the server.
+4. Update `sdk/tests/test_client.py` to assert the new payload shape:
+   `call_tool("memory", {"action": "search", ...})` instead of
+   `call_tool("search_memory", ...)`.
+5. Bump SDK version `0.6.0 → 0.7.0`. Update `sdk/CHANGELOG.md` with a
+   "BREAKING (wire format)" entry that links this rework, #198, and
+   #202.
+6. Bump kagenti-adk's `memoryhub>=0.5.0` pin to `memoryhub>=0.7.0` in a
+   coordinated PR-#231 follow-up commit.
+
+## Action mapping
+
+The `memory` tool's accepted actions are documented in
+`memory-hub-mcp/src/tools/memory.py`. The mapping for each public SDK
+method:
+
+| SDK method | action | top-level args | options keys |
+|---|---|---|---|
+| `search` | `search` | `query`, `scope`, `project_id` | `max_results`, `weight_threshold`, `current_only`, `mode`, `max_response_tokens`, `include_branches`, `focus`, `session_focus_weight`, `domains`, `domain_boost_weight`, `raw_results`, `owner_id` |
+| `read` | `read` | `memory_id`, `project_id` | `include_versions`, `history_offset`, `history_max_versions`, `hydrate` |
+| `write` | `write` | `content`, `scope`, `project_id` | `weight`, `parent_id`, `branch_type`, `metadata`, `domains`, `force`, `owner_id` |
+| `update` | `update` | `memory_id`, `content`, `project_id` | `weight`, `metadata`, `domains` |
+| `delete` | `delete` | `memory_id`, `project_id` | (none) |
+| `report_contradiction` | `report` | `memory_id`, `project_id` | `observed_behavior`, `confidence` |
+| `resolve_contradiction` | `resolve` | (none) | `contradiction_id`, `resolution_action`, `resolution_note` |
+| `get_similar` | `similar` | `memory_id`, `project_id` | `threshold`, `max_results`, `offset` |
+| `get_relationships` | `relationships` | `memory_id`, `project_id` | `relationship_type`, `direction`, `include_provenance` |
+| `create_relationship` | `relate` | `project_id` | `source_id`, `target_id`, `relationship_type`, `metadata` |
+| `set_curation_rule` | `set_rule` | (none) | `name`, `tier`, `action_type`, `config`, `scope_filter`, `enabled`, `priority` |
+| `list_projects` | `list_projects` | (none) | `filter` |
+| `create_project` | `create_project` | `project_id` | `project_name`, `description`, `invite_only` |
+| `add_project_member` | `add_member` | `project_id` | `user_id`, `role` |
+| `remove_project_member` | `remove_member` | `project_id` | `user_id` |
+| `get_session` | `status` | (none) | (none) |
+| `set_session_focus` | `set_focus` | `project_id` | `focus` |
+| `get_focus_history` | `focus_history` | `project_id` | `start_date`, `end_date` |
+
+Two server-side normalizations to remember when wiring the dispatch:
+
+- `relationships` action takes `memory_id` at the top level but the
+  server's `manage_graph` tool internally renames it to `node_id`. The
+  SDK should pass `memory_id` per the dispatcher contract; the server
+  handles the rename.
+- `describe_project`, `add_member`, `remove_member`, `create_project`
+  take `project_id` at the top level, not `project_name`. The
+  dispatcher normalizes.
+
+## Implementation shape
+
+Add one private helper:
+
+```
+async def _call_action(
+    self,
+    action: str,
+    *,
+    memory_id: str | None = None,
+    query: str | None = None,
+    content: str | None = None,
+    scope: str | None = None,
+    project_id: str | None = None,
+    options: dict | None = None,
+) -> dict:
+    payload = {"action": action}
+    if memory_id is not None: payload["memory_id"] = memory_id
+    if query is not None: payload["query"] = query
+    if content is not None: payload["content"] = content
+    if scope is not None: payload["scope"] = scope
+    if project_id is not None: payload["project_id"] = project_id
+    if options: payload["options"] = options
+    return await self._call("memory", payload)
+```
+
+Each public method becomes a thin wrapper that builds its own `options`
+dict and calls `_call_action`. The error-classification logic in
+`_call` is unchanged — the server returns the same error envelopes for
+the dispatched action as it did for the per-action tools.
+
+## Backwards compatibility
+
+- Public Python API: **stable**. No method signature changes, no
+  imports moved. Existing callers (kagenti-adk wrapper, internal
+  scripts) continue to compile after a version bump.
+- Wire format: **breaking**. SDK 0.6.0 cannot talk to a server with
+  per-action tools removed. SDK 0.7.0 cannot talk to a server that
+  only exposes per-action tools. We pin kagenti-adk to 0.7.0+; the
+  minimal-tool deployment is for legacy connectors and is not in the
+  SDK's target set.
+
+## Out of scope
+
+- Re-introducing server-side per-action tools as aliases. Decision
+  recorded above.
+- Updating fipsagents/agent-template SDK consumers. Track separately
+  if any are pinned <0.7.0.
+- `manage_curation` / `set_curation_rule` parity with the dispatcher.
+  The server still exposes `manage_curation` independently for tier-2
+  callers; the SDK uses the dispatcher path for `set_rule`, `report`,
+  `resolve`. No behavioral change.
+
+## Open questions
+
+- Do we want a `--use-legacy-tools` flag on the SDK for talking to the
+  minimal deployment? Recommend **no** — minimal is a 4-tool subset
+  used by legacy connectors, not a full target. Document in the README
+  instead.
+- Should the rework also update the SDK's docstrings to describe the
+  dispatcher path? Recommend **yes**, but only on methods where the
+  new wire format affects observable behavior (e.g., error messages
+  reference the action name).
+
+## References
+
+- `planning/mcp-single-tool-schema.md` — the original action-dispatch design.
+- `memory-hub-mcp/src/tools/memory.py` — the dispatcher implementation.
+- `sdk/src/memoryhub/client.py` — the SDK to be reworked.
+- `sdk/tests/test_client.py` — the test suite to update.
+- `kagenti/adk` PR #231 — the integration that surfaced the gap.

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -2,7 +2,21 @@
 
 All notable changes to the `memoryhub` SDK package.
 
-## [0.6.0] — 2026-04-23
+## [0.7.0] — 2026-04-29
+
+- **BREAKING (wire format)**: `MemoryHubClient` now dispatches every
+  operation through the unified `memory(action=..., options={...})` MCP
+  tool introduced by the server-side consolidation in #198/#202.
+  Per-action tool names (`search_memory`, `read_memory`, `write_memory`,
+  `update_memory`, `delete_memory`, `report_contradiction`,
+  `get_similar_memories`, `get_relationships`, `create_relationship`,
+  `set_curation_rule`, `manage_session`, `manage_project`,
+  `set_session_focus`, `get_focus_history`) are no longer called.
+  This release **cannot** talk to a server that only exposes the legacy
+  per-action tools; older releases (≤ 0.6.0) **cannot** talk to the
+  primary `memory-hub-mcp` deployment. The Python API is unchanged —
+  consumers only need to update the dependency pin. Tracks #210, closes
+  the alias gap left by #202.
 
 - **Stub result compatibility**: Default `content` and `owner_id` fields to
   empty strings in the `Memory` model so cache-optimized search responses

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "memoryhub"
-version = "0.6.0"
+version = "0.7.0"
 description = "Centralized, governed memory for AI agents"
 readme = "README.md"
 license = "Apache-2.0"

--- a/sdk/src/memoryhub/client.py
+++ b/sdk/src/memoryhub/client.py
@@ -322,6 +322,42 @@ class MemoryHubClient:
             self._mcp = None
         self._message_handler = None
 
+    async def _call_action(
+        self,
+        action: str,
+        *,
+        memory_id: str | None = None,
+        query: str | None = None,
+        content: str | None = None,
+        scope: str | None = None,
+        project_id: str | None = None,
+        options: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Dispatch an action through the unified ``memory`` tool (#198/#202).
+
+        Builds the ``memory(action=..., ...)`` payload accepted by the
+        compacted server tool surface and forwards it through ``_call``.
+        Top-level keys are only included when their value is not None;
+        ``options`` is included only when non-empty.
+
+        See ``planning/sdk-compacted-tool-rework.md`` for the action
+        mapping.
+        """
+        payload: dict[str, Any] = {"action": action}
+        if memory_id is not None:
+            payload["memory_id"] = memory_id
+        if query is not None:
+            payload["query"] = query
+        if content is not None:
+            payload["content"] = content
+        if scope is not None:
+            payload["scope"] = scope
+        if project_id is not None:
+            payload["project_id"] = project_id
+        if options:
+            payload["options"] = options
+        return await self._call("memory", payload)
+
     async def _call(self, tool_name: str, arguments: dict[str, Any]) -> dict[str, Any]:
         """Call an MCP tool and return the parsed response dict.
 
@@ -464,29 +500,35 @@ class MemoryHubClient:
         if session_focus_weight is None:
             session_focus_weight = loading.session_focus_weight
 
-        payload: dict[str, Any] = {
-            "query": query,
-            "scope": scope,
-            "owner_id": owner_id,
+        opts: dict[str, Any] = {
             "max_results": max_results,
             "weight_threshold": weight_threshold,
             "current_only": current_only,
             "mode": mode,
             "max_response_tokens": max_response_tokens,
             "include_branches": include_branches,
-            "project_id": project_id,
-            "domains": domains,
-            "domain_boost_weight": domain_boost_weight,
             "raw_results": raw_results,
         }
+        if owner_id is not None:
+            opts["owner_id"] = owner_id
+        if domains is not None:
+            opts["domains"] = domains
+        if domain_boost_weight is not None:
+            opts["domain_boost_weight"] = domain_boost_weight
         # Only forward focus params when the caller actually supplied a
         # focus string. Sending session_focus_weight without focus would
         # be a no-op on the server but adds noise to the wire format.
         if focus is not None:
-            payload["focus"] = focus
-            payload["session_focus_weight"] = session_focus_weight
+            opts["focus"] = focus
+            opts["session_focus_weight"] = session_focus_weight
 
-        data = await self._call("search_memory", payload)
+        data = await self._call_action(
+            "search",
+            query=query,
+            scope=scope,
+            project_id=project_id,
+            options=opts,
+        )
         return SearchResult.model_validate(data)
 
     @staticmethod
@@ -564,15 +606,16 @@ class MemoryHubClient:
             history_max_versions: Max versions to return (1-100, default 10).
             project_id: Project identifier for campaign enrollment verification.
         """
-        payload: dict[str, Any] = {
-            "memory_id": memory_id,
-            "include_versions": include_versions,
-            "project_id": project_id,
-        }
+        opts: dict[str, Any] = {"include_versions": include_versions}
         if include_versions:
-            payload["history_offset"] = history_offset
-            payload["history_max_versions"] = history_max_versions
-        data = await self._call("read_memory", payload)
+            opts["history_offset"] = history_offset
+            opts["history_max_versions"] = history_max_versions
+        data = await self._call_action(
+            "read",
+            memory_id=memory_id,
+            project_id=project_id,
+            options=opts,
+        )
         return Memory.model_validate(data)
 
     async def write(
@@ -611,20 +654,26 @@ class MemoryHubClient:
             cache_impact fields populated. Check curation.gated before accessing
             memory.
         """
-        payload: dict[str, Any] = {
-            "content": content,
-            "scope": scope,
-            "owner_id": owner_id,
-            "weight": weight,
-            "parent_id": parent_id,
-            "branch_type": branch_type,
-            "metadata": metadata,
-            "project_id": project_id,
-            "domains": domains,
-        }
+        opts: dict[str, Any] = {"weight": weight}
+        if owner_id is not None:
+            opts["owner_id"] = owner_id
+        if parent_id is not None:
+            opts["parent_id"] = parent_id
+        if branch_type is not None:
+            opts["branch_type"] = branch_type
+        if metadata is not None:
+            opts["metadata"] = metadata
+        if domains is not None:
+            opts["domains"] = domains
         if force:
-            payload["force"] = True
-        data = await self._call("write_memory", payload)
+            opts["force"] = True
+        data = await self._call_action(
+            "write",
+            content=content,
+            scope=scope,
+            project_id=project_id,
+            options=opts,
+        )
         return WriteResult.model_validate(data)
 
     async def update(
@@ -651,16 +700,19 @@ class MemoryHubClient:
         """
         if content is None and weight is None and metadata is None:
             raise ValueError("update() requires at least one of: content, weight, metadata")
-        data = await self._call(
-            "update_memory",
-            {
-                "memory_id": memory_id,
-                "content": content,
-                "weight": weight,
-                "metadata": metadata,
-                "project_id": project_id,
-                "domains": domains,
-            },
+        opts: dict[str, Any] = {}
+        if weight is not None:
+            opts["weight"] = weight
+        if metadata is not None:
+            opts["metadata"] = metadata
+        if domains is not None:
+            opts["domains"] = domains
+        data = await self._call_action(
+            "update",
+            memory_id=memory_id,
+            content=content,
+            project_id=project_id,
+            options=opts,
         )
         return Memory.model_validate(data)
 
@@ -671,12 +723,10 @@ class MemoryHubClient:
             memory_id: ID of the memory to delete.
             project_id: Project identifier for campaign enrollment verification.
         """
-        data = await self._call(
-            "delete_memory",
-            {
-                "memory_id": memory_id,
-                "project_id": project_id,
-            },
+        data = await self._call_action(
+            "delete",
+            memory_id=memory_id,
+            project_id=project_id,
         )
         return DeleteResult.model_validate(data)
 
@@ -698,13 +748,13 @@ class MemoryHubClient:
             confidence: Reporter's confidence in the contradiction (0.0-1.0, default 0.7).
             project_id: Project identifier for campaign enrollment verification.
         """
-        data = await self._call(
-            "report_contradiction",
-            {
-                "memory_id": memory_id,
+        data = await self._call_action(
+            "report",
+            memory_id=memory_id,
+            project_id=project_id,
+            options={
                 "observed_behavior": observed_behavior,
                 "confidence": confidence,
-                "project_id": project_id,
             },
         )
         return ContradictionResult.model_validate(data)
@@ -725,15 +775,13 @@ class MemoryHubClient:
                 or 'manual_merge'.
             resolution_note: Optional rationale for the resolution.
         """
-        return await self._call(
-            "manage_curation",
-            {
-                "action": "resolve_contradiction",
-                "contradiction_id": contradiction_id,
-                "resolution_action": resolution_action,
-                "resolution_note": resolution_note,
-            },
-        )
+        opts: dict[str, Any] = {
+            "contradiction_id": contradiction_id,
+            "resolution_action": resolution_action,
+        }
+        if resolution_note is not None:
+            opts["resolution_note"] = resolution_note
+        return await self._call_action("resolve", options=opts)
 
     # ── Similarity & relationships ──────────────────────────────────
 
@@ -755,14 +803,14 @@ class MemoryHubClient:
             offset: Pagination offset (default 0).
             project_id: Project identifier for campaign enrollment verification.
         """
-        data = await self._call(
-            "get_similar_memories",
-            {
-                "memory_id": memory_id,
+        data = await self._call_action(
+            "similar",
+            memory_id=memory_id,
+            project_id=project_id,
+            options={
                 "threshold": threshold,
                 "max_results": max_results,
                 "offset": offset,
-                "project_id": project_id,
             },
         )
         results = data.get("results", [])
@@ -786,15 +834,20 @@ class MemoryHubClient:
             include_provenance: If True, include provenance metadata on each edge.
             project_id: Project identifier for campaign enrollment verification.
         """
-        data = await self._call(
-            "get_relationships",
-            {
-                "node_id": node_id,
-                "relationship_type": relationship_type,
-                "direction": direction,
-                "include_provenance": include_provenance,
-                "project_id": project_id,
-            },
+        opts: dict[str, Any] = {
+            "direction": direction,
+            "include_provenance": include_provenance,
+        }
+        if relationship_type is not None:
+            opts["relationship_type"] = relationship_type
+        # The dispatcher accepts `memory_id` at the top level and renames
+        # it to `node_id` server-side; the SDK keeps the public `node_id`
+        # parameter for backward compatibility.
+        data = await self._call_action(
+            "relationships",
+            memory_id=node_id,
+            project_id=project_id,
+            options=opts,
         )
         return RelationshipsResult.model_validate(data)
 
@@ -816,15 +869,17 @@ class MemoryHubClient:
             metadata: Arbitrary metadata for the relationship edge.
             project_id: Project identifier for campaign enrollment verification.
         """
-        data = await self._call(
-            "create_relationship",
-            {
-                "source_id": source_id,
-                "target_id": target_id,
-                "relationship_type": relationship_type,
-                "metadata": metadata,
-                "project_id": project_id,
-            },
+        opts: dict[str, Any] = {
+            "source_id": source_id,
+            "target_id": target_id,
+            "relationship_type": relationship_type,
+        }
+        if metadata is not None:
+            opts["metadata"] = metadata
+        data = await self._call_action(
+            "relate",
+            project_id=project_id,
+            options=opts,
         )
         return RelationshipInfo.model_validate(data)
 
@@ -842,18 +897,20 @@ class MemoryHubClient:
         priority: int = 10,
     ) -> CurationRuleResult:
         """Create or update a curation rule."""
-        data = await self._call(
-            "set_curation_rule",
-            {
-                "name": name,
-                "tier": tier,
-                "action": action,
-                "config": config,
-                "scope_filter": scope_filter,
-                "enabled": enabled,
-                "priority": priority,
-            },
-        )
+        # Dispatcher uses `action_type` for the rule action to avoid
+        # colliding with the top-level `action` parameter.
+        opts: dict[str, Any] = {
+            "name": name,
+            "tier": tier,
+            "action_type": action,
+            "enabled": enabled,
+            "priority": priority,
+        }
+        if config is not None:
+            opts["config"] = config
+        if scope_filter is not None:
+            opts["scope_filter"] = scope_filter
+        data = await self._call_action("set_rule", options=opts)
         return CurationRuleResult.model_validate(data)
 
     # ── Projects ──────────────────────────────────────────────────────
@@ -869,12 +926,9 @@ class MemoryHubClient:
             filter: 'mine' (default) for your projects, 'all' to include
                 open projects you could join.
         """
-        return await self._call(
-            "manage_project",
-            {
-                "action": "list",
-                "filter": filter,
-            },
+        return await self._call_action(
+            "list_projects",
+            options={"filter": filter},
         )
 
     async def create_project(
@@ -892,14 +946,15 @@ class MemoryHubClient:
             invite_only: If True, members must be added explicitly.
                 Default False allows auto-enrollment.
         """
-        return await self._call(
-            "manage_project",
-            {
-                "action": "create",
-                "project_name": project_name,
-                "description": description,
-                "invite_only": invite_only,
-            },
+        # The dispatcher accepts the project name at the top level as
+        # `project_id` for consistency with other project actions.
+        opts: dict[str, Any] = {"invite_only": invite_only}
+        if description is not None:
+            opts["description"] = description
+        return await self._call_action(
+            "create_project",
+            project_id=project_name,
+            options=opts,
         )
 
     async def add_project_member(
@@ -916,14 +971,10 @@ class MemoryHubClient:
             user_id: User to add.
             role: 'member' (default) or 'admin'.
         """
-        return await self._call(
-            "manage_project",
-            {
-                "action": "add_member",
-                "project_name": project_name,
-                "user_id": user_id,
-                "role": role,
-            },
+        return await self._call_action(
+            "add_member",
+            project_id=project_name,
+            options={"user_id": user_id, "role": role},
         )
 
     async def remove_project_member(
@@ -937,13 +988,10 @@ class MemoryHubClient:
             project_name: Project identifier.
             user_id: User to remove.
         """
-        return await self._call(
-            "manage_project",
-            {
-                "action": "remove_member",
-                "project_name": project_name,
-                "user_id": user_id,
-            },
+        return await self._call_action(
+            "remove_member",
+            project_id=project_name,
+            options={"user_id": user_id},
         )
 
     # ── Session focus (#61) ─────────────────────────────────────────
@@ -954,10 +1002,7 @@ class MemoryHubClient:
         Returns your user_id, name, scopes, session expiry, and project
         memberships without re-authenticating.
         """
-        return await self._call(
-            "manage_session",
-            {"action": "status"},
-        )
+        return await self._call_action("status")
 
     async def set_session_focus(
         self,
@@ -983,12 +1028,12 @@ class MemoryHubClient:
             A dict with ``session_id``, ``user_id``, ``project``, ``focus``,
             ``expires_at``, and ``message``.
         """
-        return await self._call(
-            "set_session_focus",
-            {
-                "focus": focus,
-                "project": project,
-            },
+        # Dispatcher takes the project at the top level as `project_id`
+        # and `focus` as an option key.
+        return await self._call_action(
+            "set_focus",
+            project_id=project,
+            options={"focus": focus},
         )
 
     async def get_focus_history(
@@ -1016,13 +1061,15 @@ class MemoryHubClient:
             ``total_sessions``, and ``histogram`` (list of ``{focus, count}``
             sorted by count descending, ties alphabetical).
         """
-        return await self._call(
-            "get_focus_history",
-            {
-                "project": project,
-                "start_date": start_date,
-                "end_date": end_date,
-            },
+        opts: dict[str, Any] = {}
+        if start_date is not None:
+            opts["start_date"] = start_date
+        if end_date is not None:
+            opts["end_date"] = end_date
+        return await self._call_action(
+            "focus_history",
+            project_id=project,
+            options=opts,
         )
 
     # ── Push notifications (#62, Pattern E) ─────────────────────────

--- a/sdk/tests/test_client.py
+++ b/sdk/tests/test_client.py
@@ -60,6 +60,27 @@ MINIMAL_CURATION = {
 }
 
 
+def _payload(mock_mcp) -> dict:
+    """Return the SDK's forwarded call as a flat key->value dict.
+
+    Since the rework against the compacted ``memory(action=..., options={...})``
+    tool surface, top-level params and option keys live at different levels of
+    the wire payload. This helper merges them so existing assertions on
+    individual keys keep working without nesting.
+    """
+    args = mock_mcp.call_tool.call_args[0][1]
+    flat = {k: v for k, v in args.items() if k != "options"}
+    flat.update(args.get("options") or {})
+    return flat
+
+
+def _tool_and_action(mock_mcp) -> tuple[str, str | None]:
+    """Return (tool_name, action) for the most recent forwarded call."""
+    tool = mock_mcp.call_tool.call_args[0][0]
+    payload = mock_mcp.call_tool.call_args[0][1]
+    return tool, payload.get("action") if isinstance(payload, dict) else None
+
+
 def _make_client() -> MemoryHubClient:
     return MemoryHubClient(
         url="https://fake.example.com/mcp/",
@@ -300,9 +321,8 @@ async def test_search(client):
     assert result.has_more is False
 
     mock_mcp.call_tool.assert_awaited_once()
-    call_args = mock_mcp.call_tool.call_args
-    assert call_args[0][0] == "search_memory"
-    assert call_args[0][1]["query"] == "Podman vs Docker"
+    assert _tool_and_action(mock_mcp) == ("memory", "search")
+    assert _payload(mock_mcp)["query"] == "Podman vs Docker"
 
 
 async def test_search_defaults_pass_through_new_params(client):
@@ -314,7 +334,7 @@ async def test_search_defaults_pass_through_new_params(client):
 
     await c.search("any")
 
-    forwarded = mock_mcp.call_tool.call_args[0][1]
+    forwarded = _payload(mock_mcp)
     assert forwarded["mode"] == "full"
     assert forwarded["max_response_tokens"] == 4000
     assert forwarded["include_branches"] is False
@@ -334,7 +354,7 @@ async def test_search_explicit_new_params(client):
         include_branches=True,
     )
 
-    forwarded = mock_mcp.call_tool.call_args[0][1]
+    forwarded = _payload(mock_mcp)
     assert forwarded["mode"] == "index"
     assert forwarded["max_response_tokens"] == 1500
     assert forwarded["include_branches"] is True
@@ -362,7 +382,7 @@ async def test_search_applies_project_config_retrieval_defaults():
 
     await c.search("anything")
 
-    forwarded = mock_mcp.call_tool.call_args[0][1]
+    forwarded = _payload(mock_mcp)
     assert forwarded["max_results"] == 25
     assert forwarded["max_response_tokens"] == 8000
     assert forwarded["mode"] == "index"
@@ -390,7 +410,7 @@ async def test_search_explicit_args_override_project_config():
 
     await c.search("anything", max_results=5, max_response_tokens=500, mode="full_only")
 
-    forwarded = mock_mcp.call_tool.call_args[0][1]
+    forwarded = _payload(mock_mcp)
     assert forwarded["max_results"] == 5
     assert forwarded["max_response_tokens"] == 500
     assert forwarded["mode"] == "full_only"
@@ -437,7 +457,7 @@ async def test_search_no_focus_omits_focus_params_from_payload(client):
 
     await c.search("any query")
 
-    forwarded = mock_mcp.call_tool.call_args[0][1]
+    forwarded = _payload(mock_mcp)
     assert "focus" not in forwarded
     assert "session_focus_weight" not in forwarded
 
@@ -455,7 +475,7 @@ async def test_search_focus_string_forwards_with_default_weight(client):
 
     await c.search("any query", focus="OpenShift deployment")
 
-    forwarded = mock_mcp.call_tool.call_args[0][1]
+    forwarded = _payload(mock_mcp)
     assert forwarded["focus"] == "OpenShift deployment"
     assert forwarded["session_focus_weight"] == 0.4
 
@@ -468,7 +488,7 @@ async def test_search_explicit_session_focus_weight_overrides_default(client):
 
     await c.search("query", focus="auth", session_focus_weight=0.2)
 
-    forwarded = mock_mcp.call_tool.call_args[0][1]
+    forwarded = _payload(mock_mcp)
     assert forwarded["focus"] == "auth"
     assert forwarded["session_focus_weight"] == 0.2
 
@@ -495,7 +515,7 @@ async def test_search_session_focus_weight_from_project_config():
 
     await c.search("query", focus="auth")
 
-    forwarded = mock_mcp.call_tool.call_args[0][1]
+    forwarded = _payload(mock_mcp)
     assert forwarded["session_focus_weight"] == 0.6
 
 
@@ -607,9 +627,8 @@ async def test_read(client):
     assert result.id == "mem-001"
     assert result.content == "Use Podman, not Docker."
 
-    call_args = mock_mcp.call_tool.call_args
-    assert call_args[0][0] == "read_memory"
-    assert call_args[0][1]["memory_id"] == "mem-001"
+    assert _tool_and_action(mock_mcp) == ("memory", "read")
+    assert _payload(mock_mcp)["memory_id"] == "mem-001"
 
 
 # ── write ─────────────────────────────────────────────────────────────────────
@@ -631,10 +650,10 @@ async def test_write(client):
     assert result.curation.blocked is False
     assert result.curation.similar_count == 0
 
-    call_args = mock_mcp.call_tool.call_args
-    assert call_args[0][0] == "write_memory"
-    assert call_args[0][1]["content"] == "Use Podman, not Docker."
-    assert call_args[0][1]["scope"] == "user"
+    assert _tool_and_action(mock_mcp) == ("memory", "write")
+    forwarded = _payload(mock_mcp)
+    assert forwarded["content"] == "Use Podman, not Docker."
+    assert forwarded["scope"] == "user"
 
 
 def test_write_result_gated_response():
@@ -705,12 +724,12 @@ async def test_write_force_in_payload(client):
 
     # force=True — key must be present and True
     await c.write("something", force=True)
-    forwarded = mock_mcp.call_tool.call_args[0][1]
+    forwarded = _payload(mock_mcp)
     assert forwarded.get("force") is True
 
     # force=False (default) — key must be absent (backward compat)
     await c.write("something else")
-    forwarded = mock_mcp.call_tool.call_args[0][1]
+    forwarded = _payload(mock_mcp)
     assert "force" not in forwarded
 
 
@@ -728,9 +747,8 @@ async def test_update(client):
     assert result.version == 2
     assert "never Docker" in result.content
 
-    call_args = mock_mcp.call_tool.call_args
-    assert call_args[0][0] == "update_memory"
-    assert call_args[0][1]["memory_id"] == "mem-001"
+    assert _tool_and_action(mock_mcp) == ("memory", "update")
+    assert _payload(mock_mcp)["memory_id"] == "mem-001"
 
 
 # ── report_contradiction ──────────────────────────────────────────────────────
@@ -755,9 +773,8 @@ async def test_report_contradiction(client):
     assert result.contradiction_count == 2
     assert result.revision_triggered is False
 
-    call_args = mock_mcp.call_tool.call_args
-    assert call_args[0][0] == "report_contradiction"
-    assert call_args[0][1]["memory_id"] == "mem-001"
+    assert _tool_and_action(mock_mcp) == ("memory", "report")
+    assert _payload(mock_mcp)["memory_id"] == "mem-001"
 
 
 # ── error handling ────────────────────────────────────────────────────────────
@@ -773,7 +790,7 @@ async def test_tool_error_raised(client):
     with pytest.raises(ToolError) as exc_info:
         await c.search("anything")
 
-    assert exc_info.value.tool_name == "search_memory"
+    assert exc_info.value.tool_name == "memory"
     assert "database unavailable" in exc_info.value.detail
 
 
@@ -828,7 +845,7 @@ async def test_permission_denied_error(client):
     )
     with pytest.raises(PermissionDeniedError) as exc_info:
         await c.read("mem-001")
-    assert exc_info.value.tool_name == "read_memory"
+    assert exc_info.value.tool_name == "memory"
     assert "Not authorized" in exc_info.value.detail
 
 
@@ -850,7 +867,7 @@ async def test_validation_error(client):
     )
     with pytest.raises(ValidationError) as exc_info:
         await c.read("bad-id")
-    assert exc_info.value.tool_name == "read_memory"
+    assert exc_info.value.tool_name == "memory"
 
 
 async def test_validation_error_must_be(client):
@@ -902,7 +919,7 @@ async def test_curation_veto_error(client):
     )
     with pytest.raises(CurationVetoError) as exc_info:
         await c.write("duplicate stuff", scope="user")
-    assert exc_info.value.tool_name == "write_memory"
+    assert exc_info.value.tool_name == "memory"
     assert "Curation rule blocked" in exc_info.value.detail
 
 
@@ -980,9 +997,10 @@ async def test_set_session_focus_forwards_arguments(client):
     assert result["focus"] == "deployment"
 
     mock_mcp.call_tool.assert_awaited_once()
-    call_args = mock_mcp.call_tool.call_args
-    assert call_args[0][0] == "set_session_focus"
-    assert call_args[0][1] == {"focus": "deployment", "project": "memory-hub"}
+    assert _tool_and_action(mock_mcp) == ("memory", "set_focus")
+    forwarded = _payload(mock_mcp)
+    assert forwarded["project_id"] == "memory-hub"
+    assert forwarded["focus"] == "deployment"
 
 
 async def test_get_focus_history_forwards_date_range(client):
@@ -1010,8 +1028,9 @@ async def test_get_focus_history_forwards_date_range(client):
     assert result["total_sessions"] == 3
     assert result["histogram"][0] == {"focus": "deployment", "count": 2}
 
-    forwarded = mock_mcp.call_tool.call_args[0][1]
-    assert forwarded["project"] == "memory-hub"
+    assert _tool_and_action(mock_mcp) == ("memory", "focus_history")
+    forwarded = _payload(mock_mcp)
+    assert forwarded["project_id"] == "memory-hub"
     assert forwarded["start_date"] == "2026-04-01"
     assert forwarded["end_date"] == "2026-04-07"
 
@@ -1033,9 +1052,9 @@ async def test_get_focus_history_strips_none_dates(client):
 
     await c.get_focus_history("memory-hub")
 
-    forwarded = mock_mcp.call_tool.call_args[0][1]
-    assert forwarded["project"] == "memory-hub"
-    # None values are stripped by _call before sending
+    forwarded = _payload(mock_mcp)
+    assert forwarded["project_id"] == "memory-hub"
+    # None values are stripped before sending
     assert "start_date" not in forwarded
     assert "end_date" not in forwarded
 
@@ -1057,7 +1076,7 @@ async def test_search_forwards_project_id_and_domains(client):
         domain_boost_weight=0.5,
     )
 
-    forwarded = mock_mcp.call_tool.call_args[0][1]
+    forwarded = _payload(mock_mcp)
     assert forwarded["project_id"] == "proj-123"
     assert forwarded["domains"] == ["React", "Spring Boot"]
     assert forwarded["domain_boost_weight"] == 0.5
@@ -1072,7 +1091,7 @@ async def test_search_omits_campaign_params_when_none(client):
 
     await c.search("query")
 
-    forwarded = mock_mcp.call_tool.call_args[0][1]
+    forwarded = _payload(mock_mcp)
     assert "project_id" not in forwarded
     assert "domains" not in forwarded
     assert "domain_boost_weight" not in forwarded
@@ -1087,7 +1106,7 @@ async def test_write_forwards_project_id_and_domains(client):
 
     await c.write("content", project_id="proj-123", domains=["React"])
 
-    forwarded = mock_mcp.call_tool.call_args[0][1]
+    forwarded = _payload(mock_mcp)
     assert forwarded["project_id"] == "proj-123"
     assert forwarded["domains"] == ["React"]
 
@@ -1100,7 +1119,7 @@ async def test_update_forwards_project_id_and_domains(client):
 
     await c.update("mem-001", content="updated", project_id="proj-123", domains=["React"])
 
-    forwarded = mock_mcp.call_tool.call_args[0][1]
+    forwarded = _payload(mock_mcp)
     assert forwarded["project_id"] == "proj-123"
     assert forwarded["domains"] == ["React"]
 
@@ -1142,41 +1161,42 @@ _CREATE_REL_RESPONSE = {
 
 
 @pytest.mark.parametrize(
-    "method,tool_name,call_kwargs,response",
+    "method,action,call_kwargs,response",
     [
-        ("read", "read_memory", {"memory_id": "mem-001"}, MINIMAL_MEMORY),
-        ("write", "write_memory", {"content": "test"}, _WRITE_RESPONSE),
+        ("read", "read", {"memory_id": "mem-001"}, MINIMAL_MEMORY),
+        ("write", "write", {"content": "test"}, _WRITE_RESPONSE),
         (
             "update",
-            "update_memory",
+            "update",
             {"memory_id": "mem-001", "content": "updated"},
             {**MINIMAL_MEMORY, "version": 2},
         ),
-        ("delete", "delete_memory", {"memory_id": "mem-001"}, _DELETE_RESPONSE),
+        ("delete", "delete", {"memory_id": "mem-001"}, _DELETE_RESPONSE),
         (
             "report_contradiction",
-            "report_contradiction",
+            "report",
             {"memory_id": "mem-001", "observed_behavior": "changed"},
             _CONTRADICTION_RESPONSE,
         ),
-        ("get_similar", "get_similar_memories", {"memory_id": "mem-001"}, {"results": []}),
+        ("get_similar", "similar", {"memory_id": "mem-001"}, {"results": []}),
         (
             "get_relationships",
-            "get_relationships",
+            "relationships",
             {"node_id": "mem-001"},
             _RELATIONSHIPS_RESPONSE,
         ),
-        ("create_relationship", "create_relationship", _CREATE_REL_KWARGS, _CREATE_REL_RESPONSE),
+        ("create_relationship", "relate", _CREATE_REL_KWARGS, _CREATE_REL_RESPONSE),
     ],
 )
 async def test_project_id_forwarded_when_provided(
     client,
     method,
-    tool_name,
+    action,
     call_kwargs,
     response,
 ):
-    """project_id is forwarded to the MCP tool when provided."""
+    """project_id is forwarded to the dispatcher when provided, and the
+    dispatched action matches the expected per-method action name."""
     c, mock_mcp = client
     mock_mcp.call_tool.return_value = FakeCallToolResult(
         structured_content=response,
@@ -1185,7 +1205,8 @@ async def test_project_id_forwarded_when_provided(
     func = getattr(c, method)
     await func(**call_kwargs, project_id="proj-123")
 
-    forwarded = mock_mcp.call_tool.call_args[0][1]
+    assert _tool_and_action(mock_mcp) == ("memory", action)
+    forwarded = _payload(mock_mcp)
     assert forwarded["project_id"] == "proj-123"
 
 
@@ -1218,7 +1239,7 @@ async def test_project_id_omitted_when_none(
 
     await getattr(c, method)(**call_kwargs)
 
-    forwarded = mock_mcp.call_tool.call_args[0][1]
+    forwarded = _payload(mock_mcp)
     assert "project_id" not in forwarded
 
 
@@ -1489,7 +1510,7 @@ async def test_search_forwards_raw_results_false_by_default(client):
 
     await c.search("any")
 
-    forwarded = mock_mcp.call_tool.call_args[0][1]
+    forwarded = _payload(mock_mcp)
     assert forwarded["raw_results"] is False
 
 
@@ -1502,7 +1523,7 @@ async def test_search_forwards_raw_results_true(client):
 
     await c.search("any", raw_results=True)
 
-    forwarded = mock_mcp.call_tool.call_args[0][1]
+    forwarded = _payload(mock_mcp)
     assert forwarded["raw_results"] is True
 
 

--- a/sdk/tests/test_sdk_kagenti_contract.py
+++ b/sdk/tests/test_sdk_kagenti_contract.py
@@ -1,0 +1,253 @@
+"""SDK contract test guarding the kagenti-adk integration (#208).
+
+This test pins the SDK surface that kagenti-adk's
+``MemoryHubMemoryStoreInstance`` (kagenti/adk PR #231) depends on. A
+breaking change here means kagenti-adk's CI breaks; that is the cue
+to either revert, ship a compat shim, or coordinate a downstream
+update before the SDK release.
+
+The test uses the SDK's existing mocked transport — no live
+MemoryHub required. See ``planning/sdk-kagenti-contract-test.md`` for
+the rationale.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from unittest.mock import AsyncMock
+
+import pytest
+
+# These imports are part of the contract — kagenti-adk uses every one of them.
+# Renaming or relocating any of these would break the downstream consumer.
+from memoryhub.client import MemoryHubClient
+from memoryhub.exceptions import NotFoundError
+from memoryhub.models import DeleteResult, Memory, SearchResult, WriteResult
+
+
+@dataclass
+class _FakeContent:
+    text: str
+    type: str = "text"
+
+
+@dataclass
+class _FakeCallToolResult:
+    content: list = field(default_factory=list)
+    structured_content: dict | None = None
+    data: object = None
+    is_error: bool = False
+    meta: dict | None = None
+
+
+_MEMORY = {
+    "id": "mem-001",
+    "content": "Use Podman, not Docker.",
+    "scope": "user",
+    "owner_id": "kagenti-ci",
+    "weight": 0.9,
+    "is_current": True,
+    "version": 1,
+    "storage_type": "inline",
+}
+
+_WRITE_OK = {
+    "memory": _MEMORY,
+    "curation": {"blocked": False, "similar_count": 0, "flags": []},
+}
+
+_WRITE_GATED = {
+    "memory": None,
+    "curation": {
+        "blocked": False,
+        "gated": True,
+        "similar_count": 1,
+        "flags": ["near_duplicate"],
+        "reason": "near_duplicate",
+        "existing_memory_id": "mem-existing",
+    },
+}
+
+
+def _client_with_mock() -> tuple[MemoryHubClient, AsyncMock]:
+    c = MemoryHubClient(url="https://fake.example.com/mcp/", api_key="mh-dev-test")
+    mock = AsyncMock()
+    c._mcp = mock
+    return c, mock
+
+
+# ── Constructor contract ────────────────────────────────────────────────────
+
+
+def test_constructor_api_key_mode_accepts_url_and_api_key() -> None:
+    """kagenti-adk's MemoryHubExtensionServer instantiates this way when
+    the A2A extension fulfillment carries an API key."""
+    c = MemoryHubClient(url="https://example.com/mcp/", api_key="mh-dev-abc")
+    assert c._url == "https://example.com/mcp/"
+    assert c._api_key == "mh-dev-abc"
+
+
+def test_constructor_oauth_mode_accepts_full_oauth_params() -> None:
+    """kagenti-adk's MemoryHubExtensionServer instantiates this way when
+    the A2A extension fulfillment carries OAuth credentials."""
+    c = MemoryHubClient(
+        url="https://example.com/mcp/",
+        auth_url="https://auth.example.com",
+        client_id="kagenti-client",
+        client_secret="kagenti-secret",
+    )
+    assert c._url == "https://example.com/mcp/"
+    assert c._auth is not None
+
+
+# ── search contract ─────────────────────────────────────────────────────────
+
+
+async def test_search_signature_and_result_fields() -> None:
+    """kagenti-adk calls
+    ``store.search(query, scope=..., project_id=..., max_results=...)``
+    and projects ``id``, ``content``, ``scope``, ``weight`` from each
+    result. All four fields are load-bearing."""
+    c, mock = _client_with_mock()
+    mock.call_tool.return_value = _FakeCallToolResult(
+        structured_content={
+            "results": [_MEMORY],
+            "total_matching": 1,
+            "has_more": False,
+        }
+    )
+
+    result = await c.search(
+        "podman",
+        scope="user",
+        project_id="kagenti-tests",
+        max_results=5,
+    )
+
+    assert isinstance(result, SearchResult)
+    assert len(result.results) == 1
+    m = result.results[0]
+    assert m.id == "mem-001"
+    assert m.content == "Use Podman, not Docker."
+    assert m.scope == "user"
+    assert m.weight == 0.9
+
+
+# ── write contract (happy path + curation veto) ────────────────────────────
+
+
+async def test_write_signature_and_happy_path() -> None:
+    """kagenti-adk calls
+    ``store.create(content, scope=..., weight=..., tags=...,
+    project_id=...)`` which becomes ``client.write(...)``. It reads
+    ``result.memory.id`` on success."""
+    c, mock = _client_with_mock()
+    mock.call_tool.return_value = _FakeCallToolResult(structured_content=_WRITE_OK)
+
+    result = await c.write(
+        "Use Podman, not Docker.",
+        scope="user",
+        weight=0.9,
+        domains=["devops"],
+        project_id="kagenti-tests",
+    )
+
+    assert isinstance(result, WriteResult)
+    assert result.memory is not None
+    assert result.memory.id == "mem-001"
+
+
+async def test_write_curation_gated_exposes_reason() -> None:
+    """kagenti-adk's MemoryHubMemoryStoreInstance.create raises
+    MemoryRejectionError(result.curation.reason) when the write is
+    gated. This contract requires that ``result.memory is None`` and
+    ``result.curation.reason`` is a non-empty string in the gated
+    response — both are read directly by the wrapper."""
+    c, mock = _client_with_mock()
+    mock.call_tool.return_value = _FakeCallToolResult(structured_content=_WRITE_GATED)
+
+    result = await c.write("duplicate stuff", scope="user")
+
+    assert result.memory is None
+    assert result.curation.reason == "near_duplicate"
+
+
+# ── read contract (success + NotFoundError) ─────────────────────────────────
+
+
+async def test_read_returns_memory_with_required_fields() -> None:
+    c, mock = _client_with_mock()
+    mock.call_tool.return_value = _FakeCallToolResult(structured_content=_MEMORY)
+
+    m = await c.read("mem-001")
+
+    assert isinstance(m, Memory)
+    assert m.id == "mem-001"
+    assert m.content == "Use Podman, not Docker."
+    assert m.scope == "user"
+    assert m.weight == 0.9
+
+
+async def test_read_raises_not_found_on_missing_id() -> None:
+    """kagenti-adk's read() catches NotFoundError explicitly and returns
+    None to its caller. Renaming or relocating this exception breaks
+    that catch."""
+    c, mock = _client_with_mock()
+    mock.call_tool.return_value = _FakeCallToolResult(
+        is_error=True,
+        content=[_FakeContent("Memory not found: mem-missing")],
+    )
+
+    with pytest.raises(NotFoundError):
+        await c.read("mem-missing")
+
+
+# ── update contract ────────────────────────────────────────────────────────
+
+
+async def test_update_signature_and_returns_new_version() -> None:
+    """kagenti-adk does not currently update memories itself, but the
+    public update() signature is part of the SDK surface we promised
+    not to break. ``client.update(memory_id, content=...)`` must return
+    a Memory with the new version visible."""
+    c, mock = _client_with_mock()
+    mock.call_tool.return_value = _FakeCallToolResult(
+        structured_content={**_MEMORY, "content": "Always Podman.", "version": 2}
+    )
+
+    m = await c.update("mem-001", content="Always Podman.")
+
+    assert isinstance(m, Memory)
+    assert m.version == 2
+    assert m.content == "Always Podman."
+
+
+# ── delete contract ────────────────────────────────────────────────────────
+
+
+async def test_delete_returns_delete_result() -> None:
+    c, mock = _client_with_mock()
+    mock.call_tool.return_value = _FakeCallToolResult(
+        structured_content={
+            "deleted_id": "mem-001",
+            "deleted": True,
+            "versions_deleted": 1,
+        }
+    )
+
+    result = await c.delete("mem-001")
+
+    assert isinstance(result, DeleteResult)
+
+
+async def test_delete_raises_not_found_on_missing_id() -> None:
+    """``client.delete`` must raise NotFoundError on unknown id, same
+    as ``read`` — kagenti-adk relies on a uniform contract for both."""
+    c, mock = _client_with_mock()
+    mock.call_tool.return_value = _FakeCallToolResult(
+        is_error=True,
+        content=[_FakeContent("Memory not found: mem-missing")],
+    )
+
+    with pytest.raises(NotFoundError):
+        await c.delete("mem-missing")


### PR DESCRIPTION
## Summary
- Rewrite ``MemoryHubClient`` to dispatch every operation through the unified ``memory(action=..., options={...})`` MCP tool. Public Python API is unchanged; only the wire format moves.
- Restores end-to-end behavior against the primary ``memory-hub-mcp`` deployment, which exposes only ``register_session`` + ``memory`` after the consolidation in #198/#202.
- Bumps SDK 0.6.0 → 0.7.0 with a BREAKING-wire-format CHANGELOG note.
- Adds ``sdk/tests/test_sdk_kagenti_contract.py`` (closes #208) pinning the SDK surface that kagenti-adk's ``MemoryHubMemoryStoreInstance`` depends on.

Tracks #210. Closes #208.

This is the cutover that the deprecation-alias path scoped in #202 was meant to bridge. Server-side aliases were not added — design decision recorded in ``planning/sdk-compacted-tool-rework.md``.

Smoke-tested live against the primary server: ``search``, ``get_session``, and ``list_projects`` all succeed.

## Test plan
- [x] ``pytest sdk/tests/`` — 150 passed, 8 skipped, 0 ruff errors.
- [x] Live smoke against primary ``memory-hub-mcp`` route from an interactive session.
- [ ] After merge, cut a 0.7.0 release and bump kagenti-adk's ``memoryhub>=0.5.0`` pin to ``>=0.7.0`` in the PR-#231 follow-up commit, then run their E2E example.

## Notes for review
- During smoke-testing, ``search(max_results=N)`` returned 81–85 results for N ∈ {3, 5, 10}. That is a server-side bug in the cache-optimized assembly path — the SDK now correctly forwards the ``max_results`` option; the server is over-returning appendix entries. Filing separately.
- Ruff is clean. The single existing ``PytestUnknownMarkWarning`` for ``pytest.mark.integration`` is pre-existing.