### PR TITLE
deploy: Parameterize cluster context and guard OdhApplication CRD

### DIFF
--- a/scripts/backup-db.sh
+++ b/scripts/backup-db.sh
@@ -12,6 +12,7 @@ set -euo pipefail
 SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}")"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+CONTEXT="${MEMORYHUB_CONTEXT:-mcp-rhoai}"
 
 DB_NAMESPACE="memoryhub-db"
 POD_LABEL="app.kubernetes.io/name=memoryhub-pg"
@@ -62,16 +63,16 @@ fi
 # ---------------------------------------------------------------------------
 banner "MemoryHub DB Backup"
 
-if ! oc whoami &>/dev/null; then
+if ! oc whoami --context "$CONTEXT" &>/dev/null; then
     die "Not logged in to an OpenShift cluster. Run 'oc login' first."
 fi
-info "Logged in as: $(oc whoami)"
+info "Logged in as: $(oc whoami --context "$CONTEXT")"
 
 # ---------------------------------------------------------------------------
 # Step 2: Find the PostgreSQL pod
 # ---------------------------------------------------------------------------
 info "Finding PostgreSQL pod in namespace ${DB_NAMESPACE}..."
-PG_POD="$(oc get pod -l "${POD_LABEL}" -n "${DB_NAMESPACE}" \
+PG_POD="$(oc get pod --context "$CONTEXT" -l "${POD_LABEL}" -n "${DB_NAMESPACE}" \
     -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)" \
     || die "No pod found matching label '${POD_LABEL}' in namespace '${DB_NAMESPACE}'."
 
@@ -85,11 +86,11 @@ info "Using pod: ${PG_POD}"
 # ---------------------------------------------------------------------------
 info "Reading credentials from secret '${CREDENTIALS_SECRET}'..."
 
-POSTGRES_USER="$(oc get secret "${CREDENTIALS_SECRET}" -n "${DB_NAMESPACE}" \
+POSTGRES_USER="$(oc get secret --context "$CONTEXT" "${CREDENTIALS_SECRET}" -n "${DB_NAMESPACE}" \
     -o jsonpath='{.data.POSTGRES_USER}' | base64 -d)"
-POSTGRES_DB="$(oc get secret "${CREDENTIALS_SECRET}" -n "${DB_NAMESPACE}" \
+POSTGRES_DB="$(oc get secret --context "$CONTEXT" "${CREDENTIALS_SECRET}" -n "${DB_NAMESPACE}" \
     -o jsonpath='{.data.POSTGRES_DB}' | base64 -d)"
-POSTGRES_PASSWORD="$(oc get secret "${CREDENTIALS_SECRET}" -n "${DB_NAMESPACE}" \
+POSTGRES_PASSWORD="$(oc get secret --context "$CONTEXT" "${CREDENTIALS_SECRET}" -n "${DB_NAMESPACE}" \
     -o jsonpath='{.data.POSTGRES_PASSWORD}' | base64 -d)"
 
 if [[ -z "$POSTGRES_USER" || -z "$POSTGRES_DB" || -z "$POSTGRES_PASSWORD" ]]; then
@@ -111,7 +112,7 @@ fi
 # ---------------------------------------------------------------------------
 info "Starting backup → ${OUTPUT_FILE}"
 
-oc exec "${PG_POD}" -n "${DB_NAMESPACE}" -c "${CONTAINER}" \
+oc exec --context "$CONTEXT" "${PG_POD}" -n "${DB_NAMESPACE}" -c "${CONTAINER}" \
     -- env PGPASSWORD="${POSTGRES_PASSWORD}" \
     pg_dump --format=custom -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" \
     > "$OUTPUT_FILE"

--- a/scripts/deploy-full.sh
+++ b/scripts/deploy-full.sh
@@ -520,13 +520,18 @@ deploy_tile() {
         die "OdhApplication manifest not found: $odh_manifest"
     fi
 
-    info "Applying OdhApplication CR to $RHOAI_NAMESPACE..."
-    if ! oc apply --context "$CONTEXT" -f "$odh_manifest" -n "$RHOAI_NAMESPACE"; then
-        die "Failed to apply OdhApplication manifest."
+    if oc get crd odhapplications.dashboard.opendatahub.io --context "$CONTEXT" &>/dev/null; then
+        info "Applying OdhApplication CR to $RHOAI_NAMESPACE..."
+        if ! oc apply --context "$CONTEXT" -f "$odh_manifest" -n "$RHOAI_NAMESPACE"; then
+            die "Failed to apply OdhApplication manifest."
+        fi
+        echo ""
+        echo -e "  ${GREEN}RHOAI tile applied${RESET}"
+    else
+        warn "OdhApplication CRD not found — skipping dashboard tile (non-blocking)"
+        echo ""
+        echo -e "  ${YELLOW}RHOAI tile skipped (CRD not available)${RESET}"
     fi
-
-    echo ""
-    echo -e "  ${GREEN}RHOAI tile applied${RESET}"
 }
 
 # ---------------------------------------------------------------------------

--- a/scripts/deploy-full.sh
+++ b/scripts/deploy-full.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}")"
+CONTEXT="${MEMORYHUB_CONTEXT:-mcp-rhoai}"
 
 DB_NAMESPACE="memoryhub-db"
 MCP_PROJECT="memory-hub-mcp"
@@ -58,31 +59,31 @@ skipped() { echo -e "  ${YELLOW}(skipped)${RESET} $*"; }
 # Idempotent: skips if the target already exists.
 copy_secret() {
     local src_name=$1 src_ns=$2 dst_name=$3 dst_ns=$4
-    if oc get secret "$dst_name" -n "$dst_ns" &>/dev/null; then
+    if oc get secret --context "$CONTEXT" "$dst_name" -n "$dst_ns" &>/dev/null; then
         info "Secret $dst_name already exists in $dst_ns"
         return 0
     fi
     info "Copying Secret $src_name from $src_ns to $dst_ns (as $dst_name)..."
-    oc get secret "$src_name" -n "$src_ns" -o json | \
+    oc get secret --context "$CONTEXT" "$src_name" -n "$src_ns" -o json | \
         python3 -c "
 import json, sys
 s = json.load(sys.stdin)
 s['metadata'] = {'name': '$dst_name', 'namespace': '$dst_ns'}
 s.pop('status', None)
 json.dump(s, sys.stdout)
-" | oc apply -f -
+" | oc apply --context "$CONTEXT" -f -
 }
 
 # Create a Secret with a random hex value if it doesn't already exist.
 # Idempotent: skips if the target already exists.
 ensure_random_secret() {
     local name=$1 ns=$2 key=$3
-    if oc get secret "$name" -n "$ns" &>/dev/null; then
+    if oc get secret --context "$CONTEXT" "$name" -n "$ns" &>/dev/null; then
         info "Secret $name already exists in $ns"
         return 0
     fi
     info "Generating Secret $name in $ns..."
-    oc create secret generic "$name" --from-literal="$key=$(openssl rand -hex 32)" -n "$ns"
+    oc create secret --context "$CONTEXT" generic "$name" --from-literal="$key=$(openssl rand -hex 32)" -n "$ns"
 }
 
 elapsed() {
@@ -165,11 +166,11 @@ preflight() {
     banner "1. Preflight Checks"
 
     info "Verifying OpenShift login..."
-    if ! oc whoami &>/dev/null; then
+    if ! oc whoami --context "$CONTEXT" &>/dev/null; then
         die "Not logged in to OpenShift. Run 'oc login' first."
     fi
-    echo "     Logged in as: $(oc whoami)"
-    echo "     Server:       $(oc whoami --show-server)"
+    echo "     Logged in as: $(oc whoami --context "$CONTEXT")"
+    echo "     Server:       $(oc whoami --context "$CONTEXT" --show-server)"
 
     info "Verifying .venv and alembic..."
     if [ ! -d "$REPO_ROOT/.venv" ]; then
@@ -206,24 +207,24 @@ deploy_postgresql() {
     fi
 
     # Ensure namespace exists before creating the Secret
-    if ! oc get namespace "$DB_NAMESPACE" &>/dev/null; then
+    if ! oc get namespace --context "$CONTEXT" "$DB_NAMESPACE" &>/dev/null; then
         info "Creating namespace $DB_NAMESPACE..."
-        oc create namespace "$DB_NAMESPACE"
+        oc create namespace --context "$CONTEXT" "$DB_NAMESPACE"
     fi
 
     # Ensure DB credentials Secret exists (generate password on first install,
     # preserve on subsequent runs).  The Secret is NOT in the kustomization so
     # re-applying kustomize never overwrites an existing password.
-    if ! oc get secret memoryhub-pg-credentials -n "$DB_NAMESPACE" &>/dev/null; then
+    if ! oc get secret --context "$CONTEXT" memoryhub-pg-credentials -n "$DB_NAMESPACE" &>/dev/null; then
         local db_pass
         db_pass=$(openssl rand -hex 16)
         info "Generating DB credentials Secret (first install)..."
-        oc create secret generic memoryhub-pg-credentials \
+        oc create secret --context "$CONTEXT" generic memoryhub-pg-credentials \
             --from-literal=POSTGRES_USER=memoryhub \
             --from-literal=POSTGRES_PASSWORD="$db_pass" \
             --from-literal=POSTGRES_DB=memoryhub \
             -n "$DB_NAMESPACE"
-        oc label secret memoryhub-pg-credentials \
+        oc label secret --context "$CONTEXT" memoryhub-pg-credentials \
             app.kubernetes.io/name=memoryhub-pg \
             app.kubernetes.io/part-of=memoryhub \
             app.kubernetes.io/component=database \
@@ -233,25 +234,25 @@ deploy_postgresql() {
     fi
 
     info "Applying kustomize manifests..."
-    oc apply -k "$REPO_ROOT/deploy/postgresql/"
+    oc apply --context "$CONTEXT" -k "$REPO_ROOT/deploy/postgresql/"
 
     info "Granting anyuid SCC to default service account..."
-    # idempotent — oc adm policy exits 0 whether or not the grant was new
-    oc adm policy add-scc-to-user anyuid -z default -n "$DB_NAMESPACE"
+    # idempotent — oc adm policy --context "$CONTEXT" exits 0 whether or not the grant was new
+    oc adm policy --context "$CONTEXT" add-scc-to-user anyuid -z default -n "$DB_NAMESPACE"
 
     # If the pod already existed before the SCC grant, it may be stuck.
     # Check if the pod is in a bad state and delete it so it restarts with the SCC.
     local pod_phase
-    pod_phase=$(oc get pod -n "$DB_NAMESPACE" -l "$DB_POD_LABEL" \
+    pod_phase=$(oc get pod --context "$CONTEXT" -n "$DB_NAMESPACE" -l "$DB_POD_LABEL" \
         -o jsonpath='{.items[0].status.phase}' 2>/dev/null || echo "")
 
     if [ -n "$pod_phase" ] && [ "$pod_phase" != "Running" ]; then
         warn "PostgreSQL pod is in '$pod_phase' state — deleting so it restarts with updated SCC..."
-        oc delete pod -n "$DB_NAMESPACE" -l "$DB_POD_LABEL" --ignore-not-found
+        oc delete pod --context "$CONTEXT" -n "$DB_NAMESPACE" -l "$DB_POD_LABEL" --ignore-not-found
     fi
 
     info "Waiting for PostgreSQL pod to be ready (timeout: 120s)..."
-    if ! oc wait --for=condition=ready pod -l "$DB_POD_LABEL" \
+    if ! oc wait --context "$CONTEXT" --for=condition=ready pod -l "$DB_POD_LABEL" \
             -n "$DB_NAMESPACE" --timeout=120s; then
         die "PostgreSQL pod did not become ready within 120s. Check: oc describe pod -l $DB_POD_LABEL -n $DB_NAMESPACE"
     fi
@@ -303,7 +304,7 @@ run_migrations() {
     # Auto-read DB password from K8s Secret if not already set
     if [ -z "${MEMORYHUB_DB_PASSWORD:-}" ]; then
         info "Reading DB password from K8s Secret in $DB_NAMESPACE..."
-        MEMORYHUB_DB_PASSWORD=$(oc get secret memoryhub-pg-credentials -n "$DB_NAMESPACE" \
+        MEMORYHUB_DB_PASSWORD=$(oc get secret --context "$CONTEXT" memoryhub-pg-credentials -n "$DB_NAMESPACE" \
             -o jsonpath='{.data.POSTGRES_PASSWORD}' | base64 -d)
         export MEMORYHUB_DB_PASSWORD
     fi
@@ -330,26 +331,26 @@ deploy_infra() {
 
     # Ensure MCP namespace exists (MCP deploy script also does this, but we
     # need it now for MinIO/Valkey which must be ready before MCP starts)
-    if ! oc get namespace "$MCP_PROJECT" &>/dev/null; then
+    if ! oc get namespace --context "$CONTEXT" "$MCP_PROJECT" &>/dev/null; then
         info "Creating namespace $MCP_PROJECT..."
-        oc create namespace "$MCP_PROJECT"
+        oc create namespace --context "$CONTEXT" "$MCP_PROJECT"
     fi
 
     info "Deploying MinIO..."
-    oc apply -k "$REPO_ROOT/deploy/minio/" -n "$MCP_PROJECT"
-    oc adm policy add-scc-to-user anyuid -z memoryhub-minio -n "$MCP_PROJECT"
+    oc apply --context "$CONTEXT" -k "$REPO_ROOT/deploy/minio/" -n "$MCP_PROJECT"
+    oc adm policy --context "$CONTEXT" add-scc-to-user anyuid -z memoryhub-minio -n "$MCP_PROJECT"
 
     info "Deploying Valkey..."
-    oc apply -k "$REPO_ROOT/deploy/valkey/" -n "$MCP_PROJECT"
-    oc adm policy add-scc-to-user anyuid -z memoryhub-valkey -n "$MCP_PROJECT"
+    oc apply --context "$CONTEXT" -k "$REPO_ROOT/deploy/valkey/" -n "$MCP_PROJECT"
+    oc adm policy --context "$CONTEXT" add-scc-to-user anyuid -z memoryhub-valkey -n "$MCP_PROJECT"
 
     info "Waiting for MinIO rollout..."
-    if ! oc rollout status deployment/memoryhub-minio -n "$MCP_PROJECT" --timeout=120s; then
+    if ! oc rollout --context "$CONTEXT" status deployment/memoryhub-minio -n "$MCP_PROJECT" --timeout=120s; then
         die "MinIO did not become ready. Check: oc describe deployment/memoryhub-minio -n $MCP_PROJECT"
     fi
 
     info "Waiting for Valkey rollout..."
-    if ! oc rollout status deployment/memoryhub-valkey -n "$MCP_PROJECT" --timeout=120s; then
+    if ! oc rollout --context "$CONTEXT" status deployment/memoryhub-valkey -n "$MCP_PROJECT" --timeout=120s; then
         die "Valkey did not become ready. Check: oc describe deployment/memoryhub-valkey -n $MCP_PROJECT"
     fi
 
@@ -385,9 +386,9 @@ prepare_auth_infra() {
 
     banner "4b. Auth Infrastructure"
 
-    if ! oc get namespace "$AUTH_PROJECT" &>/dev/null; then
+    if ! oc get namespace --context "$CONTEXT" "$AUTH_PROJECT" &>/dev/null; then
         info "Creating namespace $AUTH_PROJECT..."
-        oc create namespace "$AUTH_PROJECT"
+        oc create namespace --context "$CONTEXT" "$AUTH_PROJECT"
     fi
 
     copy_secret memoryhub-pg-credentials "$DB_NAMESPACE" memoryhub-pg-credentials "$AUTH_PROJECT"
@@ -427,34 +428,34 @@ prepare_ui_infra() {
 
     banner "5b. UI Infrastructure"
 
-    if ! oc get namespace "$UI_NAMESPACE" &>/dev/null; then
+    if ! oc get namespace --context "$CONTEXT" "$UI_NAMESPACE" &>/dev/null; then
         info "Creating namespace $UI_NAMESPACE..."
-        oc create namespace "$UI_NAMESPACE"
+        oc create namespace --context "$CONTEXT" "$UI_NAMESPACE"
     fi
 
     # ServiceAccount for oauth-proxy sidecar
     info "Applying UI ServiceAccount..."
-    oc apply -f "$REPO_ROOT/memoryhub-ui/openshift/oauth-proxy-sa.yaml" -n "$UI_NAMESPACE"
+    oc apply --context "$CONTEXT" -f "$REPO_ROOT/memoryhub-ui/openshift/oauth-proxy-sa.yaml" -n "$UI_NAMESPACE"
 
     # DB credentials for the UI BFF — must use MEMORYHUB_DB_* key names
     # (the UI's Pydantic settings uses env_prefix="MEMORYHUB_"). Cannot use
     # copy_secret here because the source Secret has POSTGRES_* keys.
     info "Creating/updating memoryhub-db-credentials in $UI_NAMESPACE..."
     local ui_db_pass
-    ui_db_pass=$(oc get secret memoryhub-pg-credentials -n "$DB_NAMESPACE" \
+    ui_db_pass=$(oc get secret --context "$CONTEXT" memoryhub-pg-credentials -n "$DB_NAMESPACE" \
         -o jsonpath='{.data.POSTGRES_PASSWORD}' | base64 -d)
-    oc create secret generic memoryhub-db-credentials \
+    oc create secret --context "$CONTEXT" generic memoryhub-db-credentials \
         --from-literal=MEMORYHUB_DB_HOST=memoryhub-pg.memoryhub-db.svc.cluster.local \
         --from-literal=MEMORYHUB_DB_PORT=5432 \
         --from-literal=MEMORYHUB_DB_NAME=memoryhub \
         --from-literal=MEMORYHUB_DB_USER=memoryhub \
         --from-literal=MEMORYHUB_DB_PASSWORD="$ui_db_pass" \
-        --dry-run=client -o json | oc apply -f - -n "$UI_NAMESPACE"
+        --dry-run=client -o json | oc apply --context "$CONTEXT" -f - -n "$UI_NAMESPACE"
 
     # OAuth proxy session secret (must be exactly 32 bytes, key must be "session-secret")
-    if ! oc get secret memoryhub-ui-proxy -n "$UI_NAMESPACE" &>/dev/null; then
+    if ! oc get secret --context "$CONTEXT" memoryhub-ui-proxy -n "$UI_NAMESPACE" &>/dev/null; then
         info "Generating OAuth proxy session secret..."
-        oc create secret generic memoryhub-ui-proxy \
+        oc create secret --context "$CONTEXT" generic memoryhub-ui-proxy \
             --from-literal="session-secret=$(openssl rand -base64 32 | head -c 32)" \
             -n "$UI_NAMESPACE"
     else
@@ -463,14 +464,14 @@ prepare_ui_infra() {
 
     # Admin key for the UI BFF — copy from auth service's secret, remapping
     # the key name to match the UI's MEMORYHUB_ env prefix.
-    if oc get secret auth-admin-key -n "$AUTH_PROJECT" &>/dev/null; then
+    if oc get secret --context "$CONTEXT" auth-admin-key -n "$AUTH_PROJECT" &>/dev/null; then
         info "Creating/updating memoryhub-ui-admin-key in $UI_NAMESPACE..."
         local admin_key_val
-        admin_key_val=$(oc get secret auth-admin-key -n "$AUTH_PROJECT" \
+        admin_key_val=$(oc get secret --context "$CONTEXT" auth-admin-key -n "$AUTH_PROJECT" \
             -o jsonpath='{.data.AUTH_ADMIN_KEY}' | base64 -d)
-        oc create secret generic memoryhub-ui-admin-key \
+        oc create secret --context "$CONTEXT" generic memoryhub-ui-admin-key \
             --from-literal=MEMORYHUB_ADMIN_KEY="$admin_key_val" \
-            --dry-run=client -o json | oc apply -f - -n "$UI_NAMESPACE"
+            --dry-run=client -o json | oc apply --context "$CONTEXT" -f - -n "$UI_NAMESPACE"
     else
         warn "auth-admin-key not found in $AUTH_PROJECT — skipping memoryhub-ui-admin-key (deploy auth first or re-run without --skip-auth)"
     fi
@@ -520,7 +521,7 @@ deploy_tile() {
     fi
 
     info "Applying OdhApplication CR to $RHOAI_NAMESPACE..."
-    if ! oc apply -f "$odh_manifest" -n "$RHOAI_NAMESPACE"; then
+    if ! oc apply --context "$CONTEXT" -f "$odh_manifest" -n "$RHOAI_NAMESPACE"; then
         die "Failed to apply OdhApplication manifest."
     fi
 
@@ -535,17 +536,17 @@ print_summary() {
     banner "Deployment Summary"
 
     local cluster_url current_user
-    cluster_url=$(oc whoami --show-server 2>/dev/null || echo "(unavailable)")
-    current_user=$(oc whoami 2>/dev/null || echo "(unavailable)")
+    cluster_url=$(oc whoami --context "$CONTEXT" --show-server 2>/dev/null || echo "(unavailable)")
+    current_user=$(oc whoami --context "$CONTEXT" 2>/dev/null || echo "(unavailable)")
 
     local ui_route mcp_route auth_route rhoai_route
-    ui_route=$(oc get route memoryhub-ui -n "$UI_NAMESPACE" \
+    ui_route=$(oc get route --context "$CONTEXT" memoryhub-ui -n "$UI_NAMESPACE" \
         -o jsonpath='{.spec.host}' 2>/dev/null || echo "")
-    mcp_route=$(oc get route memory-hub-mcp -n "$MCP_PROJECT" \
+    mcp_route=$(oc get route --context "$CONTEXT" memory-hub-mcp -n "$MCP_PROJECT" \
         -o jsonpath='{.spec.host}' 2>/dev/null || echo "")
-    auth_route=$(oc get route auth-server -n "$AUTH_PROJECT" \
+    auth_route=$(oc get route --context "$CONTEXT" auth-server -n "$AUTH_PROJECT" \
         -o jsonpath='{.spec.host}' 2>/dev/null || echo "")
-    rhoai_route=$(oc get route rhods-dashboard -n "$RHOAI_NAMESPACE" \
+    rhoai_route=$(oc get route --context "$CONTEXT" rhods-dashboard -n "$RHOAI_NAMESPACE" \
         -o jsonpath='{.spec.host}' 2>/dev/null || echo "")
 
     echo ""
@@ -556,25 +557,25 @@ print_summary() {
     if [ -n "$ui_route" ]; then
         printf "    %-24s %s\n" "UI:" "https://${ui_route}"
     else
-        printf "    %-24s %s\n" "UI:" "(route not found — check: oc get route memoryhub-ui -n $UI_NAMESPACE)"
+        printf "    %-24s %s\n" "UI:" "(route not found — check: oc get route --context "$CONTEXT" memoryhub-ui -n $UI_NAMESPACE)"
     fi
 
     if [ -n "$mcp_route" ]; then
         printf "    %-24s %s\n" "MCP server:" "https://${mcp_route}/mcp/"
     else
-        printf "    %-24s %s\n" "MCP server:" "(route not found — check: oc get route -n $MCP_PROJECT)"
+        printf "    %-24s %s\n" "MCP server:" "(route not found — check: oc get route --context "$CONTEXT" -n $MCP_PROJECT)"
     fi
 
     if [ -n "$auth_route" ]; then
         printf "    %-24s %s\n" "Auth server:" "https://${auth_route}"
     else
-        printf "    %-24s %s\n" "Auth server:" "(route not found — check: oc get route auth-server -n $AUTH_PROJECT)"
+        printf "    %-24s %s\n" "Auth server:" "(route not found — check: oc get route --context "$CONTEXT" auth-server -n $AUTH_PROJECT)"
     fi
 
     if [ -n "$rhoai_route" ]; then
         printf "    %-24s %s\n" "RHOAI dashboard:" "https://${rhoai_route}"
     else
-        printf "    %-24s %s\n" "RHOAI dashboard:" "(route not found — check: oc get route rhods-dashboard -n $RHOAI_NAMESPACE)"
+        printf "    %-24s %s\n" "RHOAI dashboard:" "(route not found — check: oc get route --context "$CONTEXT" rhods-dashboard -n $RHOAI_NAMESPACE)"
     fi
 
     echo ""

--- a/scripts/restore-db.sh
+++ b/scripts/restore-db.sh
@@ -6,6 +6,7 @@
 set -euo pipefail
 
 SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}")"
+CONTEXT="${MEMORYHUB_CONTEXT:-mcp-rhoai}"
 
 DB_NAMESPACE="memoryhub-db"
 POD_LABEL="app.kubernetes.io/name=memoryhub-pg"
@@ -99,20 +100,20 @@ preflight() {
     echo "     Dump file: $DUMP_FILE ($(du -h "$DUMP_FILE" | cut -f1))"
 
     info "Verifying OpenShift login..."
-    if ! oc whoami &>/dev/null; then
+    if ! oc whoami --context "$CONTEXT" &>/dev/null; then
         die "Not logged in to OpenShift. Run 'oc login' first."
     fi
-    echo "     Logged in as: $(oc whoami)"
-    echo "     Server:       $(oc whoami --show-server)"
+    echo "     Logged in as: $(oc whoami --context "$CONTEXT")"
+    echo "     Server:       $(oc whoami --context "$CONTEXT" --show-server)"
 
     info "Locating PostgreSQL pod..."
-    PG_POD="$(oc get pod -n "$DB_NAMESPACE" \
+    PG_POD="$(oc get pod --context "$CONTEXT" -n "$DB_NAMESPACE" \
         -l "$POD_LABEL" \
         -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)"
     if [[ -z "$PG_POD" ]]; then
         die "No pod found in namespace '$DB_NAMESPACE' with label '$POD_LABEL'. Is the DB deployed?"
     fi
-    POD_PHASE="$(oc get pod "$PG_POD" -n "$DB_NAMESPACE" \
+    POD_PHASE="$(oc get pod --context "$CONTEXT" "$PG_POD" -n "$DB_NAMESPACE" \
         -o jsonpath='{.status.phase}' 2>/dev/null || true)"
     if [[ "$POD_PHASE" != "Running" ]]; then
         die "Pod '$PG_POD' is in phase '$POD_PHASE', expected 'Running'."
@@ -120,11 +121,11 @@ preflight() {
     echo "     Pod: $PG_POD (Running)"
 
     info "Reading credentials from secret '$SECRET_NAME'..."
-    PG_USER="$(oc get secret "$SECRET_NAME" -n "$DB_NAMESPACE" \
+    PG_USER="$(oc get secret --context "$CONTEXT" "$SECRET_NAME" -n "$DB_NAMESPACE" \
         -o jsonpath='{.data.POSTGRES_USER}' | base64 -d)"
-    PG_PASSWORD="$(oc get secret "$SECRET_NAME" -n "$DB_NAMESPACE" \
+    PG_PASSWORD="$(oc get secret --context "$CONTEXT" "$SECRET_NAME" -n "$DB_NAMESPACE" \
         -o jsonpath='{.data.POSTGRES_PASSWORD}' | base64 -d)"
-    PG_DB="$(oc get secret "$SECRET_NAME" -n "$DB_NAMESPACE" \
+    PG_DB="$(oc get secret --context "$CONTEXT" "$SECRET_NAME" -n "$DB_NAMESPACE" \
         -o jsonpath='{.data.POSTGRES_DB}' | base64 -d)"
 
     if [[ -z "$PG_USER" || -z "$PG_PASSWORD" || -z "$PG_DB" ]]; then
@@ -168,7 +169,7 @@ restore() {
     banner "Restore"
 
     info "Streaming dump into pod and running pg_restore..."
-    cat "$DUMP_FILE" | oc exec -i "$PG_POD" \
+    cat "$DUMP_FILE" | oc exec --context "$CONTEXT" -i "$PG_POD" \
         -n "$DB_NAMESPACE" \
         -c "$CONTAINER" \
         -- env PGPASSWORD="$PG_PASSWORD" \

--- a/scripts/uninstall-full.sh
+++ b/scripts/uninstall-full.sh
@@ -16,6 +16,7 @@
 set -euo pipefail
 
 SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}")"
+CONTEXT="${MEMORYHUB_CONTEXT:-mcp-rhoai}"
 
 DB_NAMESPACE="memoryhub-db"
 MCP_PROJECT="memory-hub-mcp"
@@ -98,11 +99,11 @@ preflight() {
     banner "Preflight"
 
     info "Verifying OpenShift login..."
-    if ! oc whoami &>/dev/null; then
+    if ! oc whoami --context "$CONTEXT" &>/dev/null; then
         die "Not logged in to OpenShift. Run 'oc login' first."
     fi
-    echo "     Logged in as: $(oc whoami)"
-    echo "     Server:       $(oc whoami --show-server)"
+    echo "     Logged in as: $(oc whoami --context "$CONTEXT")"
+    echo "     Server:       $(oc whoami --context "$CONTEXT" --show-server)"
 }
 
 # ---------------------------------------------------------------------------
@@ -168,7 +169,7 @@ backup_before_uninstall() {
     banner "Pre-Uninstall Backup"
 
     # Check if the DB pod is even running — can't back up a dead pod.
-    if ! oc get pod -l "app.kubernetes.io/name=memoryhub-pg" \
+    if ! oc get pod --context "$CONTEXT" -l "app.kubernetes.io/name=memoryhub-pg" \
             -n "$DB_NAMESPACE" &>/dev/null; then
         warn "No PostgreSQL pod found in $DB_NAMESPACE — skipping backup."
         return 0
@@ -206,33 +207,33 @@ remove_tile() {
     fi
 
     info "Removing OdhApplication/memoryhub..."
-    oc delete odhapplication memoryhub \
+    oc delete odhapplication --context "$CONTEXT" memoryhub \
         -n "$RHOAI_NAMESPACE" \
         --ignore-not-found
 
     info "Removing Route/memoryhub-ui..."
-    oc delete route memoryhub-ui \
+    oc delete route --context "$CONTEXT" memoryhub-ui \
         -n "$RHOAI_NAMESPACE" \
         --ignore-not-found
 
     info "Removing Service/memoryhub-ui..."
-    oc delete service memoryhub-ui \
+    oc delete service --context "$CONTEXT" memoryhub-ui \
         -n "$RHOAI_NAMESPACE" \
         --ignore-not-found
 
     info "Removing Endpoints/memoryhub-ui..."
-    oc delete endpoints memoryhub-ui \
+    oc delete endpoints --context "$CONTEXT" memoryhub-ui \
         -n "$RHOAI_NAMESPACE" \
         --ignore-not-found
 
     info "Removing memoryhub entry from odh-enabled-applications-config..."
-    if oc get configmap odh-enabled-applications-config \
+    if oc get configmap --context "$CONTEXT" odh-enabled-applications-config \
             -n "$RHOAI_NAMESPACE" &>/dev/null; then
         # Check if the key exists before attempting removal (oc patch fails if key is absent)
-        if oc get configmap odh-enabled-applications-config \
+        if oc get configmap --context "$CONTEXT" odh-enabled-applications-config \
                 -n "$RHOAI_NAMESPACE" \
                 -o jsonpath='{.data.memoryhub}' 2>/dev/null | grep -q .; then
-            oc patch configmap odh-enabled-applications-config \
+            oc patch configmap --context "$CONTEXT" odh-enabled-applications-config \
                 -n "$RHOAI_NAMESPACE" \
                 --type json \
                 -p '[{"op":"remove","path":"/data/memoryhub"}]'
@@ -254,7 +255,7 @@ remove_ui_namespace() {
     banner "2. UI Namespace ($UI_NAMESPACE)"
 
     info "Deleting namespace $UI_NAMESPACE (--wait=false)..."
-    oc delete namespace "$UI_NAMESPACE" \
+    oc delete namespace --context "$CONTEXT" "$UI_NAMESPACE" \
         --ignore-not-found \
         --wait=false
     warn "Namespace deletion is async; full teardown may take 30-60s."
@@ -272,22 +273,22 @@ remove_legacy_ui() {
     local ns="-n $MCP_PROJECT --ignore-not-found"
 
     info "Removing Deployment/memoryhub-ui..."
-    oc delete deployment memoryhub-ui $ns
+    oc delete deployment --context "$CONTEXT" memoryhub-ui $ns
 
     info "Removing Service/memoryhub-ui..."
-    oc delete service memoryhub-ui $ns
+    oc delete service --context "$CONTEXT" memoryhub-ui $ns
 
     info "Removing Route/memoryhub-ui..."
-    oc delete route memoryhub-ui $ns
+    oc delete route --context "$CONTEXT" memoryhub-ui $ns
 
     info "Removing ImageStream/memoryhub-ui..."
-    oc delete imagestream memoryhub-ui $ns
+    oc delete imagestream --context "$CONTEXT" memoryhub-ui $ns
 
     info "Removing BuildConfig/memoryhub-ui..."
-    oc delete buildconfig memoryhub-ui $ns
+    oc delete buildconfig --context "$CONTEXT" memoryhub-ui $ns
 
     info "Removing ServiceAccount/memoryhub-ui..."
-    oc delete serviceaccount memoryhub-ui $ns
+    oc delete service --context "$CONTEXT"account memoryhub-ui $ns
 
     echo ""
     echo -e "  ${GREEN}Legacy UI artifacts removed from $MCP_PROJECT${RESET}"
@@ -300,7 +301,7 @@ remove_mcp_namespace() {
     banner "4. MCP Namespace ($MCP_PROJECT)"
 
     info "Deleting namespace $MCP_PROJECT (--wait=false)..."
-    oc delete namespace "$MCP_PROJECT" \
+    oc delete namespace --context "$CONTEXT" "$MCP_PROJECT" \
         --ignore-not-found \
         --wait=false
     warn "Namespace deletion is async; full teardown may take 30-60s."
@@ -316,7 +317,7 @@ remove_auth_namespace() {
     banner "5. Auth Namespace ($AUTH_PROJECT)"
 
     info "Deleting namespace $AUTH_PROJECT (--wait=false)..."
-    oc delete namespace "$AUTH_PROJECT" \
+    oc delete namespace --context "$CONTEXT" "$AUTH_PROJECT" \
         --ignore-not-found \
         --wait=false
     warn "Namespace deletion is async; full teardown may take 30-60s."
@@ -337,7 +338,7 @@ remove_db_namespace() {
     fi
 
     warn "Deleting $DB_NAMESPACE — ALL STORED MEMORIES WILL BE LOST."
-    oc delete namespace "$DB_NAMESPACE" \
+    oc delete namespace --context "$CONTEXT" "$DB_NAMESPACE" \
         --ignore-not-found \
         --wait=false
     warn "Namespace deletion is async; full teardown may take 30-60s."

--- a/scripts/uninstall-full.sh
+++ b/scripts/uninstall-full.sh
@@ -288,7 +288,7 @@ remove_legacy_ui() {
     oc delete buildconfig --context "$CONTEXT" memoryhub-ui $ns
 
     info "Removing ServiceAccount/memoryhub-ui..."
-    oc delete service --context "$CONTEXT"account memoryhub-ui $ns
+    oc delete serviceaccount --context "$CONTEXT" memoryhub-ui $ns
 
     echo ""
     echo -e "  ${GREEN}Legacy UI artifacts removed from $MCP_PROJECT${RESET}"


### PR DESCRIPTION
## Summary

Two deploy hardening fixes:

1. All scripts hardcoded `--context mcp-rhoai`, making them unusable on other clusters. Now configurable via `MEMORYHUB_CONTEXT` env var, defaulting to `mcp-rhoai` for backward compatibility. Covers `deploy-full.sh`, `uninstall-full.sh`, `backup-db.sh`, and `restore-db.sh`.

2. The deploy script unconditionally created an `OdhApplication` resource, which fails on clusters without the RHOAI dashboard CRD. Now skips with a non-blocking message when the CRD is absent.

Closes #196
Closes #197

## Design reference

- `docs/admin/build-deploy-hardening.md`
- `planning/kagenti-poc-findings.md` (findings #5 and #8)

## Test plan

- [x] **Unit tests only** -- script changes, no application code
- [x] All scripts pass `bash -n` syntax validation
- [x] Default value preserves existing behavior (no breaking change)