### PR TITLE
deploy: Fold all known operators into users-configmap example template

### DIFF
--- a/docs/runbooks/add-mcp-api-user.md
+++ b/docs/runbooks/add-mcp-api-user.md
@@ -4,6 +4,8 @@ This runbook covers adding a new API key to the `memoryhub-users` ConfigMap so a
 
 If you are looking for OAuth 2.1 `client_credentials` provisioning instead — used by SDK consumers and dashboards — see [`docs/auth/README.md`](../auth/README.md). API keys are the dev-path shim; OAuth is the durable mechanism. Both work today.
 
+> **Prefer adding users to the example template.** If the user is expected to persist across fresh deploys (CI accounts, automation agents), add them to `memory-hub-mcp/deploy/users-configmap.example.yaml` rather than patching the live ConfigMap. The runbook procedure below is for one-off or temporary users.
+
 ## When to use this
 
 - Adding a new API key for an external CI test job (e.g., `kagenti-ci`) that needs to exercise the MCP server end-to-end.

--- a/memory-hub-mcp/deploy/users-configmap.example.yaml
+++ b/memory-hub-mcp/deploy/users-configmap.example.yaml
@@ -27,13 +27,36 @@ data:
           "user_id": "wjackson",
           "name": "Wes Jackson",
           "api_key": "REPLACE-ME-GENERATE-WITH-openssl-rand-hex-16",
-          "scopes": ["user", "project", "role", "organizational", "enterprise"]
+          "scopes": ["user", "project", "role", "organizational", "enterprise"],
+          "_comment": "primary operator"
         },
         {
           "user_id": "dev-test",
           "name": "Test User",
-          "api_key": "REPLACE-ME-GENERATE-A-SECOND-KEY",
-          "scopes": ["user", "project"]
+          "api_key": "REPLACE-ME-GENERATE-WITH-openssl-rand-hex-16",
+          "scopes": ["user", "project"],
+          "_comment": "local development and integration testing"
+        },
+        {
+          "user_id": "rdwj-agent-1",
+          "name": "RDWJ Agent 1",
+          "api_key": "REPLACE-ME-GENERATE-WITH-openssl-rand-hex-16",
+          "scopes": ["user", "project", "role", "organizational", "enterprise"],
+          "_comment": "agent automation slot 1"
+        },
+        {
+          "user_id": "rdwj-agent-2",
+          "name": "RDWJ Agent 2",
+          "api_key": "REPLACE-ME-GENERATE-WITH-openssl-rand-hex-16",
+          "scopes": ["user", "project", "role", "organizational", "enterprise"],
+          "_comment": "agent automation slot 2"
+        },
+        {
+          "user_id": "kagenti-ci",
+          "name": "Kagenti CI",
+          "api_key": "REPLACE-ME-GENERATE-WITH-openssl-rand-hex-16",
+          "scopes": ["user", "project"],
+          "_comment": "kagenti-adk E2E test runner (see docs/SYSTEMS.md)"
         }
       ]
     }


### PR DESCRIPTION
## Summary

The example template only included 2 of 5 known users. A fresh `deploy-full.sh` would silently drop `kagenti-ci`, `rdwj-agent-1`, and `rdwj-agent-2`, breaking downstream consumers like the kagenti-adk E2E test.

- Adds all 5 known users to `users-configmap.example.yaml` with placeholder keys
- Each user gets a `_comment` field explaining its purpose
- Runbook updated to recommend template updates over live ConfigMap patches for persistent users

Closes #221

## Design reference

- `retrospectives/2026-04-30_kagenti-ci-cleanup-and-provisioning/RETRO.md`

## Test plan

- [x] **Unit tests only** -- deploy template change, no application code
- [x] Verified existing placeholder validation in `deploy.sh` still applies