### PR TITLE
ci: Add version-consistency check for SDK and CLI releases

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -82,3 +82,11 @@ Closes #
 - [ ] No committed credentials or cluster-specific URLs
 - [ ] CLAUDE.md / docs updated if behavior or conventions changed
 - [ ] Commit message follows `subsystem: Imperative summary` format
+
+## Release readiness (if this PR touches `sdk/` or `memoryhub-cli/`)
+
+<!-- Skip this section if the PR does not modify files under sdk/ or memoryhub-cli/. -->
+
+- [ ] `pyproject.toml` version matches `__init__.py` `__version__`
+- [ ] `CHANGELOG.md` has an entry for the new version
+- [ ] If breaking: CHANGELOG entry is flagged with `BREAKING` and links the tracking issue

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -1,0 +1,87 @@
+name: Version Consistency
+
+on:
+  pull_request:
+    paths:
+      - 'sdk/**'
+      - 'memoryhub-cli/**'
+
+jobs:
+  version-check:
+    name: Version Consistency
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check version consistency
+        run: |
+          set -e
+
+          # Determine which components changed
+          CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD)
+
+          SDK_CHANGED=false
+          CLI_CHANGED=false
+
+          if echo "$CHANGED_FILES" | grep -q '^sdk/'; then
+            SDK_CHANGED=true
+          fi
+
+          if echo "$CHANGED_FILES" | grep -q '^memoryhub-cli/'; then
+            CLI_CHANGED=true
+          fi
+
+          EXIT_CODE=0
+
+          check_component() {
+            local LABEL="$1" DIR="$2" PKG="$3"
+
+            echo "Checking $LABEL version consistency..."
+
+            if [ ! -f "$DIR/pyproject.toml" ] || [ ! -f "$DIR/src/$PKG/__init__.py" ]; then
+              echo "❌ ERROR: $LABEL version files missing"
+              return 1
+            fi
+
+            PYPROJECT_VERSION=$(grep -E '^version' "$DIR/pyproject.toml" | head -1 | cut -d'"' -f2)
+            INIT_VERSION=$(grep -E '^__version__' "$DIR/src/$PKG/__init__.py" | cut -d'"' -f2)
+
+            if [ -z "$PYPROJECT_VERSION" ] || [ -z "$INIT_VERSION" ]; then
+              echo "❌ ERROR: Could not extract $LABEL version (pyproject=$PYPROJECT_VERSION, __init__=$INIT_VERSION)"
+              return 1
+            fi
+
+            echo "  $DIR/pyproject.toml version: $PYPROJECT_VERSION"
+            echo "  $DIR/src/$PKG/__init__.py __version__: $INIT_VERSION"
+
+            if [ "$PYPROJECT_VERSION" != "$INIT_VERSION" ]; then
+              echo "❌ ERROR: $LABEL versions do not match!"
+              return 1
+            fi
+            echo "✅ $LABEL versions match"
+
+            if [ -f "$DIR/CHANGELOG.md" ] && grep -q "## \[$PYPROJECT_VERSION\]" "$DIR/CHANGELOG.md"; then
+              echo "✅ $LABEL CHANGELOG.md has entry for version $PYPROJECT_VERSION"
+            else
+              echo "⚠️  WARNING: $DIR/CHANGELOG.md missing entry for version $PYPROJECT_VERSION"
+              echo "   Fine for intermediate PRs, but required before release."
+            fi
+            return 0
+          }
+
+          if [ "$SDK_CHANGED" = "true" ]; then
+            check_component "SDK" "sdk" "memoryhub" || EXIT_CODE=1
+          fi
+
+          if [ "$CLI_CHANGED" = "true" ]; then
+            check_component "CLI" "memoryhub-cli" "memoryhub_cli" || EXIT_CODE=1
+          fi
+
+          if [ "$SDK_CHANGED" = "false" ] && [ "$CLI_CHANGED" = "false" ]; then
+            echo "No SDK or CLI files changed, skipping version check."
+          fi
+
+          exit $EXIT_CODE

--- a/memoryhub-cli/src/memoryhub_cli/__init__.py
+++ b/memoryhub-cli/src/memoryhub_cli/__init__.py
@@ -1,3 +1,3 @@
 """MemoryHub CLI client."""
 
-__version__ = "0.4.0"
+__version__ = "0.5.0"


### PR DESCRIPTION
## Summary

Shift version-drift detection from tag time (post-merge) to PR time. The SDK is now a transitive dependency of kagenti-adk, so catching version mismatches before merge matters more than before.

- PR template gains a "Release readiness" checklist for PRs touching `sdk/` or `memoryhub-cli/`
- New `version-check.yml` workflow compares `pyproject.toml` version against `__init__.py` `__version__`, warns on missing CHANGELOG entries
- Fixes existing CLI drift (pyproject.toml 0.5.0 vs __init__.py 0.4.0) as a prep commit

Closes #213

## Design reference

- `retrospectives/2026-04-29_sdk-compacted-tool-rework/RETRO.md`

## Test plan

- [x] **Unit tests only** -- CI workflow change, no application code
- [x] Verified the workflow would catch the existing CLI version drift (fixed in second commit)