### PR TITLE
retro: SDK rework against compacted tool surface (#210)

### DIFF
--- a/retrospectives/2026-04-29_sdk-compacted-tool-rework/RETRO.md
+++ b/retrospectives/2026-04-29_sdk-compacted-tool-rework/RETRO.md
@@ -1,0 +1,77 @@
+# Retrospective: SDK rework against compacted MCP tool surface
+
+**Date:** 2026-04-29
+**Effort:** Reroute the `memoryhub` Python SDK through the unified `memory(action=..., options={...})` MCP tool after the consolidation in #198/#202, ship a contract test for kagenti-adk (#208), and unblock kagenti-adk PR #231.
+**Issues:** #210 (closed), #208 (closed), #212 (filed), kagenti/adk#231 (unpaused, pin pushed)
+**Commits:** memory-hub `fabdc54` (squashed PR #211), `c50872d` (`__version__` follow-up), `2ac0ed7` (doc refresh) · kagenti-adk `79ad3d28`
+**Tag / release:** `sdk/v0.7.0` → `memoryhub==0.7.0` on PyPI
+
+## What We Set Out To Do
+
+The prior NEXT_SESSION listed "fix the SDK `max_results` forwarding bug" as a small, unfiled, ready-to-pick-up task. The expected work was a one-line SDK change plus an issue-file. Address #207–#209 if time permitted, watch PR #231 for review activity.
+
+## What Changed
+
+| Change | Type | Rationale |
+|---|---|---|
+| "Small SDK kwarg fix" → full SDK rework against the compacted tool surface | Missed requirement (in the prior session, not this one) | The `max_results` symptom was a misdiagnosis. The kwarg *is* forwarded; the SDK never reached the server because every per-action tool name (`search_memory`, `read_memory`, …) had been removed from the primary deployment. Confirmed in 5 minutes with a live MCP `list_tools` against the route. |
+| Server-side compat aliases scoped in #202 explicitly **not** added | Good pivot | Wes called the moment: the alias work was follow-on we'd flagged but skipped, and dragging it back in would multiply the surface to maintain. The right move was to take the SDK forward and close the gap. Decision recorded in `planning/sdk-compacted-tool-rework.md`. |
+| New issue #212 filed (server `search` over-returns appendix beyond `max_results`) | Scope deferral | Surfaced during smoke testing (N=3 → 81 results, N=10 → 85). Independent of the SDK rework, real bug, but not blocking the cutover. Filed and moved on. |
+| Three direct pushes to memory-hub `main` instead of folding into PR #211 | Process slip | The `__init__.py` version bump was missed in PR #211 itself; the doc-refresh commit (`2ac0ed7`) and version push (`c50872d`) followed. Wes considers direct push to `main` a judgment call, not banned; the real miss was not catching the `__init__.py` mismatch pre-merge when the release workflow's version-match check made the gap visible. |
+
+## What Went Well
+
+- **Diagnosis was fast.** The smoke-test (`fastmcp.Client(...).list_tools()` against the deployed route) made the real failure mode obvious within minutes of starting work, before any code was touched.
+- **Public API stability held.** Reworking 17 methods to dispatch through `memory(action=..., options={...})` was internal-only — kagenti-adk's `MemoryHubMemoryStoreInstance` did not need a single source change, just the dependency pin. Their 24 unit tests passed against 0.7.0 unchanged.
+- **Test rewrite leaned on a helper, not 25 ad-hoc rewrites.** Two helpers in `test_client.py` (`_payload`, `_tool_and_action`) flatten the new wire format back to a key-by-key dict so existing assertions kept working with minimal churn. Clean re-test: 150 passed, 8 integration skipped, ruff clean.
+- **Live E2E cycle done before merging.** Write → read → update → delete → re-delete-`NotFoundError` against the primary server confirmed the rework end-to-end before the merge button was clicked.
+- **Contract test landed alongside the cutover.** #208 had been languishing; landing it in the same PR meant the rework had a regression net the moment it merged.
+- **Incremental commits during implementation.** Three commits on the branch (rework, version bump, contract test) made the squash-merge readable in `git log`.
+
+## Gaps Identified
+
+| Gap | Severity | Resolution |
+|---|---|---|
+| The deprecation-alias step from #202 was scoped but never shipped — that's how the SDK was wholesale broken end-to-end against the primary deployment without anyone noticing | High (process) | Already closed by this session's rework. Pinned learning added to NEXT_SESSION: in any future tool consolidation, the alias layer ships *with* the consolidation, not after. |
+| The `max_results` misdiagnosis in the prior NEXT_SESSION carried forward into this session's plan untested | Medium (process) | New rule in the pinned learnings: test the leading hypothesis with a 5-minute live repro before planning around it. |
+| `__init__.py` version mismatch caught after PR #211 merged, not before | Low (one-off) | Already fixed via direct push (`c50872d`); the failure mode is recurring enough to warrant a PR-template checkbox — see action items. |
+| Trust signal with kagenti team | High (relational) | Not technical. We had told JanPokorny the SDK worked; PR #231 review #1 and #2 happened before we discovered our SDK never worked against the primary deployment. The unpause comment on PR #231 was honest about the cause. The fix shipped same-day. We carry this forward as a flag against the next "small follow-up we'll get to" — see Patterns. |
+| `[tool.uv] exclude-newer = "3 days"` policy on kagenti-adk means freshly-released SDK versions take 3 days to land in their lockfile naturally | Low (known) | Documented in the PR #231 unpause comment. Two paths offered to Jan; lock change deferred to him. |
+
+## Action Items
+
+- [x] PR #211 merged, `sdk/v0.7.0` tagged, `memoryhub==0.7.0` published.
+- [x] Contract test (#208) landed in same PR as the rework.
+- [x] kagenti-adk PR #231 pin bumped (commit `79ad3d28`); explanatory comment posted.
+- [x] Server-side `search`/`max_results` over-return filed as #212 in Backlog.
+- [x] `docs/SYSTEMS.md` sdk row refreshed for 0.7.0.
+- [x] `NEXT_SESSION.md` refreshed with this session's outcomes and pinned learnings.
+- [ ] **Add a PR-template checkbox** for "version is consistent across pyproject.toml + `__init__.py` + CHANGELOG entry exists" on memory-hub. Filing as a follow-up issue.
+- [ ] **Watch PR #231** for JanPokorny's next review pass. Be ready to either push the lock update (`UV_EXCLUDE_NEWER="0 days" uv lock --upgrade-package memoryhub`) on his ask, or wait through ~2026-05-02 for the natural window.
+- [ ] **Address #212** — server-side `max_results` over-return is bounded and concrete; good candidate for a focused next session.
+
+## Headline Finding
+
+> **We forgot to fix our own SDK after consolidating the server tool surface a few sessions ago, and that bit us at exactly the moment we were trying to build trust with the kagenti team.**
+
+The technical fix was contained and shipped same-day. The relational cost — having an external collaborator review a PR that integrated an SDK we hadn't validated against our own production server — is the part that matters. Two structural responses, both already in flight:
+
+1. The deprecation-alias step in any tool consolidation is now a hard gate, not a follow-up.
+2. The SDK contract test (#208) gives us an automated fail-loud whenever we make a change that would break kagenti-adk's surface.
+
+## Patterns
+
+**Start:**
+- Live smoke-test the SDK against the primary deployment after every server-side tool surface change. Unit tests do not catch this class of regression; they passed throughout the entire window the SDK was broken end-to-end.
+- Test the leading hypothesis from the prior session's NEXT_SESSION with a 5-minute live repro before letting it shape this session's plan.
+- File a PR-template checkbox covering version-consistency for SDK releases.
+
+**Stop:**
+- Treating "SDK update" as follow-on work that drifts. If we change the server's tool surface, the SDK update lands in the same release window, not "next session."
+- Trusting HTTP-200-on-the-route as a smoke test for an MCP server. It only proves the route is alive; nothing about whether any tool actually responds to a call.
+
+**Continue:**
+- Live E2E cycle (write → read → update → delete → re-delete-`NotFoundError`) before merging anything that touches the SDK transport layer.
+- Contract tests for known external consumers — adding the kagenti-adk one was straightforward and is the right shape (mocked transport, fail-loud on rename/relocation, no live server dependency).
+- Incremental commits on the branch (design doc → rework → version bump → contract test) so the squash-merge is readable.
+- Honest, full-detail comments on downstream PRs when we've caused a problem (see PR #231 unpause comment).


### PR DESCRIPTION
## Summary
Retrospective for the SDK 0.7.0 cutover and the kagenti-adk PR #231 unblock. Captures the headline finding that the deprecation-alias step from #202 was scoped but never shipped, and surfaces two structural responses already in flight: (1) future tool consolidations land their alias layer in the same release, not as follow-up; (2) the SDK contract test from #208 is the automated fail-loud against this class of regression.

## Test plan
- [x] No code changes — retro doc only.
- [x] PR-template version-consistency follow-up filed as #213.