### PR TITLE
ui: Drop unused COPY frontend/public ./public from Containerfile

### DIFF
--- a/memoryhub-ui/Containerfile
+++ b/memoryhub-ui/Containerfile
@@ -8,7 +8,6 @@ COPY frontend/package-lock.json* ./
 RUN if [ -f package-lock.json ]; then npm ci; else npm install; fi
 
 COPY frontend/src ./src
-COPY frontend/public ./public
 COPY frontend/index.html ./index.html
 COPY frontend/tsconfig.json ./tsconfig.json
 COPY frontend/tsconfig.node.json ./tsconfig.node.json


### PR DESCRIPTION
## Summary

- The `COPY frontend/public ./public` line in `memoryhub-ui/Containerfile` referenced a directory that has never existed in git history.
- Vite has no `publicDir` override; the build's only frontend inputs are `index.html` and `src/`.
- `build-context.sh` already guards the corresponding rsync with `[ -d ... ]`, so the staging side is correct; the Containerfile was the inconsistent half.
- Past local deploys must have either staged a `frontend/public/` dir by hand or run with the line edited out; the dormant bug surfaced when the deploy ran cleanly in a fresh worktree.

## Context

While redeploying the welcome-email URL fix from #222, builds #3 and #4 of the `memoryhub-ui` BuildConfig failed at this step before a third build (with the line removed) succeeded. This commit makes that fix permanent so the next clean deploy works first try.

## Test plan

- [x] Bundle from build #5 (the build that succeeded with the line removed) is currently serving the running pod
- [x] `frontend/public` is not referenced in `vite.config.ts`, `index.html`, `package.json`, or any other build input
- [ ] Next clean run of `memoryhub-ui/deploy/deploy.sh` completes without retries