### PR TITLE
auth: Support ROSA clusters in OAuth URL resolution

### DIFF
--- a/memoryhub-auth/deploy.sh
+++ b/memoryhub-auth/deploy.sh
@@ -34,12 +34,19 @@ fi
 
 # Derive cluster-specific URLs (used by apply_manifest via sed)
 echo "→ Resolving cluster URLs..."
-OAUTH_HOST=$(oc get route oauth-openshift -n openshift-authentication -o jsonpath='{.spec.host}' 2>/dev/null)
-if [ -z "$OAUTH_HOST" ]; then
-    echo "Error: Cannot resolve OpenShift OAuth route. Is this an OpenShift 4 cluster?"
-    exit 1
+OAUTH_HOST=$(oc get route oauth-openshift -n openshift-authentication -o jsonpath='{.spec.host}' 2>/dev/null || true)
+if [ -n "$OAUTH_HOST" ]; then
+    OAUTH_AUTHORIZE_URL="https://${OAUTH_HOST}/oauth/authorize"
+else
+    echo "  No oauth-openshift route (ROSA cluster?) — querying API metadata..."
+    OAUTH_AUTHORIZE_URL=$(oc get --raw '/.well-known/oauth-authorization-server' \
+        | python3 -c "import sys,json; print(json.load(sys.stdin).get('authorization_endpoint',''))" \
+        || true)
+    if [ -z "$OAUTH_AUTHORIZE_URL" ]; then
+        echo "Error: Cannot resolve OpenShift OAuth endpoint via route or API metadata."
+        exit 1
+    fi
 fi
-OAUTH_AUTHORIZE_URL="https://${OAUTH_HOST}/oauth/authorize"
 echo "  OAuth authorize: $OAUTH_AUTHORIZE_URL"
 # AUTH_ISSUER_URL — try to resolve now (Route may already exist from a
 # previous deploy).  If not, it's resolved after the first apply creates


### PR DESCRIPTION
## Summary

The auth server deploy script (`memoryhub-auth/deploy.sh`) assumed every OpenShift cluster exposes an `oauth-openshift` route in `openshift-authentication`. ROSA clusters don't. They serve OAuth through a dedicated `oauth.*` hostname discoverable via the API server's `/.well-known/oauth-authorization-server` metadata.

The script now tries the route first (self-managed OCP) and falls back to the well-known metadata endpoint (ROSA). Both paths produce the same `OAUTH_AUTHORIZE_URL` used downstream by the OAuthClient CR and the broker redirect.

### What changed

- Added `|| true` to the route lookup so `set -euo pipefail` doesn't kill the script before the fallback runs.
- Flipped the conditional to test the happy path first (`-n` check), keeping the fallback in the `else` branch.
- Used `.get('authorization_endpoint', '')` instead of `['authorization_endpoint']` so a missing key returns empty string (handled by the existing `-z` guard) rather than a `KeyError` that `set -e` would exit on before the guard runs.
- Removed `2>/dev/null` from the fallback pipeline so failures are visible for debugging.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Opus 4.6 (1M context)](https://img.shields.io/badge/Opus_4.6_(1M)-D97757?logo=claude&logoColor=white)