### PR TITLE
docs+ui: Fix doc paths after docs/admin/ move

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ research/agent-memory-benchmarks/
 
 # Local DB backups (created by scripts/backup-db.sh)
 backups/
+
+medium_article_1.pdf
+

--- a/docs/admin/inviting-new-contributors.md
+++ b/docs/admin/inviting-new-contributors.md
@@ -4,7 +4,7 @@ This document is for the project maintainer (currently `@rdwj`). It is the check
 
 The goal is to make the invitation process mechanical enough that you do not have to remember what the steps are, but thorough enough that the new person lands in a working state with the context they need.
 
-If you are the new contributor and somebody just pointed you at this document by mistake, you want [`CONTRIBUTING.md`](../CONTRIBUTING.md) instead.
+If you are the new contributor and somebody just pointed you at this document by mistake, you want [`CONTRIBUTING.md`](../../CONTRIBUTING.md) instead.
 
 ## When to use this document
 
@@ -26,7 +26,7 @@ Confirm all of the following are true before you send anybody an invite:
 3. **`CODEOWNERS` is current.** `.github/CODEOWNERS` should list `@rdwj` and whichever Red Hat colleagues have agreed to act as code owners. Adding a new contributor as a code owner is a separate step and requires their explicit agreement — do not do it at invite time.
 4. **PR and issue templates exist.** Verify `.github/pull_request_template.md` and `.github/ISSUE_TEMPLATE/*.yml` are present (commit `3b4b1d8`). These are what set expectations on the contributor's first PR and first issue without you having to re-explain the conventions.
 5. **Backlog has starter work.** Run `gh issue list --label "good first issue"` and confirm at least three open issues exist. If the backlog is empty, triage before sending invitations — an empty starter pile makes the invite feel performative.
-6. **The cluster access policy doc is current.** [`docs/contributor-cluster-access.md`](contributor-cluster-access.md) needs to exist and the cluster route identifiers in it need to match the current sandbox rebuild. New contributors do not get cluster access at first, and the doc explains the policy.
+6. **The cluster access policy doc is current.** [`docs/admin/contributor-cluster-access.md`](contributor-cluster-access.md) needs to exist and the cluster route identifiers in it need to match the current sandbox rebuild. New contributors do not get cluster access at first, and the doc explains the policy.
 
 If any of the above is missing, fix it before inviting.
 
@@ -73,7 +73,7 @@ Compose a message with the following pieces, in this order:
 
 1. **Welcome and context.** Two sentences: what MemoryHub is, why you invited them. Do not link the architecture doc here — that comes later.
 2. **Link to `CONTRIBUTING.md`.** This is the single most important link. It has the repo layout, the per-subproject venv setup, the commit-message format, and the PR flow. Every other doc is optional; this one is not.
-3. **Link to `docs/contributor-cluster-access.md`.** Call out specifically that new contributors default to no cluster access and that this is deliberate policy, not a slight.
+3. **Link to `docs/admin/contributor-cluster-access.md`.** Call out specifically that new contributors default to no cluster access and that this is deliberate policy, not a slight.
 4. **A specific starter issue.** Not "look at the good-first-issue label" — a specific issue number. Pick one that matches their stated interests from step 1, read the issue yourself to confirm it is still a good fit, and link it. Include one line of context on why you picked it.
 5. **How to contact you.** Slack, email, whatever the fastest channel is. Set expectations: "I review PRs within a business day; ping me if I go quiet."
 6. **What their first PR should look like.** One sentence: "Your first PR should close the starter issue above. Keep the diff focused on that one issue and follow the PR template."
@@ -89,7 +89,7 @@ Example template:
 >
 > Start here: [`CONTRIBUTING.md`](https://github.com/redhat-ai-americas/memory-hub/blob/main/CONTRIBUTING.md). It has the per-subproject venv setup, the commit-message format, and the PR flow. Everything else is optional.
 >
-> One thing to know up front: new contributors default to no OpenShift cluster access. The policy is in [`docs/contributor-cluster-access.md`](https://github.com/redhat-ai-americas/memory-hub/blob/main/docs/contributor-cluster-access.md). Almost nothing in the repo actually needs the cluster — local dev is enough.
+> One thing to know up front: new contributors default to no OpenShift cluster access. The policy is in [`docs/admin/contributor-cluster-access.md`](https://github.com/redhat-ai-americas/memory-hub/blob/main/docs/admin/contributor-cluster-access.md). Almost nothing in the repo actually needs the cluster — local dev is enough.
 >
 > Your starter issue: [#<NNN>](https://github.com/redhat-ai-americas/memory-hub/issues/<NNN>). I picked it because it matches the <auth / curator / UI / storage> interest you mentioned, is tightly scoped, and has a clear acceptance criterion. Keep your first PR focused on closing just that issue.
 >
@@ -139,7 +139,7 @@ When a contributor leaves the project (finished their tour, moved to a different
 
 1. Remove them from the `redhat-ai-americas` org via https://github.com/orgs/redhat-ai-americas/people
 2. If they were added as a direct collaborator on the repo, also remove them from `gh api repos/redhat-ai-americas/memory-hub/collaborators`
-3. If they had a `memoryhub-auth` client credential, rotate it (see [`docs/contributor-cluster-access.md`](contributor-cluster-access.md#rotation)) and remove them from the `memoryhub-users` ConfigMap
+3. If they had a `memoryhub-auth` client credential, rotate it (see [`docs/admin/contributor-cluster-access.md`](contributor-cluster-access.md#rotation)) and remove them from the `memoryhub-users` ConfigMap
 4. If they were listed in `.github/CODEOWNERS`, remove them in a separate commit
 5. If they had cluster-level role bindings, delete those: `oc delete rolebinding <name> -n <namespace>`
 6. Do **not** delete their past commits, close their open PRs without explanation, or rewrite git history. Their contributions stay in the log under their authorship.
@@ -154,13 +154,13 @@ A few failure modes and their fixes:
 - **Contributor accepts but never opens a PR.** See the 7/14/30-day check-in schedule above. Do not nag beyond day 30.
 - **Contributor opens a PR but it is massively out of scope** (e.g., a sweeping refactor instead of the specific starter issue). Close or convert to a draft with a kind explanation: *"This is much bigger than #NNN — can we split it? Let's start with the specific thing in #NNN and file follow-up issues for the rest."*
 - **Contributor pushes directly to `main` by accident.** This should be blocked by branch protection, but if it somehow gets through (admin override, compromised account), revert the direct push, explain the protection policy, and point them at the PR flow.
-- **Contributor's first PR is excellent but has AI attribution in the commits** (Co-authored-by, Signed-off-by: Claude Code). Comment on the PR asking them to amend with `Assisted-by:` instead (see [`CLAUDE.md`](../CLAUDE.md)). Do not merge with non-conforming trailers — future contributors will copy the pattern.
-- **Contributor asks for cluster access before shipping any PRs.** Say no, and point them at `docs/contributor-cluster-access.md`. The policy exists precisely for this case.
+- **Contributor's first PR is excellent but has AI attribution in the commits** (Co-authored-by, Signed-off-by: Claude Code). Comment on the PR asking them to amend with `Assisted-by:` instead (see [`CLAUDE.md`](../../CLAUDE.md)). Do not merge with non-conforming trailers — future contributors will copy the pattern.
+- **Contributor asks for cluster access before shipping any PRs.** Say no, and point them at `docs/admin/contributor-cluster-access.md`. The policy exists precisely for this case.
 
 ## Related documents
 
-- [`CONTRIBUTING.md`](../CONTRIBUTING.md) — the doc you send new contributors to; local setup, PR flow, coding conventions
-- [`docs/contributor-cluster-access.md`](contributor-cluster-access.md) — the cluster access policy and the GitHub IdP reference
-- [`CLAUDE.md`](../CLAUDE.md) — agent-facing conventions that overlap with the human-facing `CONTRIBUTING.md`
-- [`.github/CODEOWNERS`](../.github/CODEOWNERS) — who reviews what
-- [`.github/pull_request_template.md`](../.github/pull_request_template.md) — what new contributors see when they open a PR
+- [`CONTRIBUTING.md`](../../CONTRIBUTING.md) — the doc you send new contributors to; local setup, PR flow, coding conventions
+- [`docs/admin/contributor-cluster-access.md`](contributor-cluster-access.md) — the cluster access policy and the GitHub IdP reference
+- [`CLAUDE.md`](../../CLAUDE.md) — agent-facing conventions that overlap with the human-facing `CONTRIBUTING.md`
+- [`.github/CODEOWNERS`](../../.github/CODEOWNERS) — who reviews what
+- [`.github/pull_request_template.md`](../../.github/pull_request_template.md) — what new contributors see when they open a PR

--- a/memoryhub-ui/frontend/src/components/welcomeEmail.ts
+++ b/memoryhub-ui/frontend/src/components/welcomeEmail.ts
@@ -34,7 +34,7 @@ export interface WelcomeEmailParams {
 
 const DOCS_URL = 'https://github.com/redhat-ai-americas/memory-hub';
 const CONTRIBUTING_URL = 'https://github.com/redhat-ai-americas/memory-hub/blob/main/CONTRIBUTING.md';
-const CLUSTER_ACCESS_DOC = 'https://github.com/redhat-ai-americas/memory-hub/blob/main/docs/contributor-cluster-access.md';
+const CLUSTER_ACCESS_DOC = 'https://github.com/redhat-ai-americas/memory-hub/blob/main/docs/admin/contributor-cluster-access.md';
 
 const SECRET_PLACEHOLDER = '<ask the maintainer — rotate via the dashboard>';
 

--- a/research/oracle-comparison.md
+++ b/research/oracle-comparison.md
@@ -1,0 +1,225 @@
+# Oracle AI Agent Memory: Competitive and Architectural Comparison with MemoryHub
+
+**Date**: 2026-05-06
+**Status**: Research analysis
+**Context**: Oracle AI Agent Memory (published as `oracleagentmemory` on [PyPI](https://pypi.org/project/oracleagentmemory/), documented in the [Oracle Help Center](https://docs.oracle.com/en/database/oracle/agent-memory/26.4/)) was announced in [a May 2026 Oracle Developers blog post](https://blogs.oracle.com/developers/oracle-ai-agent-memory-a-governed-unified-memory-core-for-enterprise-ai-agents) by Richmond Alake. It is positioned as a "governed, unified memory core for enterprise AI agents" running on Oracle AI Database. This analysis informs the v3 follow-up blog post on memory taxonomy and the arXiv survey paper, and supplements the v2 platform-memory blog now published on Medium.
+
+---
+
+## 1. Executive Summary
+
+Oracle AI Agent Memory is the cleanest single-paragraph statement of the "unified substrate, multiple access patterns" thesis we have yet seen, and it is shipped by a database vendor large enough to make the framing stick in enterprise procurement conversations. The architectural claim is exactly the one MemoryHub also makes: working, semantic, episodic, and procedural memory are not four services, they are four access patterns over one governed store. They publish a credible LongMemEval result (93.8% / 469 of 500, with 88% on the hardest multi-session category), token-efficiency curves on an 80-turn scripted conversation (≈9.5× lower per-request input than a flat-history baseline), and a head-to-head win rate over flat history (48–13 with 19 ties, judged by GPT-5.4). The architectural thesis is right and we should adopt it explicitly. The implementation choice (Oracle AI Database as the only substrate) is the wrong answer for the platform-tier ecosystem we are arguing for. Oracle is selling "one vendor relationship for production agent memory"; we are selling "memory follows the protocol, not the platform." Both can be true, and Oracle's existence strengthens our v2 thesis that platform memory is now a category rather than a feature. The sharpest divergence is taxonomic: Oracle organizes memory by access pattern (cognitive-science 4-type), MemoryHub organizes it by governance dimension (scope + branch). These are orthogonal cuts and both are useful, but the choice of which one is *primary* in your data model determines what enterprise governance you can express cheaply.
+
+## 2. Background: Who Built This and Why
+
+Oracle AI Agent Memory is shipped by Oracle's database organization, with Richmond Alake (Oracle Developer Relations, previously known for MongoDB AI content) authoring the launch post. The release is accompanied by quotes from Tirthankar Lahiri (SVP, Mission-Critical Data and AI Engines, Oracle Database) framing it as part of Oracle's converged-database strategy, and from Chris Latimer (Co-Founder & CEO of Vectorize) endorsing Oracle AI Database as a Hindsight backend. The supporting materials include framework integration notebooks for [LangGraph, Claude Agent SDK, OpenAI Agents SDK, WayFlow, and custom Python harnesses](https://github.com/oracle-devrel/oracle-ai-developer-hub/tree/main/notebooks/agent_memory).
+
+This is not a research artifact. It is a productized commercial offering shipped under Oracle's enterprise-data go-to-market. The same-namespace strategy is unmistakable: every existing Oracle Database customer is a target, and the value proposition leads with "one set of credentials, one compliance review, one backup story." The blog post explicitly positions Oracle AI Agent Memory as "the first release of a broader commitment to a governed memory substrate enterprise agents."
+
+## 3. Architecture Overview
+
+### 3.1 The Four-Type Taxonomy
+
+The defining conceptual choice is the cognitive-science 4-type taxonomy:
+
+| Type | Definition (verbatim) | Examples |
+|------|------------------------|----------|
+| Working | "active state the agent is reasoning over right now, the running conversation and the scratchpad the model sees at inference time" | current conversation, in-flight task state |
+| Semantic | "durable facts and knowledge the agent accumulates about users, entities, and the world" | preferences, canonical definitions, structured reference data |
+| Episodic | "specific past experiences the agent can recall" | prior session, what user asked weeks ago, how a similar task resolved |
+| Procedural | "behavioral rules, guidelines, and learned procedures" | how to handle customers, which tools to prefer, what not to do |
+
+The taxonomy itself is not novel. LangMem ships three of the four (semantic / episodic / procedural; LangMem omits working), MAGMA's multi-graph proposal uses the same three, and the cognitive-science roots go back decades. What is novel is Oracle's explicit framing: *"These are not four different systems. They are four access patterns over the same underlying state, which is what makes a unified memory core the right architectural answer rather than four bolted-together services."* That sentence is the most quotable single articulation of the unified-substrate thesis to date.
+
+### 3.2 Oracle AI Database as the Substrate
+
+Oracle's bet is that Oracle AI Database, combining vector similarity search, relational querying, graph-aware data access, and JSON document storage in one engine, is a sufficient substrate for all four memory types. The substrate provides:
+
+- Vector search (HNSW indexes referenced in the LongMemEval configuration)
+- Relational state for thread, message, and memory records with user/agent/thread/timestamp scoping
+- Graph-aware traversal (presumably property-graph queries against the same data)
+- JSON storage for flexible metadata
+- Operational primitives: backups, replication, high availability, encryption, fine-grained access control, native auditing
+
+The reference architecture diagram shows a clean two-layer separation: customer-owned application tier (the agent) talks to an Oracle-owned `oracleagentmemory` SDK, which talks to Oracle AI Database. Tenant isolation and governance are SDK + database concerns, not application concerns.
+
+### 3.3 Threads, Messages, and Memories
+
+The published API surface (illustrative, the final API is in the Help Center docs) shows three top-level concepts:
+
+```python
+memory = AgentMemory.from_connection(connection_string="...", user_id="user_123")
+thread_id = memory.create_thread(user_id="user_123")
+memory.add_messages(thread_id, messages=[...])
+memory.extract_memories(thread_id)
+results = memory.search(user_id="user_123", query="...", limit=5)
+```
+
+A **thread** is a conversation primitive owned by the SDK. **Messages** are appended to threads. **Memories** are extracted from threads (automatically, via LLM) and stored as durable records. The `search` operation returns memories scoped per-user. This is essentially the same shape as Letta's archival memory + recall memory model and Mem0's conversation-extraction pipeline.
+
+What is interesting from MemoryHub's perspective: the thread / conversation primitive is *inside* the Oracle store. We deliberately moved conversation persistence out of MemoryHub and into kagenti / OGX / LlamaStack as a separate platform capability. Oracle has chosen the opposite: thread management, message storage, and memory extraction live in the same governed store.
+
+### 3.4 Working Memory in the Governed Store
+
+The four-type taxonomy includes working memory ("active state the agent is reasoning over right now, the running conversation and the scratchpad"). Oracle's implementation appears to handle this through:
+
+- Periodic thread summarization (compacts older messages into a summary)
+- "Context cards" (LLM-extracted prompt-time context blocks from the durable store)
+- Prompt-time message compaction (the SDK chooses what messages to send to the LLM)
+
+The token-efficiency numbers (1,300 tokens flat vs. 13,900 baseline at turn 80) are achieved by the SDK actively managing what enters the model's context window. So in practice "working memory" in Oracle's system is a *managed view* over the durable conversation store, not an in-memory ephemeral cache.
+
+This is a defensible design but it conflates two things MemoryHub keeps separate. The harness's working set (KV cache, current turn buffer, tool-call scratch) is genuinely ephemeral and should not be subject to the audit / encryption / cross-scope governance overhead of durable memory. Oracle puts everything on the same substrate; we argue some things shouldn't be there.
+
+### 3.5 Automatic LLM-Based Memory Extraction
+
+Oracle ships an `extract_memories(thread_id)` primitive that uses an LLM to turn conversation turns into durable memory records without a hand-rolled extraction prompt. This is the same approach Mem0, Letta, and OpenViking take. The blog calls this "automatic LLM-based extraction" and pitches it as eliminating "hand-written extraction logic the team can maintain."
+
+There is no published detail on the extraction policy: what triggers extraction, what the LLM is instructed to look for, how dedup against existing memories is handled, or how the system handles contradictions. The PyPI package and Help Center docs presumably contain the answers.
+
+### 3.6 Multi-Tenant Isolation
+
+The blog references "tenant isolation enforced at the store layer" and "per-record scoping fields (user, agent, thread, timestamp)." From the API shape, isolation appears to be predicate-based row filtering by `user_id` rather than a separate tenant boundary. This is similar to Mem0's approach. There is no explicit account-or-organization boundary above user_id described in the announcement materials.
+
+### 3.7 LongMemEval Results
+
+| Category | Score |
+|----------|-------|
+| Overall | 93.8% (469/500) |
+| Single-session assistant | 100% |
+| Temporal reasoning | 96.2% |
+| Knowledge update | 94.9% |
+| Single-session user | 94.3% |
+| Single-session preference | 93.3% |
+| Multi-session | 88.0% |
+
+Configuration: GPT-5.5 (reasoning effort xhigh), nomic-embed-text-v1.5 embeddings, local HNSW index, top-K = 200. The multi-session score (88%) is the most informative; multi-session recall is the category that hardest-tests durable cross-session memory, and 88% is competitive with Zep's published Graphiti numbers.
+
+### 3.8 Token-Efficiency and Win-Rate Numbers
+
+On an 80-turn scripted conversation (ChromAtlas-ND benchmark, GPT-5.4 raw OpenAI client):
+
+- Per-request input held flat at ≈1,300 tokens with Oracle AI Agent Memory; flat-history baseline grew to ≈13,900 tokens at turn 80 (≈9.5× reduction).
+- GPT-5.4 judge scoring on accuracy, completeness, relevance, coherence: Oracle won 48 turns, flat-history won 13, 19 ties (3.7× wins despite the baseline's full-context information advantage).
+- Threshold sweep (8-query demo, 5 runs per threshold): 10k-token summarization trigger landed at mean 121,268 total tokens vs. 306,823 baseline (≈60% reduction); thresholds in the 50–70k range approach or exceed the baseline.
+
+These are concrete, quotable, and credibly produced numbers. The flat-history baseline is the right comparator (it represents the strongest information advantage a non-managed agent can have), and the win-rate result against that baseline is the strongest evidence that *retrieved focus beats retained noise* at this conversation length.
+
+### 3.9 Audit and Erasure
+
+The blog explicitly addresses GDPR-style requirements: every record carries user/agent/thread/timestamp scoping, the SDK exposes search/list/delete operations across memories/threads/messages, and Oracle Database's native auditing covers the storage layer. This is a more concrete erasure story than most memory startups have shipped.
+
+## 4. Where They Validate Our Approach
+
+Several core design decisions appear independently in both systems:
+
+**Unified substrate, multiple access patterns.** Oracle's "four access patterns over the same underlying state" is structurally identical to MemoryHub's "one typed-graph store, multiple scopes and branch types." Both systems explicitly reject the patchwork (vector store + chat log + extraction script + isolation logic) that most production agents inherit. Two independent teams converging on this framing is strong validation.
+
+**Memory typing beyond vector blob.** Oracle's four types map roughly to OpenViking's eight memory subcategories and MemoryHub's branch-typed nodes. Three independent teams have concluded that a flat "embedded record" model is ergonomically painful for retrieval. Typing matters.
+
+**Automatic extraction is required, not optional.** The agreement that hand-written extraction is a liability rather than an asset is now near-universal in the memory category (Mem0, Letta, OpenViking, and now Oracle).
+
+**Multi-tenant isolation is a substrate-level concern.** Oracle enforces tenancy at the store layer; OpenViking does the same with account / user / agent boundaries; MemoryHub does the same with scope + RBAC. All three reject application-layer-only isolation as inadequate for governed deployments.
+
+**Audit and erasure as first-class.** Oracle puts audit/retention/access on the database layer rather than building it in the SDK. MemoryHub puts audit/RBAC at the SQL layer (PostgreSQL row-level security and explicit grants) rather than only in the application. Both teams arrived at the same defense-in-depth answer.
+
+**Cost is a tunable knob.** Oracle's threshold sweep makes the cost-fidelity trade-off explicit and configurable; MemoryHub's compaction / compilation policy is similarly user-controlled. Both reject the "accept whatever curve a fragmented stack produces" posture.
+
+## 5. Where We Diverge
+
+**Substrate lock-in vs. substrate portability.** Oracle's value proposition leads with "one vendor relationship for production agent memory." That works for organizations already running Oracle AI Database; it is a hard sell for everyone else, and it is explicitly the lock-in posture our v2 blog argues against. MemoryHub's reference deployment uses PostgreSQL + pgvector specifically because both ship with OpenShift OOTB and because the architecture should not be coupled to a vendor's flagship product.
+
+**Cognitive-science taxonomy vs. governance taxonomy.** Oracle organizes memory by *access pattern* (working / semantic / episodic / procedural). MemoryHub organizes it by *governance dimension* (scope: user / project / role / organizational / enterprise / campaign) crossed with *epistemic role* (branch type: rationale / provenance). These are orthogonal cuts, but the choice of which is primary in the data model determines what enterprise governance you can express cheaply. Knowing a memory is "episodic" tells you nothing about who can read it; knowing it is "project-scoped at memory:read:project" tells you exactly that. The 4-type taxonomy is useful for retrieval ergonomics; the scope-and-branch taxonomy is necessary for multi-scope enforcement with omission transparency.
+
+**Working memory in the governed store vs. harness-owned working memory.** Oracle pulls thread / message / scratchpad state into the same audit/encryption/replication pipeline as durable memory. MemoryHub deliberately leaves working memory to the harness (and to peer platform services like kagenti / OGX / LlamaStack for conversation persistence and resume). The harness owns context-window management; the platform owns durable governed knowledge. This is the same harness-vs-platform line drawn in the v2 blog post, applied at the working-vs-durable seam.
+
+**Conversation persistence as memory primitive vs. separate platform primitive.** Oracle's `create_thread` / `add_messages` / `extract_memories` makes conversation persistence an integral part of the memory SDK. MemoryHub's scope decision was the opposite: conversation thread persistence was scoped out and is now expected to live in kagenti / OGX / LlamaStack. The right answer here is not obvious. Oracle's coupling buys ergonomic simplicity; our split buys clean separation between conversation-shaped state (which different harnesses model differently) and durable-fact state (which is harness-agnostic). Worth re-examining as the v3 follow-up blog frames the platform-component split.
+
+**Cross-scope read with omission transparency vs. per-user isolation.** Oracle's announcement materials describe per-user / per-agent / per-thread scoping but do not describe a model for "Agent A in Project X reads from organizational scope while authorized to write only to project scope." MemoryHub's six-scope model with authorization-aware search and `omitted_count` is structurally different: cross-scope reading is the norm, and omissions are visible.
+
+**Implicit governance vs. explicit governance.** Oracle inherits its governance story from Oracle AI Database (auditing, encryption, RBAC at the row/column level). MemoryHub builds explicit application-layer governance on top of the database (curation pipeline, contradiction detection, branch-typed provenance, omission transparency). These are different bets about where governance lives: at the database for Oracle, in the application plus database for us.
+
+**Selling a product vs. proposing a category.** Oracle is shipping a commercial offering tied to one substrate. MemoryHub is shipping an open, substrate-agnostic implementation of what a platform-memory category should look like. These are different market motions, and their existence does not contradict ours.
+
+## 6. What They Do Well That We Don't (Yet)
+
+**Published, audited benchmark numbers.** Oracle's LongMemEval result (93.8%, with 88% multi-session) is published with full configuration disclosure and is competitive with Graphiti's numbers. MemoryHub has no published benchmark on LongMemEval today. We should add one. The configuration disclosure matters: GPT-5.5 reasoning xhigh, nomic-embed-text-v1.5, top-K = 200. That is reproducible.
+
+**Token-efficiency curves and head-to-head win rates.** The 80-turn ChromAtlas-ND scripted conversation evaluating tokens-per-request and judge-scored win rate vs. flat history is the clearest empirical case for managed memory we have seen anywhere. We should adopt this evaluation pattern (or borrow ChromAtlas-ND if it is publicly available) for the survey paper.
+
+**Threshold sweep showing cost as a tunable knob.** The 10k–70k summarization threshold sweep is the kind of evaluation that turns "we manage cost" into "here is the cost-quality curve." Adopt the pattern.
+
+**Single-paragraph framing of the unified-substrate thesis.** *"These are not four different systems. They are four access patterns over the same underlying state."* Quotable. Will land in the survey, and arguably in the v3 follow-up blog.
+
+**Database-native audit at the storage layer.** Oracle inherits SOC / FIPS / FedRAMP-level audit primitives from Oracle Database. MemoryHub's audit story is currently application-layer events plus PostgreSQL logs; it is correct, but the inheritance from a regulated-database substrate is a stronger compliance pitch than ours.
+
+**Concrete framework integration matrix.** Oracle ships notebook integrations for LangGraph, Claude Agent SDK, OpenAI Agents SDK, WayFlow, and custom harnesses on day one. MemoryHub has MCP as the primary integration; SDK-level integrations for the same matrix would be useful follow-ups.
+
+## 7. What We Do That They Can't (Yet)
+
+**Substrate portability.** MemoryHub deploys to OpenShift with PostgreSQL + pgvector that ship OOTB. Oracle AI Agent Memory requires Oracle AI Database. For organizations not already on Oracle, that is a procurement problem, a compliance review problem, and a vendor-relationship problem. For organizations on OpenShift AI specifically, MemoryHub deploys without adding a database vendor.
+
+**Cross-scope read with authorization-aware filtering and omission transparency.** Our six-scope model with `omitted_count` is structurally different from per-user predicate filtering. It enables organization-wide knowledge sharing with project-level authoring boundaries, the case Oracle's per-user isolation does not address.
+
+**Branch-typed memory (rationale, provenance) and contradiction detection.** A MemoryHub node can carry rationale and provenance branches; the curation pipeline reports contradictions explicitly; manage_curation supports contradiction reporting and resolution. Oracle's announcement does not describe equivalent primitives.
+
+**Working memory left to the harness.** Conversation buffers, scratchpads, and ephemeral state stay with the harness, where they belong. We do not pay the audit/encryption overhead for state that exists for one inference turn. Oracle pays that overhead by design.
+
+**MCP-native interface.** MemoryHub's primary interface is MCP, so any MCP-compatible agent reads/writes through a standard protocol. Oracle's primary interface is a Python SDK, so MCP-compatible agents would need a wrapper.
+
+**Conversation persistence as a separate platform primitive.** By scoping thread / message persistence out of MemoryHub and into kagenti / OGX / LlamaStack, we leave room for harnesses to model conversation differently while keeping durable memory uniform. Oracle bundles conversation into the same SDK, which couples conversation modeling to memory.
+
+## 8. Honest Framing
+
+Oracle AI Agent Memory is a serious, well-engineered productized offering. It will land with Oracle Database customers in particular, and it will substantially raise the legibility of "governed agent memory as platform infrastructure" in enterprise procurement conversations. That is good for the category. We should not write about it adversarially.
+
+Where we should be specific in our framing:
+
+- The architectural thesis Oracle articulates ("four access patterns over one substrate") is exactly ours. Quoting them is rhetorical leverage, not a concession.
+- The implementation choice (Oracle AI Database as the only substrate) is the wrong answer for the open, portable, platform-tier ecosystem we are arguing for. That is a real disagreement, and we should make it on substrate-portability grounds rather than on Oracle-the-company grounds.
+- The cognitive-science 4-type taxonomy is genuinely useful and increasingly standard. We should adopt it as a *complementary* lens alongside scope + branch, not as a replacement for it.
+- Their benchmark numbers are real and we should engage with them on benchmark grounds, not dismiss them.
+
+The Cloudflare Project Think analogy applies: Oracle and MemoryHub make different bets on substrate (Oracle DB vs. PostgreSQL + open standards) and on coupling (everything-in vs. harness/platform split). Both are defensible answers. The architecturally important conversation is what the *standard* (transport, semantics, governance contract) for the platform-memory tier should look like, and the existence of two well-engineered answers strengthens that conversation rather than weakening it.
+
+## 9. Implications for Our Publications
+
+### 9.1 v2 Blog Post (already published)
+
+["When Agent Memory Becomes a Platform Concern"](https://medium.com/@wjackson_63436/when-agent-memory-becomes-a-platform-concern-4b6cd23af47f) is published on Medium as of early May 2026. Oracle AI Agent Memory was announced after the post was published, so no retrofit is needed. The Oracle release is a strong supporting datapoint, another large vendor treating governed memory as a platform tier, and the right place to note it is in a follow-up post or in a v3 post on memory taxonomy.
+
+### 9.2 v3 Follow-up Blog (proposed)
+
+A follow-up that builds on v2 by addressing memory taxonomy directly is now well-motivated. Oracle's framing ("four access patterns, one substrate") is the cleanest articulation of the unified-substrate thesis; LangMem, MAGMA, and OpenViking all reach related conclusions; the cognitive-science 4-type taxonomy is becoming de facto standard. The follow-up should:
+
+- Name and adopt the 4-type taxonomy explicitly (working / semantic / episodic / procedural)
+- Cross it with the governance taxonomy (scope + branch) to show they are orthogonal lenses
+- Argue that working memory belongs to the harness, not the governed memory platform
+- Argue that conversation persistence, compaction, and resume are platform concerns but *separate* from governed memory. They live in kagenti / OGX / LlamaStack, not in MemoryHub
+- Sketch the platform-component split: governed memory, conversation persistence, compaction, code-execution sandbox logging, working-memory forensics. Decide what is one component vs. several
+
+This frames the v3 post as a complement to v2 (v2 said "platform memory is a tier"; v3 says "and here is what does and does not belong inside that tier").
+
+### 9.3 arXiv Survey Paper
+
+**Section 3.5 (Hybrid Architectures).** Add Oracle AI Agent Memory as an example. Sits cleanly alongside Mem0, Letta, LangMem, and OpenViking. Cite the "four access patterns over one substrate" framing explicitly. It is the most quotable single articulation of the unified-substrate thesis. One paragraph, with the LongMemEval numbers and configuration.
+
+**Section 3.6 (Emergent Patterns).** The cognitive-science 4-type taxonomy (working / semantic / episodic / procedural) is now used explicitly by LangMem (three of four), MAGMA (three of four), Oracle (all four), and implicitly by several others. Worth a short paragraph naming this as an emergent taxonomy convergence.
+
+**Section 5 (Failure Modes and Governance).** Oracle's per-record user/agent/thread/timestamp scoping plus database-native audit is a useful concrete example of governance-by-substrate-inheritance. Worth a sentence in §5.5 alongside MemoryHub's application-layer governance and OpenViking's path-lock + redo-log design.
+
+**New section or §6 expansion (Sufficiency).** Oracle's value proposition ("one vendor relationship") is the cleanest articulation of the substrate-coupled position, the same way Project Think articulates the harness-native position. The sufficiency framework should explicitly treat substrate coupling as a sufficiency dimension: an organization already on Oracle AI Database may find Oracle AI Agent Memory the right answer in the same way an organization fully on Cloudflare may find Project Think the right answer.
+
+**Section 8 (Open Problems).** Oracle's published LongMemEval numbers raise the bar on what an "evaluated" memory system looks like. The survey's call for standardized evaluation is sharpened by the existence of credible vendor-published numbers.
+
+### 9.4 No Direct Engagement Required
+
+We are not adversaries. Oracle is selling a product to Oracle Database customers; we are arguing for an open category standard. Both positions are defensible and not in direct conflict. The honest framing is: Oracle's release strengthens the platform-memory thesis, and the architectural thesis we share with them is strong evidence that the unified-substrate approach is the right answer; we disagree on whether that substrate should be a single proprietary database or an open, substrate-portable layer.
+
+## 10. Strategic Assessment
+
+Oracle AI Agent Memory is the most legitimizing release the platform-memory category has had so far. The combination of (a) a database vendor of Oracle's procurement weight, (b) a clear architectural thesis that matches ours, and (c) credible benchmark numbers materially raises the floor on what "platform memory" means in enterprise conversations. That is good for the category and good for MemoryHub's positioning, even though Oracle's product is a competitor at the implementation level.
+
+The strategic implication for MemoryHub is twofold. First, adopt the 4-type taxonomy explicitly in our publications and treat it as complementary to scope + branch. The convergence across LangMem, MAGMA, OpenViking, and Oracle is strong enough that resisting the taxonomy looks idiosyncratic. Second, sharpen the substrate-portability argument: Oracle is the cleanest example of why substrate coupling is a real cost for organizations not already on the substrate, and our reference deployment (PostgreSQL + pgvector on OpenShift) is the cleanest counter-example. The v3 follow-up blog is the right venue for both arguments.
+
+Borrow specifically: the LongMemEval evaluation discipline (publish numbers with configuration), the threshold-sweep methodology for cost-as-a-tunable-knob, the unified-substrate-thesis framing, the head-to-head-vs-flat-history evaluation pattern. Don't borrow: the substrate coupling, the inclusion of working memory in the governed store, the bundling of conversation persistence with memory.


### PR DESCRIPTION
## Summary

- The `CLUSTER_ACCESS_DOC` constant in `welcomeEmail.ts` (the body the Client Management modal hands every new contributor) pointed at `docs/contributor-cluster-access.md`, which 404s. Restore it to `docs/admin/contributor-cluster-access.md`.
- Inside the moved checklist `docs/admin/inviting-new-contributors.md`, repair the relative links that were left at `../FILE.md` (resolving to `docs/FILE.md`) so they correctly walk up to the repo root via `../../FILE.md`. Also align display text with the new path.
- Background: commit 162aa76 moved both onboarding docs into `docs/admin/` but did not fix the inbound and outbound links.

## Test plan

- [x] `welcomeEmail.ts` URL resolves: https://github.com/redhat-ai-americas/memory-hub/blob/main/docs/admin/contributor-cluster-access.md
- [x] Every relative link in `docs/admin/inviting-new-contributors.md` resolves on disk (verified with a path-resolution sweep)
- [x] No remaining `docs/contributor-cluster-access.md` references in the touched files
- [x] `gitleaks` clean on the diff
- [x] mcp-rhoai's deployed `memoryhub-ui` env shows `MEMORYHUB_PUBLIC_MCP_URL` and `MEMORYHUB_PUBLIC_AUTH_URL` set to the live cluster routes; both auth `/token` and `/mcp/` endpoints respond