### PR TITLE
search: Cap max_results after compiled-prefix backfill (#212)

### DIFF
--- a/NEXT_SESSION.md
+++ b/NEXT_SESSION.md
@@ -25,19 +25,29 @@
 - Ruff clean across all surfaces.
 - gitleaks: 392 commits scanned, no leaks.
 
+## Strategic frame
+
+The active milestone is **#176 — First 3 real users actively consuming MemoryHub**. Kagenti-adk is user 1. Every priority below should be evaluated against "does this move us toward an actual user finding MemoryHub useful?" If a candidate item doesn't answer that, it's a backlog item, not a next-session item.
+
 ## Priority items for next session
 
 ### 1. Server-side `max_results` over-return on search (#212)
-Concrete and bounded. Reproduce against the deployed primary, decide whether `max_results` should cap the compiled block, the appendix, or both, and ship a fix. Update the dispatcher docstring to match shipped semantics. Useful agent ergonomics issue — agents asking for 5 memories should not get 80+.
+Concrete and bounded. Reproduce against the deployed primary, decide whether `max_results` should cap the compiled block, the appendix, or both, and ship a fix. Update the dispatcher docstring to match shipped semantics. Direct kagenti-relevance: agents asking for 5 memories should not get 80+.
 
-### 2. Watch for / respond to JanPokorny's review pass on PR #231
-He may approve, request the lock update inline, or wait the 3-day window and re-test. Be ready to push the lock update commit if he chooses option 2 from my comment. Branch: `feat/memory-store-protocol` in `~/Developer/adk-fork`. Latest commit: `79ad3d28`.
+### 2. Cleanup strategy for kagenti-ci E2E test memories (#207)
+Locks down the kagenti-adk integration as a clean, repeatable test target — the single best structural defense against another "we shipped a buggy SDK to kagenti" episode. Planning doc has options + recommendation; pick one and ship. Higher leverage than #209.
 
-### 3. Address #207, #209 when ready
-Carried over — neither blocks anything. #207 (kagenti-tests scope-down + cleanup) and #209 (cluster URL stability) both have planning docs and recommendations. Pick up when the schedule is open.
+### 3. PR-template version-consistency checkbox (#213)
+Small, structural, ~30 min. Prevents recurrence of the exact `__init__.py` mismatch that drove the third direct-push to `main` this last session. Cheap to land alongside the bigger work above.
 
-### 4. Verify carry-over items still relevant
-- **Granite agent gateway demo**: confirm the demo is still wired correctly against the granite stack in `memoryhub-granite` namespace.
+## Watch list (passive — no work unless triggered)
+
+- **PR kagenti/adk#231** — JanPokorny may approve, request the lock update inline, or wait the 3-day `exclude-newer` window. If he asks for the lock update, push it via `UV_EXCLUDE_NEWER="0 days" uv lock --upgrade-package memoryhub`. Branch: `feat/memory-store-protocol` in `~/Developer/adk-fork`. Latest commit: `79ad3d28`.
+- **#209 (cluster URL stability for kagenti-adk E2E)** — recommendation in the planning doc is "document and accept rotations." Pick up when an actual rotation hurts; not worth a session slot on its own.
+
+## Carry-over to verify when convenient
+
+- **Granite agent gateway demo**: confirm wired correctly against the granite stack in `memoryhub-granite` namespace.
 - **Compact profile for Claude Code**: still no compact-profile references in `.claude/rules/`.
 
 ## Process / retro flags

--- a/memory-hub-mcp/src/tools/search_memory.py
+++ b/memory-hub-mcp/src/tools/search_memory.py
@@ -892,6 +892,25 @@ async def search_memory(
                 for item, score, is_app in compilation_meta["ordered_results"]
                 if str(item.id) not in branch_ids
             ]
+            # #212: cap to max_results. _backfill_compiled_entries inflates the
+            # set with every compiled epoch ID, and the format loop below has
+            # no inherent page bound — without this clamp the response can
+            # carry the entire cache-stable prefix regardless of caller intent.
+            # Compiled entries lead the order, so the cache-stable prefix is
+            # preserved up to max_results before any appendix fills the tail.
+            ordered = compilation_meta["ordered_results"]
+            if len(ordered) > max_results:
+                kept_ids = {str(item.id) for item, _, _ in ordered[:max_results]}
+                appendix_kept = sum(
+                    1 for _, _, is_app in ordered[:max_results] if is_app
+                )
+                compilation_meta["ordered_results"] = ordered[:max_results]
+                compilation_meta["appendix_count"] = appendix_kept
+                # Drop nested branches whose parent was clipped, so they
+                # don't become orphaned top-level entries.
+                nested_by_parent = {
+                    pid: bs for pid, bs in nested_by_parent.items() if pid in kept_ids
+                }
 
         # Token-budget packing. Walk results in order; full-form entries
         # that exceed the remaining budget (and everything after them)

--- a/memory-hub-mcp/tests/tools/test_search_memory.py
+++ b/memory-hub-mcp/tests/tools/test_search_memory.py
@@ -294,6 +294,169 @@ async def test_search_memory_has_more_false_when_page_holds_all():
 
 
 @pytest.mark.asyncio
+async def test_search_memory_caps_response_to_max_results_when_backfill_inflates():
+    """Regression for #212: cache-optimized backfill must not over-return.
+
+    `_backfill_compiled_entries` loads every missing compiled epoch ID into
+    the result set so the cache-stable prefix is preserved. Without a final
+    clamp, an epoch with N compiled entries returns all N regardless of the
+    caller's `max_results`. This test fakes a 30-entry backfill against a
+    `max_results=5` request and asserts the response is capped at 5 with
+    `has_more=True`. Compiled entries lead the order, so all 5 returned
+    items must be non-appendix (the cache-stable prefix wins the budget).
+    """
+    similarity_hits = [_fake_full_result(f"hit-{i}", score=0.9 - i * 0.01) for i in range(3)]
+    inflated = similarity_hits + [
+        _fake_full_result(f"compiled-{i}", score=0.0) for i in range(30)
+    ]
+
+    mock_session = AsyncMock()
+    mock_gen = AsyncMock()
+    fake_embedding_service = AsyncMock()
+
+    auth_mod._current_session = {
+        "user_id": "wjackson",
+        "scopes": ["user"],
+        "identity_type": "user",
+    }
+    try:
+        with (
+            patch(
+                "src.tools.search_memory.get_db_session",
+                return_value=(mock_session, mock_gen),
+            ),
+            patch("src.tools.search_memory.release_db_session", new_callable=AsyncMock),
+            patch(
+                "src.tools.search_memory.get_embedding_service",
+                return_value=fake_embedding_service,
+            ),
+            patch(
+                "src.tools.search_memory.search_memories",
+                new_callable=AsyncMock,
+                return_value=similarity_hits,
+            ),
+            patch(
+                "src.tools.search_memory.count_search_matches",
+                new_callable=AsyncMock,
+                return_value=33,
+            ),
+            patch(
+                "src.tools.search_memory._backfill_compiled_entries",
+                new_callable=AsyncMock,
+                return_value=inflated,
+            ),
+            patch(
+                "src.tools.search_memory._apply_cache_optimized_ordering",
+                new_callable=AsyncMock,
+                return_value={
+                    "ordered_results": [(item, score, False) for item, score in inflated],
+                    "compilation_hash": "deadbeef",
+                    "compilation_epoch": 1,
+                    "appendix_count": 0,
+                },
+            ),
+            patch(
+                "src.tools.search_memory.ROLE_ISOLATION_ENABLED",
+                False,
+            ),
+            patch(
+                "src.tools.search_memory.PROJECT_ISOLATION_ENABLED",
+                False,
+            ),
+        ):
+            result = await search_memory(query="memory", max_results=5)
+    finally:
+        auth_mod._current_session = None
+
+    assert len(result["results"]) == 5
+    assert result["total_matching"] == 33
+    assert result["has_more"] is True
+    assert result["appendix_count"] == 0
+    assert all(not entry["is_appendix"] for entry in result["results"])
+
+
+@pytest.mark.asyncio
+async def test_search_memory_cap_preserves_appendix_in_remaining_budget():
+    """#212: when compiled prefix is shorter than max_results, appendix fills the tail.
+
+    Compiled entries lead, then appendix entries fill the rest of the budget
+    up to `max_results`. The reported `appendix_count` reflects only the
+    appendix entries that survived the cap, not the pre-cap total.
+    """
+    compiled = [_fake_full_result(f"compiled-{i}", score=0.0) for i in range(3)]
+    appendix = [_fake_full_result(f"appendix-{i}", score=0.0) for i in range(10)]
+    ordered = (
+        [(item, score, False) for item, score in compiled]
+        + [(item, score, True) for item, score in appendix]
+    )
+
+    mock_session = AsyncMock()
+    mock_gen = AsyncMock()
+    fake_embedding_service = AsyncMock()
+
+    auth_mod._current_session = {
+        "user_id": "wjackson",
+        "scopes": ["user"],
+        "identity_type": "user",
+    }
+    try:
+        with (
+            patch(
+                "src.tools.search_memory.get_db_session",
+                return_value=(mock_session, mock_gen),
+            ),
+            patch("src.tools.search_memory.release_db_session", new_callable=AsyncMock),
+            patch(
+                "src.tools.search_memory.get_embedding_service",
+                return_value=fake_embedding_service,
+            ),
+            patch(
+                "src.tools.search_memory.search_memories",
+                new_callable=AsyncMock,
+                return_value=compiled + appendix,
+            ),
+            patch(
+                "src.tools.search_memory.count_search_matches",
+                new_callable=AsyncMock,
+                return_value=13,
+            ),
+            patch(
+                "src.tools.search_memory._backfill_compiled_entries",
+                new_callable=AsyncMock,
+                return_value=compiled + appendix,
+            ),
+            patch(
+                "src.tools.search_memory._apply_cache_optimized_ordering",
+                new_callable=AsyncMock,
+                return_value={
+                    "ordered_results": ordered,
+                    "compilation_hash": "deadbeef",
+                    "compilation_epoch": 1,
+                    "appendix_count": 10,
+                },
+            ),
+            patch(
+                "src.tools.search_memory.ROLE_ISOLATION_ENABLED",
+                False,
+            ),
+            patch(
+                "src.tools.search_memory.PROJECT_ISOLATION_ENABLED",
+                False,
+            ),
+        ):
+            result = await search_memory(query="memory", max_results=5)
+    finally:
+        auth_mod._current_session = None
+
+    assert len(result["results"]) == 5
+    # First three are compiled (cache-stable prefix), last two are appendix.
+    is_appendix_flags = [entry["is_appendix"] for entry in result["results"]]
+    assert is_appendix_flags == [False, False, False, True, True]
+    assert result["appendix_count"] == 2
+    assert result["has_more"] is True
+
+
+@pytest.mark.asyncio
 async def test_search_memory_empty_returns_zero_total():
     """Empty results must still emit total_matching and has_more=False."""
     mock_session = AsyncMock()


### PR DESCRIPTION
## Summary

Fixes #212 — `search` over-returned far past `max_results` when an
established compilation epoch existed for the caller.

### What was actually broken
`_backfill_compiled_entries` (search_memory.py) loads every compiled
epoch ID missing from the similarity hits so the cache-stable prefix is
preserved across queries. The cache-optimized assembly then orders
compiled-then-appendix, and the format loop iterates that result with
no page bound — so a search against an established epoch returns the
entire prefix regardless of the caller's `max_results`.

Live reproduction against `memory-hub-mcp` (primary deployment) before
the fix: `search(max_results=8)` returned **82** results (81 compiled +
1 appendix). Issue #212's original hypothesis pinned the appendix; the
actual inflation is the compiled backfill.

### Fix
Cap `compilation_meta["ordered_results"]` to `max_results` after the
branch filter, before the format loop. Compiled entries lead the order,
so the cache-stable prefix wins the budget and any appendix entries
fill the remainder — preserving #175's cache-stability guarantee for
callers who pass a consistent `max_results`. Also recomputes
`appendix_count` from the kept slice and drops nested branches whose
parent was clipped so they don't become orphaned top-level entries.

### Design choice (option A from the diagnosis)
Strict cap, single budget. Caller asks for N, gets at most N. The
alternative — separate budgets for compiled vs appendix — was a bigger
surface change and not what callers (kagenti-adk) actually expect. We
can revisit if a real use case shows up.

## Test plan
- [x] New regression: `test_search_memory_caps_response_to_max_results_when_backfill_inflates`
      simulates a 30-entry backfill, asserts cap=5, all returned items
      non-appendix (cache-stable prefix wins the budget).
- [x] New regression: `test_search_memory_cap_preserves_appendix_in_remaining_budget`
      asserts compiled-first-then-appendix slicing and recomputed
      `appendix_count` (3 compiled + 10 appendix → 5 returned, last 2
      are appendix, `appendix_count=2`).
- [x] Full search suite: 40/40 pass (38 prior + 2 new)
- [x] Ruff clean on changed files
- [ ] Live re-verify against deployed primary post-merge: rerun the
      `search("test", max_results=N)` reproduction and confirm
      `len(results) <= N` for N ∈ {3, 5, 10}.

## Out of scope
- Drift in the manage_graph test suite (7 pre-existing failures on
  `chore/next-session-reorder`, unrelated to search). Tracked
  separately.