### PR TITLE
discovery: Add URL discovery endpoint for downstream consumers

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,37 @@
+name: Deploy discovery to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/public/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy to Pages
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/configure-pages@v5
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/public
+
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/SYSTEMS.md
+++ b/docs/SYSTEMS.md
@@ -107,6 +107,7 @@ The IBM Python Agent Development Kit (ADK) ships a MemoryStore extension that wr
 - **SDK surface used**: `MemoryHubClient` constructor, `search`/`write`/`read`/`update`/`delete`, `WriteResult.curation.reason`, `NotFoundError`.
 - **Authentication**: API key (default) or OAuth 2.1 `client_credentials`.
 - **E2E tests**: gated behind `MEMORYHUB_E2E_URL` and `MEMORYHUB_E2E_API_KEY` repo secrets on `kagenti/adk`; skipped without them.
+- **URL discovery**: The current MCP URL is published at `https://redhat-ai-americas.github.io/memory-hub/discovery.json` via GitHub Pages. When the sandbox cluster rotates, run `scripts/update-discovery.sh --push <new-url>` to update the discovery file. E2E tests can read this endpoint to self-heal after rotation. See `planning/kagenti-adk-e2e-cluster-url-stability.md` for the decision record.
 - **Stability promise**: SDK breaking changes (renamed fields, signature changes, new exceptions on the happy path) need to be coordinated with the kagenti-adk maintainers before release.
 
 ## What's not yet shipped

--- a/docs/public/discovery.json
+++ b/docs/public/discovery.json
@@ -1,0 +1,12 @@
+{
+  "instances": {
+    "sandbox": {
+      "mcp_url": "https://memory-hub-mcp-memory-hub-mcp.apps.cluster-n7pd5.n7pd5.sandbox5167.opentlc.com/mcp/",
+      "environment": "sandbox",
+      "updated": "2026-05-12",
+      "status": "active"
+    }
+  },
+  "default": "sandbox",
+  "schema_version": 1
+}

--- a/docs/public/index.html
+++ b/docs/public/index.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<html>
+<head><meta http-equiv="refresh" content="0;url=https://github.com/redhat-ai-americas/memory-hub"></head>
+<body><p>Redirecting to <a href="https://github.com/redhat-ai-americas/memory-hub">MemoryHub</a>...</p></body>
+</html>

--- a/planning/kagenti-adk-e2e-cluster-url-stability.md
+++ b/planning/kagenti-adk-e2e-cluster-url-stability.md
@@ -1,7 +1,7 @@
 # Cluster URL stability for kagenti-adk E2E
 
-Status: Skeleton — 2026-04-29
-Tracks: (no GitHub issue yet — file when picking up)
+Status: Decided: Option D — 2026-05-12
+Tracks: #209
 Author: @rdwj (drafted with Claude Code Opus 4.7)
 
 ## Why this exists
@@ -16,7 +16,7 @@ That hostname embeds a sandbox cluster ID (`n7pd5`, `sandbox5167`). Sandbox clus
 
 We need to decide how stable this URL needs to be and pick a strategy proportional to that decision. See [`docs/SYSTEMS.md`](../docs/SYSTEMS.md#kagenti-adk) for the full integration profile.
 
-This document is the proposal. **No infrastructure changes in this document.** Implementation is a future session.
+This document is the proposal and decision record.
 
 ## Options
 
@@ -60,12 +60,11 @@ Publish the current URL at a known stable location (e.g., `https://redhat-ai-ame
 
 Option A as the v1 — set expectations clearly. Layer in Option D when the first rotation actually causes pain. Option B/C are over-engineering for one downstream consumer; revisit if a second consumer shows up or if the manual coordination cost gets annoying.
 
-## What needs deciding
+## Decision
 
-- Are we OK with manual coordination on rotation, or is that already too painful?
-- If layering in Option D: where does the discovery file live (GitHub Pages? a static route on the cluster itself? another)?
-- Do we need to coordinate this with @JanPokorny before changing strategies, or can we adopt server-side and have kagenti-adk catch up?
-- Sandbox cluster rotation cadence — how often does it actually happen? Influences how aggressive we need to be.
+Option D was selected. The QuickStart use case (deploying to arbitrary RHPDS or on-premise clusters) means the URL is inherently variable, not just occasionally rotated. A stable discovery endpoint handles this generically. Option A's manual coordination doesn't scale past one downstream consumer.
+
+The discovery file is published via GitHub Pages at `https://redhat-ai-americas.github.io/memory-hub/discovery.json`. The `scripts/update-discovery.sh` script updates the file, commits the change, and optionally pushes to trigger Pages rebuilds.
 
 ## Out of scope
 

--- a/scripts/update-discovery.sh
+++ b/scripts/update-discovery.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+#
+# Update the MemoryHub MCP server discovery file with a new URL.
+#
+# This script updates docs/public/discovery.json with the current MCP server
+# URL for a given instance (default: "sandbox"). The discovery file is published
+# via GitHub Pages to provide a stable discovery endpoint for downstream consumers
+# like kagenti-adk E2E tests.
+#
+# Usage:
+#   scripts/update-discovery.sh [--instance NAME] [--push] <mcp-url>
+#
+# Options:
+#   --instance NAME   Instance name to update (default: "sandbox")
+#   --push            Push the commit to remote after updating
+#
+# Example:
+#   scripts/update-discovery.sh https://memory-hub-mcp-memory-hub-mcp.apps.cluster-abc.example.com/mcp/
+#   scripts/update-discovery.sh --instance prod --push https://mcp.example.com/mcp/
+#
+
+set -euo pipefail
+
+INSTANCE="sandbox"
+PUSH=false
+MCP_URL=""
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --instance)
+            INSTANCE="$2"
+            shift 2
+            ;;
+        --push)
+            PUSH=true
+            shift
+            ;;
+        *)
+            if [[ -z "$MCP_URL" ]]; then
+                MCP_URL="$1"
+                shift
+            else
+                echo "Error: unexpected argument: $1" >&2
+                exit 1
+            fi
+            ;;
+    esac
+done
+
+if [[ -z "$MCP_URL" ]]; then
+    echo "Error: MCP URL is required" >&2
+    echo "Usage: $0 [--instance NAME] [--push] <mcp-url>" >&2
+    exit 1
+fi
+
+# Get the repo root
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+DISCOVERY_FILE="$REPO_ROOT/docs/public/discovery.json"
+
+if [[ ! -f "$DISCOVERY_FILE" ]]; then
+    echo "Error: discovery file not found at $DISCOVERY_FILE" >&2
+    exit 1
+fi
+
+# Get current date
+CURRENT_DATE="$(date +%Y-%m-%d)"
+
+# Update the discovery file using Python (arguments passed via sys.argv to avoid injection)
+python3 -c '
+import json, sys
+
+discovery_file, instance, mcp_url, current_date = sys.argv[1:5]
+
+with open(discovery_file, "r") as f:
+    data = json.load(f)
+
+data.setdefault("instances", {})
+
+if instance in data["instances"]:
+    data["instances"][instance]["mcp_url"] = mcp_url
+    data["instances"][instance]["updated"] = current_date
+else:
+    data["instances"][instance] = {
+        "mcp_url": mcp_url,
+        "environment": instance,
+        "updated": current_date,
+        "status": "active",
+    }
+
+with open(discovery_file, "w") as f:
+    json.dump(data, f, indent=2)
+    f.write("\n")
+
+print(f"Updated {instance} instance MCP URL to: {mcp_url}")
+' "$DISCOVERY_FILE" "$INSTANCE" "$MCP_URL" "$CURRENT_DATE"
+
+# Commit the change
+cd "$REPO_ROOT"
+git add "$DISCOVERY_FILE"
+git commit -m "discovery: Update $INSTANCE MCP URL"
+
+echo ""
+echo "Discovery file updated and committed."
+echo "The file will be published at: https://redhat-ai-americas.github.io/memory-hub/discovery.json"
+
+# Push if requested
+if [[ "$PUSH" == "true" ]]; then
+    CURRENT_BRANCH="$(git branch --show-current)"
+    git push origin "$CURRENT_BRANCH"
+    echo "Changes pushed to origin/$CURRENT_BRANCH"
+fi


### PR DESCRIPTION
## Summary

Downstream consumers (kagenti-adk E2E, QuickStart deployments) need a stable way to find the current MCP URL without manual coordination on each sandbox cluster rotation. This implements Option D from the planning doc: publish the URL at a stable GitHub Pages endpoint.

- `docs/public/discovery.json` with the current sandbox instance URL
- `scripts/update-discovery.sh` to update on cluster rotation
- GitHub Actions workflow to deploy `docs/public/` to Pages
- SYSTEMS.md and planning doc updated with decision record
- Filed kagenti/adk#242 for the E2E test to read this endpoint

Closes #209

## Design reference

- `planning/kagenti-adk-e2e-cluster-url-stability.md`

## Test plan

- [x] **Unit tests only** -- infrastructure/CI change, no application code
- [x] Script syntax validated and Python logic dry-run tested
- [x] Pages workflow follows GitHub's `actions/deploy-pages` standard pattern

Note: GitHub Pages needs to be enabled on the repo (Settings > Pages > Source: GitHub Actions) for the workflow to run.