### PR TITLE
ui: Add memoryhub CLI setup section to welcome email

### DIFF
--- a/memoryhub-ui/frontend/src/components/welcomeEmail.ts
+++ b/memoryhub-ui/frontend/src/components/welcomeEmail.ts
@@ -101,6 +101,20 @@ dance for you:
   python -c 'import asyncio; from memoryhub import MemoryHubClient; \\
     asyncio.run((lambda: print("ok"))())'
 
+Setting up MemoryHub in a Claude Code project
+---------------------------------------------
+The CLI bootstraps a project end-to-end:
+
+  pip install memoryhub-cli
+  memoryhub login --url ${mcpUrl} --auth-url ${authUrl} \\
+    --client-id ${clientId} --client-secret '<your secret>'
+  memoryhub config init
+
+login caches credentials at ~/.config/memoryhub/config.json (mode 0600).
+config init writes .memoryhub.yaml (your retrieval preferences) and
+.claude/rules/memoryhub-loading.md (the rule Claude Code auto-loads at
+session start). Re-run memoryhub config regenerate after editing the YAML.
+
 Then open ${CONTRIBUTING_URL}
 for the local dev setup, coding conventions, and PR flow.
 


### PR DESCRIPTION
## Summary

Add a third section to the Client Management welcome email walking new contributors through `pip install memoryhub-cli` + `memoryhub login` + `memoryhub config init`, the bootstrap path that wires up `.memoryhub.yaml` and `.claude/rules/memoryhub-loading.md` for a Claude Code project.

## Why

The existing email covers two usage paths: a raw `curl` token request, and the Python SDK's env-var auto-auth. Both stop short of the actual onboarding friction for our most common new-contributor profile: a developer writing a Claude Code agent who needs the agent rule file to land in their project. `config init` is the one command that closes that gap, but it was previously discoverable only by reading the CLI README.

## Test plan

- [x] Rendered the template with placeholder values via `tsx`; new section formats cleanly between the SDK smoke-test and the `Then open` transition
- [x] Backslash line continuation in the `memoryhub login` command renders as a single `\` in the email body
- [x] Section length matches the surrounding density (~14 lines)
- [ ] Re-deploy `memoryhub-ui` after merge so Client Management generates the updated email