### PR TITLE
docs: Agent memory landscape research and knowledge layer proposal

### DIFF
--- a/docs/faq-storage-architecture.md
+++ b/docs/faq-storage-architecture.md
@@ -1,0 +1,87 @@
+# Storage Architecture FAQ
+
+Common questions from colleagues and stakeholders about MemoryHub's storage architecture choices.
+
+## Why PostgreSQL + pgvector?
+
+MemoryHub's storage needs are governed assertions with provenance chains, vector similarity search, scope-isolated access control, tenant isolation, and temporal versioning. PostgreSQL handles all of these natively:
+
+- **Vector similarity search**: pgvector provides HNSW indexes for cosine distance queries over 384-dimensional embeddings. No separate vector database needed.
+- **Graph traversal**: Memory trees are shallow by design (2-3 hops of depth). PostgreSQL recursive CTEs handle this without a graph database. Phase 1 graph-enhanced retrieval is shipped and performing in production.
+- **Scope isolation**: SQL WHERE clauses enforce RBAC at the query level. Every query is filtered by tenant, scope, and authorization claims. No path-traversal ambiguity.
+- **Temporal versioning**: Version chains, soft-delete, and temporal validity on relationship edges are all standard relational patterns.
+- **Operational simplicity**: PostgreSQL ships with OpenShift. No additional product to license, deploy, monitor, or patch.
+
+## Why not Neo4j?
+
+Neo4j is an excellent graph database. MemoryHub doesn't use it for three reasons: operational dependency, deployment story, and fitness for purpose.
+
+**Operational dependency.** PostgreSQL ships with OpenShift out of the box. Neo4j is an additional product that enterprises must license (Enterprise Edition for production), deploy as a separate cluster, monitor, back up, and maintain HA for. For regulated enterprises -- MemoryHub's target market -- every dependency is a compliance surface. Adding Neo4j doubles the database operations burden for a capability PostgreSQL already provides.
+
+**Deployment story.** MemoryHub deploys with a single script (`deploy-full.sh`) that stands up everything it needs. Adding Neo4j means a second database cluster, a second backup strategy, a second HA configuration, a second set of credentials to manage. The golden test -- "uninstall and redeploy with zero manual steps" -- gets significantly harder with two database products.
+
+**Fitness for purpose.** Graph databases shine at unknown-depth recursive traversal: supply chains, social networks, fraud detection paths. MemoryHub's memory trees have bounded, shallow depth. The access patterns that matter for agent memory -- scope-filtered vector search, tenant-isolated reads, provenance chain traversal with known depth -- are relational patterns, not graph patterns.
+
+The security model is particularly instructive. In a graph database, if there's a traversal path from A to C through D but the user can't see D, the behavior is non-monotonic and role-dependent. In MemoryHub, scope isolation is enforced at the SQL level: you don't see nodes outside your authorized scopes. No path-traversal ambiguity, no information leakage through graph structure.
+
+Neo4j Agent Memory (neo4j-labs/agent-memory) is a strong project that provides richer graph traversal and a mature entity extraction pipeline. It focuses on different priorities than MemoryHub: traversal expressiveness and framework integrations over scope hierarchy, RBAC, governed compaction, and compliance. Both are valid design centers -- they serve different deployment contexts.
+
+## Do we need a graph database?
+
+It's a fair question. The reasoning usually goes: ontologies are graphs, agent memory involves relationships, therefore you need a graph database. Sakhatsky (April 2026) offers a useful counterpoint -- each step in that chain is weaker than it looks, and it's worth examining why.
+
+MemoryHub is a context graph, not a knowledge graph (see `research/knowledge-graphs-vs-context-graphs.md`). Context graphs capture decisions, experiences, and institutional memory -- the "why" and "how" of organizational operations. Knowledge graphs capture domain ontologies -- entities, taxonomies, and static relationships. These are different concerns with different access patterns.
+
+Context graph access patterns:
+
+- "Find memories similar to this query within my authorized scopes" -- vector search with SQL filters
+- "What was the rationale behind this decision?" -- parent-child traversal, 1-2 hops
+- "How has this knowledge evolved?" -- version chain traversal, linear
+- "What contradicts this assertion?" -- embedding similarity within scope, SQL query
+
+None of these require unbounded graph traversal. All of them require scope isolation, tenant filtering, and vector search -- PostgreSQL's strengths.
+
+MemoryHub does have a deferred decision point (Phase 3 of graph-enhanced memory design). If production observability shows we need:
+
+- Depth > 3 hops in production queries
+- Community detection or centrality algorithms
+- Graph neural network workloads
+- p95 latency > 200ms on graph traversal
+
+...then we evaluate Apache AGE (PostgreSQL extension for Cypher), NetworkX (in-memory for analytics), or Neo4j as a dedicated analytics sidecar. We'd rather make that decision based on observed production access patterns than predict it upfront.
+
+## Could I plug in my own storage backend?
+
+Not today, but the architecture doesn't prevent it.
+
+The storage layer sits behind a service abstraction (`services/memory.py`, `services/database.py`). An adapter pattern that swaps PostgreSQL for another backend is architecturally feasible. MemoryHub doesn't ship a pluggable interface today because:
+
+**The governance substrate is tightly coupled to SQL.** Scope isolation, tenant filtering, curation pipeline queries, similarity search, and temporal versioning are all SQL-level operations. Abstracting them into a storage-agnostic interface is a significant engineering investment with unclear demand.
+
+**Pluggability is a framework concern, not a service concern.** MemoryHub is a deployed service, not a library. Agents talk to it over MCP. They don't care what database sits behind the API. The question "can I plug in my own storage?" is really "can I deploy MemoryHub on my preferred database?" -- which is a deployment option, not a plugin architecture.
+
+**For teams with existing Neo4j investment.** If your organization already operates Neo4j and wants MemoryHub's governance model on top of it, the natural path is a Neo4j storage adapter behind the existing service interface. PostgreSQL remains the zero-dependency default; Neo4j would be an opt-in for teams that already have the operational expertise. This is tracked as a future consideration (see issue backlog).
+
+## What about Apache AGE?
+
+Apache AGE is a PostgreSQL extension that adds Cypher query support. It's the most natural evolution path if MemoryHub's graph needs outgrow recursive CTEs, because it doesn't introduce a new database product -- it extends the one we already run. AGE is under evaluation as part of the Phase 3 graph-enhanced memory decision, but only if production data shows the need. As of April 2026, AGE is still in the Apache Incubator, which means its stability and index management story are not yet production-grade for our purposes.
+
+## What about pluggable embedding models?
+
+The embedding model (currently sentence-transformers/all-MiniLM-L6-v2, 384 dimensions) is already configurable via the embedding service. Changing models requires re-embedding existing memories (a migration task), but the architecture supports it. The vector dimension is defined in one place and propagated through the schema.
+
+## Summary
+
+| Question | Short answer |
+|---|---|
+| Why PostgreSQL? | Handles all access patterns natively, ships with OpenShift, zero additional dependencies |
+| Why not Neo4j? | Additional operational dependency; our access patterns (shallow traversal, scope-filtered search) are well-served by PostgreSQL |
+| Is it a graph database? | No. It's a governed memory service that uses graph structures (trees, edges) on PostgreSQL |
+| Can I plug in Neo4j? | Not today. Architecturally feasible as a contributed adapter. Tracked as future consideration |
+| What if you outgrow PostgreSQL? | Phase 3 decision point: Apache AGE (Cypher on PostgreSQL) or Neo4j analytics sidecar, driven by production data |
+
+## Sources
+
+- Michael Sakhatsky, "You Probably Don't Need a Graph Database for Your Knowledge Graph" (April 2026)
+- Gartner, "Context Graphs" research (March 2026)
+- MemoryHub internal: `research/knowledge-graphs-vs-context-graphs.md`, `research/agent-memory-landscape-2026.md`, `docs/graph-enhanced-memory.md`

--- a/planning/knowledge-layer.md
+++ b/planning/knowledge-layer.md
@@ -131,7 +131,7 @@ Enterprise-scoped knowledge graduation requires human-in-the-loop approval. The 
 
 | Issue | Relationship |
 |---|---|
-| #170 (graph-enhanced memory) | Knowledge nodes participate in entity graph like any memory. `content_type` filter added to `_build_search_filters`, which #170's graph traversal already respects. |
+| #170 (graph-enhanced memory) | Knowledge nodes participate in entity graph like any memory. `content_type` filter added to `_build_search_filters`, which #170's graph traversal already respects. Note: #170 Phase 2 introduces `scope="entity"` for extracted entity nodes. Entity nodes can carry `content_type="knowledge"` when the entity assertion is graduated (e.g., "PostgreSQL" as a canonical entity vs "postgres" as an alias). The two dimensions compose: `scope` classifies structural role, `content_type` classifies epistemic status. |
 | #171 (knowledge compilation) | Compiled articles (`branch_type="compiled_article"`) gain a trust signal: `content_type="knowledge"` vs `"experiential"` distinguishes articles built from governed facts vs raw observations. |
 | #235 (memory promotion) | Scope promotion changes WHO can see it. Graduation changes TRUST LEVEL. These compose: graduate user-scoped memory to knowledge, then promote to project-scoped knowledge. Independent operations. |
 | #237 (behavioral memory) | `behavioral` is a third `content_type` value. Behavioral memories (agent configuration) are neither experiential observations nor graduated facts. |

--- a/planning/knowledge-layer.md
+++ b/planning/knowledge-layer.md
@@ -1,0 +1,168 @@
+# Knowledge Layer for MemoryHub
+
+**Status:** Proposal -- for discussion before implementation
+**Date:** May 2026
+**Related issues:** #170, #171, #235, #237, #240
+
+---
+
+## 1. What "Knowledge" Means in MemoryHub
+
+A **memory** is an experiential record -- a decision, preference, observation, or rationale that emerged from agent activity. It may be wrong, outdated, or contradicted. It is one agent's perspective at one point in time.
+
+A **knowledge node** is a governed assertion that has been validated through a defined process and can be trusted as a stable fact within its scope. It graduated from experiential memory, or was curated directly by an authorized actor, and carries provenance back to the evidence that supports it.
+
+Examples of knowledge:
+- "Our PostgreSQL clusters use connection pool size 25 in production" (organizational knowledge)
+- "The billing module depends on the tax-calculation service" (project knowledge)
+- "Wes prefers Podman over Docker" (user knowledge)
+
+What knowledge is NOT in MemoryHub:
+- Not an ontology or schema definition (that is RetrievalHub's domain)
+- Not a document or corpus chunk (that is retrieval, not memory)
+- Not immutable -- knowledge can be versioned, contradicted, and retired like any memory
+- Not a separate data store -- it lives in `memory_nodes` with the same governance substrate
+
+The distinction is **epistemic status**, not access level. A piece of knowledge can be user-scoped (personal domain facts) or enterprise-scoped (company-wide standards). Scope remains the access dimension; content type is the confidence dimension.
+
+
+## 2. Schema Approach: New `content_type` Column
+
+Add `content_type VARCHAR(20) NOT NULL DEFAULT 'experiential'` to `memory_nodes`.
+
+**Values:** `experiential` (default for all existing rows), `knowledge`, `behavioral` (#237).
+
+### Why this approach
+
+**Why not `branch_type`?** `branch_type` classifies the structural role of a node in the memory tree (rationale, provenance, chunk, compiled_article). A compiled article is a structural artifact that could contain either experiential summaries or graduated knowledge assertions. A knowledge node can be a root memory or a branch. These are orthogonal: `content_type` is what it IS; `branch_type` is where it SITS in the tree.
+
+**Why not `metadata_`?** Metadata is extensible JSON for application-specific tags. Making content type a JSON key means it cannot be indexed efficiently, filtered at the SQL level, or enforced with a CHECK constraint. Every search query that needs to distinguish knowledge from memory would require JSON path extraction. Content type is a first-class dimension, not an afterthought.
+
+**Why not a new table?** A separate `knowledge_nodes` table would duplicate the governance substrate (RBAC, tenant isolation, versioning, contradiction detection, embedding, soft-delete). Knowledge nodes need all of these. The column approach reuses everything and adds one indexed filter dimension.
+
+**Why not a new scope?** Scope is about ACCESS (who can see it). Content type is about TRUST LEVEL (how confident are we). These compose: user-scoped knowledge, project-scoped knowledge, enterprise-scoped knowledge. Conflating them into a single dimension forces a false choice.
+
+**Backward compatibility:** `DEFAULT 'experiential'` means existing rows are automatically classified. Existing searches return all content types unless the caller explicitly filters. No existing behavior changes.
+
+
+## 3. Database Layer Changes
+
+### No change to database product
+
+PostgreSQL + pgvector remains the correct choice. Knowledge nodes have the same access patterns as memories: vector similarity search, scope-filtered queries, shallow graph traversal via recursive CTEs, tenant isolation. Nothing about knowledge requires a graph database, a triple store, or OWL reasoning. Sakhatsky's critique applies: the value is in governed assertions, not graph topology.
+
+### Alembic migration 015
+
+```
+1. ADD COLUMN content_type VARCHAR(20) NOT NULL DEFAULT 'experiential'
+2. ADD CHECK (content_type IN ('experiential', 'knowledge', 'behavioral'))
+3. CREATE INDEX ix_memory_nodes_content_type ON memory_nodes (content_type)
+4. CREATE INDEX ix_memory_nodes_content_type_scope ON memory_nodes (content_type, scope)
+```
+
+No backfill needed. Non-destructive, reversible.
+
+### Model changes
+
+- `MemoryNode`: add `content_type: Mapped[str]` with `default="experiential"`
+- `schemas.py`: add `ContentType(StrEnum)` with values `experiential`, `knowledge`, `behavioral`
+- `MemoryNodeCreate`: add optional `content_type` field (default `experiential`)
+- `MemoryNodeRead` / `MemoryNodeStub`: include `content_type` in response
+
+
+## 4. MCP Tool Surface
+
+### Modified actions
+
+**`search`** -- Add optional `content_type` filter to `_SEARCH_OPTS`. When set, SQL filter includes `MemoryNode.content_type == content_type`. When omitted, searches all content types (backward compatible).
+
+**`write`** -- Add optional `content_type` to `_WRITE_OPTS`. Default `experiential`. Direct write of `content_type="knowledge"` is restricted: requires either (a) service identity (compilation service, curator agent), or (b) a `memory:knowledge_curator` role claim. Regular agents write experiential memories; knowledge is produced through graduation.
+
+**`list`** -- Add optional `content_type` filter to `_LIST_OPTS`.
+
+**`read`** -- Response includes `content_type` in the output (no input change needed).
+
+### New action: `graduate`
+
+```
+graduate(memory_id, [options: {evidence, reviewer_note}])
+```
+
+Graduates an experiential memory to knowledge:
+
+1. Validates the memory exists, is current, is `content_type="experiential"`
+2. Checks authorization (curator role or service identity)
+3. Creates a new version with `content_type="knowledge"`, `version=N+1`
+4. Creates a `derived_from` relationship from knowledge version to experiential version
+5. If `evidence` is provided, creates a child branch with `branch_type="evidence"`
+6. Records graduation metadata: `metadata_.graduation = {graduated_by, graduated_at, reviewer_note}`
+
+Authorization: requires `memory:knowledge_curator` role or service identity. Graduation is a governed write -- not available to any agent that can write experiential memories.
+
+Graduation does NOT change scope. A user-scoped experiential memory graduates to user-scoped knowledge. Scope promotion (#235) is a separate operation that composes with graduation but is not coupled to it.
+
+### No separate `knowledge_search` action
+
+`search(query=..., options={content_type: "knowledge"})` achieves the same result without action proliferation. Consistent with the single-tool design principle.
+
+
+## 5. Graduation Pipeline
+
+### Phase 1: Manual graduation (ship with the column)
+
+A curator agent or human operator calls `graduate(memory_id=..., options={evidence: "...", reviewer_note: "..."})`. The action creates a governed knowledge node with provenance. Simple, auditable, manually triggered.
+
+### Phase 2: Automatic candidate detection (after #170)
+
+The curation scanner gains a periodic rule that identifies graduation candidates:
+
+- Memories with 3+ contradiction reports all resolved as `keep_old` (stable under challenge)
+- Memories with high weight (>= 0.9) current for > 30 days without contradiction
+- Memories that are `derived_from` targets for 3+ other memories (heavily referenced)
+
+Candidates are flagged (`metadata_.graduation_candidate = true`), not auto-graduated. A curator reviews and calls `graduate` explicitly.
+
+### Phase 3: Enterprise approval workflow (deferred)
+
+Enterprise-scoped knowledge graduation requires human-in-the-loop approval. The graduation is queued, an approver reviews, and the action completes only after sign-off. Details deferred to the enterprise governance track.
+
+
+## 6. Interaction with Existing Roadmap
+
+| Issue | Relationship |
+|---|---|
+| #170 (graph-enhanced memory) | Knowledge nodes participate in entity graph like any memory. `content_type` filter added to `_build_search_filters`, which #170's graph traversal already respects. |
+| #171 (knowledge compilation) | Compiled articles (`branch_type="compiled_article"`) gain a trust signal: `content_type="knowledge"` vs `"experiential"` distinguishes articles built from governed facts vs raw observations. |
+| #235 (memory promotion) | Scope promotion changes WHO can see it. Graduation changes TRUST LEVEL. These compose: graduate user-scoped memory to knowledge, then promote to project-scoped knowledge. Independent operations. |
+| #237 (behavioral memory) | `behavioral` is a third `content_type` value. Behavioral memories (agent configuration) are neither experiential observations nor graduated facts. |
+| #240 (extraction pipeline) | Extraction writes `content_type="experiential"` always. Graduation is a separate, downstream process. |
+
+
+## 7. RetrievalHub Boundary
+
+This proposal **preserves** the boundary defined in `strategy/platform-architecture.md`.
+
+**MemoryHub knowledge:** Governed assertions that graduated from agent experience. "We use connection pool size 25" is knowledge derived from operational decisions, deployment configurations observed by agents, and team preferences accumulated over time. It is experiential knowledge made durable.
+
+**RetrievalHub knowledge:** Curated reference material from external sources. Architecture documents, compliance standards, API specifications, vendor documentation. It enters the system through ingestion pipelines, not through agent experience.
+
+The test: if the fact emerged from operational history, it is MemoryHub knowledge. If it would exist regardless of any agent's experience (documentation, standards, reference data), it is RetrievalHub's domain.
+
+What this proposal explicitly does NOT do:
+- No document ingestion pipeline
+- No ontology or schema definition language
+- No external knowledge source connectors
+- No SPARQL, OWL, or RDF
+
+MemoryHub's knowledge layer is the experience-to-assertion pipeline. RetrievalHub is the corpus-to-answer pipeline.
+
+
+## 8. Open Questions
+
+1. **Should `content_type` be mutable via `update`, or only via `graduate`?** Recommendation: only via `graduate`. Prevents bypassing the governed graduation path.
+
+2. **Minimum weight floor for knowledge nodes?** Graduated knowledge could auto-set `weight >= 0.85` to ensure it ranks above experiential memories in mixed searches. Or leave weight orthogonal.
+
+3. **Knowledge boost in mixed search results?** Add a `knowledge_boost_weight` parameter (similar to `domain_boost_weight` in RRF) that lifts knowledge results when searching all content types.
+
+4. **Naming: `graduate` vs `certify` vs `curate`?** `graduate` is consistent with the language in #235 and the research docs. `certify` implies a stronger guarantee than we intend. `curate` is overloaded (already used for the curation subsystem).

--- a/research/agent-memory-landscape-2026.md
+++ b/research/agent-memory-landscape-2026.md
@@ -28,7 +28,7 @@ None of these sources are affiliated with or aware of MemoryHub.
 
 Three independent sources converge on the same conclusion: enterprise AI agents need governed, externalized memory with explicit relationships -- but the path to getting there is not "buy a graph database."
 
-Every deployed personal AI agents company-wide and discovered that personal agents create maintenance burden, context isolation, and knowledge fragility. Their pivot to shared team agents validates MemoryHub's scope-hierarchy design. Gartner defines "context graphs" (decision traces + procedural knowledge) as distinct from knowledge graphs (entities + ontologies) and predicts 50%+ of AI agent systems will use them by 2028. MemoryHub is architecturally a context graph. Sakhatsky argues that most teams don't need a graph database at all -- PostgreSQL with recursive CTEs handles shallow traversal, and the real value is in rules and inference, not graph topology. This validates MemoryHub's choice of PostgreSQL + pgvector over Neo4j.
+Every deployed personal AI agents company-wide and discovered that personal agents create maintenance burden, context isolation, and knowledge fragility. Their pivot to shared team agents validates MemoryHub's scope-hierarchy design. Gartner defines "context graphs" (decision traces + procedural knowledge) as distinct from knowledge graphs (entities + ontologies) and predicts 50%+ of AI agent systems will use them by 2028. MemoryHub's architecture aligns with Gartner's context graph definition -- it stores decision traces, rationale branches, and procedural knowledge rather than entity ontologies. Sakhatsky argues that most teams don't need a graph database at all -- PostgreSQL with recursive CTEs handles shallow traversal, and the real value is in rules and inference, not graph topology. This validates MemoryHub's choice of PostgreSQL + pgvector over Neo4j.
 
 ---
 
@@ -84,6 +84,8 @@ Every is pivoting to "shared team resources with defined jobs" rather than "indi
 
 
 ## Mapping to MemoryHub Capabilities
+
+*Note: Some capabilities below are design-stage and not yet deployed. Entity extraction (#170 Phase 2), the extraction pipeline (#240), conversation persistence (#168), and governed compaction (#169) are designed but not yet implemented. Scope hierarchy, RBAC, contradiction detection, versioning, and provenance tracking are shipped.*
 
 ### Context isolation --> Scope hierarchy
 

--- a/research/agent-memory-landscape-2026.md
+++ b/research/agent-memory-landscape-2026.md
@@ -1,0 +1,287 @@
+# Agent Memory Landscape Analysis (May 2026)
+
+This document surveys the emerging agent memory landscape through three external sources and maps their findings to MemoryHub's architecture, identifying validations, gaps, and design guardrails.
+
+## Sources
+
+1. **"We Gave Every Employee an AI Agent. Here's What We're Doing Differently Now"**
+   Authors: Brandon Gell (COO) and Willie Williams (Head of Platform), Every
+   Published: May 2026
+   Focus: Field report on deploying personal AI agents company-wide; pivot to shared team agents.
+
+2. **"Gartner on Context Graphs: Top Insights, Capabilities & Implementation Recommendations for 2026"**
+   Author: Emily Winks, Atlan
+   Published: March 2026 (updated April 2026)
+   Focus: Gartner's definition of context graphs as distinct from knowledge graphs; decision tracing; institutional memory for agentic AI.
+
+3. **"You Probably Don't Need a Graph Database for Your Knowledge Graph"**
+   Author: Michael Sakhatsky
+   Published: April 2026
+   Focus: Critique of the assumption chain from "we need institutional knowledge" to "we need Neo4j"; case for rules engines and Datalog over graph databases.
+
+Additionally, **Neo4j Agent Memory** (neo4j-labs/agent-memory, v0.2-0.3) was reviewed as the most direct open-source competitor.
+
+None of these sources are affiliated with or aware of MemoryHub.
+
+
+## Executive Summary
+
+Three independent sources converge on the same conclusion: enterprise AI agents need governed, externalized memory with explicit relationships -- but the path to getting there is not "buy a graph database."
+
+Every deployed personal AI agents company-wide and discovered that personal agents create maintenance burden, context isolation, and knowledge fragility. Their pivot to shared team agents validates MemoryHub's scope-hierarchy design. Gartner defines "context graphs" (decision traces + procedural knowledge) as distinct from knowledge graphs (entities + ontologies) and predicts 50%+ of AI agent systems will use them by 2028. MemoryHub is architecturally a context graph. Sakhatsky argues that most teams don't need a graph database at all -- PostgreSQL with recursive CTEs handles shallow traversal, and the real value is in rules and inference, not graph topology. This validates MemoryHub's choice of PostgreSQL + pgvector over Neo4j.
+
+---
+
+# Part 1: Every's Plus One Field Report
+
+
+## Key Findings from Every's Experience
+
+### Platform instability destroying accumulated context
+
+Every built Plus One on OpenClaw, which they describe as "powerful and inherently unstable." The harness's rapid update cycle resolved existing issues but routinely caused new ones. Concrete failures:
+
+- Agents sent "Terminated" messages or responded with "a churlish yawning emoji."
+- Agents claimed they were not connected to apps they were connected to (email, Notion, PostHog).
+- After "months of silence," an agent named Zosia interjected in a Slack channel with unsolicited opinions on a competitor's marketing strategy, replying that she'd done so because she was "inevitable, apparently."
+
+The core concern is that upgrading the harness risks "forgetting everything you've told them and trained them to do." Agent knowledge was coupled to a specific harness version, making updates destructive.
+
+### Maintenance burden on individuals
+
+Every's model assigned each employee responsibility for their own agent. This created an asymmetric burden:
+
+> "Every time an agent broke, the person it belonged to had to fix it themselves."
+
+> "For every tinkerer, there are a lot of people who want the benefits of an agent without the obligation of having to manage and mend it."
+
+Getting agents to work required "constant upkeep." The article explicitly contrasts tinkerers (who tolerate instability as part of the appeal) with the majority of employees who want reliable tools. The personal-agent model failed the majority.
+
+### Context isolation and siloed knowledge
+
+Personal agents only learned from their individual owner's interactions, missing organizational knowledge:
+
+> "A one-on-one employee only builds up context on your work, often missing out on what the rest of the organization is doing and how it might affect you."
+
+The article frames good agent traits as identical to good coworker traits: "reliability, stability, and judgment" plus the ability to "absorb information from across the company to accrue tribal knowledge." Personal agents could not do the latter by construction.
+
+### Knowledge fragility and employee departure risk
+
+Agent knowledge was tightly coupled to the individual who trained it:
+
+> "A personal agent's value is tied to whomever trained it, and disappears if that employee leaves."
+
+There was no continuity mechanism. When an employee left, their agent's accumulated context, preferences, and learned behaviors disappeared with them.
+
+### Their solution direction
+
+Every is pivoting to "shared team resources with defined jobs" rather than "individual pets that reflect back their owners' personalities." Specific moves:
+
+- Exploring Claude Managed Agents as a more stable harness, noting that "the autonomous, always-on capabilities OpenClaw pioneered are becoming platform features at model companies."
+- Building shared skills. Example: a weekly engineering skill that scans Intercom support tickets, traces likely causes in GitHub, opens a Linear ticket, and tags the right person in Slack.
+- Maintaining per-user connections (email, writing tools) within shared agents.
+- Open questions they have not yet resolved: permissions for shared agents, per-department vs. company-wide agents, how much customization of shared agents, whether a "single, company-wide superagent or a roster of AI specialists" is the right model.
+
+
+## Mapping to MemoryHub Capabilities
+
+### Context isolation --> Scope hierarchy
+
+Every's central complaint is that personal agents build up siloed knowledge. MemoryHub's scope hierarchy (user, project, organizational, enterprise) addresses this directly. A team agent authenticates with project or organizational scope and reads memories spanning the entire team's knowledge base. Individual contributions are preserved at user scope and accessible to the team agent when needed, but organizational context flows naturally through higher scopes.
+
+### Knowledge fragility --> Externalized, governed memory
+
+When an Every employee leaves, their agent's knowledge leaves with them. In MemoryHub, knowledge written at project, organizational, or enterprise scope persists regardless of individual user churn. Versioning preserves history, and provenance tracking records who contributed what, so departures don't create knowledge gaps. User-scoped memories can be retained or purged per policy (GDPR Art. 17 right to erasure applies here).
+
+### Permissions for shared agents --> RBAC with operational scopes
+
+Every explicitly flags permissions as an open question for shared agents. MemoryHub already implements RBAC with operational scopes (memory:read, memory:write, memory:admin) crossed with access tiers. A team agent authenticates via client_credentials and receives scoped JWT claims. Different users interacting through the same agent can have different effective permissions based on their identity, not the agent's identity.
+
+### Platform instability --> Harness-agnostic design
+
+Every's OpenClaw updates destroyed accumulated agent context because knowledge was stored inside the harness. MemoryHub externalizes memory from the harness entirely. Switching harnesses (OpenClaw to Claude Managed Agents to anything else) does not forfeit accumulated knowledge. The memory substrate is independent of the execution layer. This is exactly the decoupling Every needs but does not yet have.
+
+### Audit and compliance --> EU AI Act readiness
+
+Not a pain point Every raised (they are a media company, not a regulated enterprise), but relevant for MemoryHub's target market. EU AI Act Article 12 audit trails, GDPR Art. 17 right to erasure, versioning, and provenance tracking are built into the governance substrate. Regulated enterprises deploying team agents need these properties; SaaS agent platforms generally do not provide them.
+
+### Contradiction detection --> Curation subsystem
+
+When multiple users interact with a shared agent, conflicting instructions are inevitable. MemoryHub's curation subsystem detects contradictions between memories and surfaces them for resolution. Every does not mention this problem yet, but it is a predictable consequence of their pivot to shared agents.
+
+
+## Identified Gaps
+
+The article surfaces five areas where MemoryHub does not have explicit answers today.
+
+### 1. Memory promotion/graduation workflow
+
+You can write at any scope in MemoryHub, but there is no explicit workflow for identifying user-scoped memories that should be promoted to project or organizational scope. A user discovers something valuable through personal use; currently the only path to sharing it is to write a new memory at a higher scope manually. There is no "promote this memory" action that preserves provenance (original author, original creation date, promotion rationale) while changing scope. This is the operational bridge between "personal pet" and "team resource" that Every is trying to cross.
+
+### 2. Team agent identity model
+
+Auth supports client_credentials for service accounts, but there is no documented pattern for a "team agent" identity: one agent that multiple users interact with, reading from project/org scope by default, writing to project scope, and conditionally reading user-scope memories when acting on behalf of a specific user. The token_exchange grant (RFC 8693) in the auth design was intended for this scenario (agent presents a user's token to act on their behalf) but the pattern has not been fleshed out or documented. Every's open question about "how permissions should work" for shared agents maps directly here.
+
+### 3. Behavioral memory as a first-class concept
+
+Every's agents had personalities, communication styles, and standing instructions baked into their harness configuration. When the harness broke, these were lost. MemoryHub could store agent behavior configuration (personality, communication style, tool preferences, standing instructions) as structured, restorable memory objects with a dedicated domain or metadata schema. This would let you reconstruct an agent from memory alone regardless of harness. The current "experiential/provenance" framing does not explicitly cover behavioral configuration as a memory type.
+
+### 4. Workflow state persistence
+
+Every's shared engineering skill (scan Intercom, trace in GitHub, open Linear ticket, tag in Slack) is a recurring workflow agent. Such agents need durable state: last processed ticket timestamp, topics already covered, in-progress work items. This is adjacent to conversation thread persistence (#168) but distinct. Thread persistence is about conversation history; workflow state persistence is about checkpoint data for recurring automated tasks. MemoryHub does not currently have a pattern for this.
+
+### 5. Memory consolidation across users
+
+When multiple users teach a shared agent the same lesson (e.g., "always check the staging environment before deploying"), the system needs convergent learning: recognize near-duplicates and strengthen weight rather than storing N copies. Contradiction detection catches conflicts, but convergent learning is a different problem. It requires near-duplicate detection (which the `similar` action provides) combined with an automatic or semi-automatic merge-and-strengthen workflow. The pieces exist but the workflow does not.
+
+
+## Strategic Implications
+
+**The industry is moving from personal agents to team agents.** Every's pivot is not an isolated decision. It reflects a structural problem with personal agents: maintenance burden scales linearly with headcount, knowledge is fragmented, and continuity is fragile. Team agents with shared memory are the natural next step, and MemoryHub's scope hierarchy was designed for exactly this transition.
+
+**Model labs are handling the harness layer.** Every explicitly notes that "the autonomous, always-on capabilities OpenClaw pioneered are becoming platform features at model companies like Anthropic and OpenAI." This frees the market to focus on the memory and context layer. MemoryHub occupies this layer.
+
+**Self-hosted and regulated enterprises need self-hosted memory.** Every is a small media company comfortable with SaaS tools. Government, financial services, healthcare, and defense organizations deploying team agents cannot use SaaS agent memory. They need something that runs on their infrastructure with their compliance controls. MemoryHub on OpenShift addresses this market directly.
+
+**Claude Managed Agents and MemoryHub are complementary.** Every is exploring Claude Managed Agents as their next harness. Managed Agents provides the execution infrastructure; it does not include a governed, persistent memory substrate. MemoryHub provides exactly what Managed Agents does not: externalized memory with RBAC, versioning, scope hierarchy, and compliance controls.
+
+**Both agent topology models work with the same memory infrastructure.** Every's open question -- "single, company-wide superagent or a roster of AI specialists" -- does not require choosing one memory architecture over another. A superagent reads from all scopes; specialist agents read from their relevant project scope plus organizational/enterprise scope. MemoryHub's scope model supports both topologies without modification.
+
+
+---
+
+# Part 2: Context Graphs vs Knowledge Graphs (Gartner / Atlan)
+
+## The distinction that matters
+
+Gartner draws a clean line between two types of graph infrastructure:
+
+- **Knowledge graphs** provide the semantic layer: entities, ontologies, taxonomies, and conceptual relationships. They encode what things ARE.
+- **Context graphs** provide the procedural layer: decision traces, workflow logic, event traces, and tribal knowledge. They encode how things HAPPEN.
+
+Gartner's position: context graphs augment knowledge graphs, they don't replace them. Together they give AI agents "both the understanding and the judgment needed to act reliably in complex enterprise environments."
+
+## MemoryHub is a context graph
+
+Mapping Gartner's context graph definition to MemoryHub's architecture:
+
+**Decision traces.** Gartner defines decision traces as "searchable, replayable records of how situations have been handled before, enabling agents to ground their reasoning in institutional reality rather than statistical inference alone." MemoryHub's rationale branches (`branch_type="rationale"`) are literally this. The memory tree captures what was decided, why, by whom, and how understanding evolved through versioning.
+
+**Institutional memory.** Gartner says context graphs solve "AI's institutional memory gap" -- agents can act but cannot reliably remember how an organization operates. MemoryHub's scope hierarchy (user, project, organizational, enterprise) is purpose-built for this: organizational-scope memories encode how the org works, project-scope memories encode how specific teams work.
+
+**Continuous learning.** Gartner's fourth critical capability is "continuous learning mechanisms that allow AI agents to improve over time." MemoryHub's versioning, contradiction detection, and curation subsystem provide exactly this -- memories evolve, conflicts are surfaced, and knowledge quality improves over time.
+
+**Decision tracing for guardrails, observability, evaluation, and self-learning.** Gartner calls these "the four pillars of trustworthy agentic systems." MemoryHub's provenance tracking, audit trails, and EU AI Act compliance posture address guardrails and observability. The curation subsystem addresses evaluation. The extraction pipeline (#240) will address self-learning.
+
+## Where context graphs reinforce MemoryHub's roadmap
+
+Gartner's four critical capabilities map to existing or planned MemoryHub features:
+
+| Gartner capability | MemoryHub status |
+|---|---|
+| Capture decision traces | Implemented (rationale branches, versioning, provenance) |
+| Build context-aware lineage graphs | Partially implemented (relationships, parent/child); #170 will enrich this |
+| Enable AI observability | Implemented (audit trails, EU AI Act compliance) |
+| Continuous learning | Partially implemented (curation); #240 (extraction pipeline) will complete |
+
+## The naming question
+
+Gartner's taxonomy sharpens a naming debate we've encountered: a colleague refers to MemoryHub as "agent knowledge" while we call it "agent memory." In Gartner's framing, "knowledge" implies the knowledge graph side (entities, ontologies, what things ARE) while "memory" implies the context graph side (experiences, decisions, how things HAPPEN). MemoryHub is firmly the latter. "Agent memory" is the correct name; "agent knowledge" would position us as a knowledge graph, which we are not.
+
+
+---
+
+# Part 3: The Case Against Graph Databases (Sakhatsky)
+
+## The argument
+
+Sakhatsky challenges the assumption chain: "we need institutional knowledge" -> "we need an ontology" -> "ontologies are RDF graphs" -> "we need a graph database." He argues each link is weaker than it looks.
+
+His key points:
+
+**Graph databases solve a narrow problem well.** Their real strength is recursive traversal of unknown depth -- supply chains, network paths, social graphs. Traditional RDBMS with recursive CTEs (SQL:1999) handle known-depth traversal adequately.
+
+**Three types of "relationships matter" are conflated.** (1) Existence -- the fact that A connects to B is itself information. (2) Traversal -- can I get from A to C through some chain? (3) Semantics -- what does the edge mean, and can I reason over it? Graph databases handle existence and traversal. They do not handle semantics -- that's the domain of logic, not graph theory.
+
+**Graph databases store facts but not rules.** In description logic terms, they store A-Boxes (assertions) but not T-Boxes (terminology and rules). SPARQL, Cypher, and Gremlin can't do inference. You need external reasoners, which complicates the pipeline.
+
+**The security model is non-monotonic.** If there's a path from A to C through D but the user can't see D, what happens? Graph databases don't have a clean answer. The model becomes role-dependent in ways that undermine trust.
+
+**His alternative:** Expose existing enterprise rules to LLMs through MCP servers. Use Datalog or Prolog for inference where needed. Build on assets the company already has.
+
+## Why this validates MemoryHub's storage choice
+
+MemoryHub uses PostgreSQL + pgvector, not Neo4j. Sakhatsky's framework explains why this is the right call:
+
+**Our traversal is shallow.** Memory trees have known, bounded depth. Parent/child relationships, rationale branches, and explicit edges between memories don't require unbounded recursive traversal. PostgreSQL recursive CTEs handle this without a graph database.
+
+**Our security model is clean.** MemoryHub's scope isolation is implemented at the SQL level -- you don't see memories outside your authorized scopes, period. No path-traversal ambiguity, no non-monotonic role-dependent visibility. This is a real advantage over graph database approaches.
+
+**No graph DB dependency for deployment.** PostgreSQL ships with OpenShift out of the box. Neo4j is an additional operational dependency that enterprises must license, deploy, and maintain. For self-hosted enterprise deployments, fewer dependencies is a significant advantage.
+
+**Semantic similarity + governed relationships > graph topology.** MemoryHub combines vector search (semantic similarity) with explicit relationships (governed edges between memories) and scope-based access control. This hybrid is more useful for agent memory than Cypher queries over a property graph.
+
+## Design guardrail for #170
+
+Sakhatsky's critique is a useful guardrail as we scope graph-enhanced memory (#170). The value of #170 should be:
+
+- Richer metadata on edges (relationship types, weights, directionality)
+- Better traversal of shallow memory trees (2-3 hops, not unbounded)
+- Entity extraction from memory content for cross-referencing
+
+The value of #170 should NOT be:
+
+- Building a general-purpose graph query engine on PostgreSQL
+- Implementing Cypher-like traversal syntax
+- Replicating Neo4j's analytics capabilities (centrality, community detection)
+- Drifting toward "Neo4j lite" when PostgreSQL + pgvector already handles our access patterns
+
+The author's warning about over-investing in graph infrastructure when simpler tools work applies directly. MemoryHub's graph features should serve agent memory use cases, not graph theory use cases.
+
+
+---
+
+# Part 4: Competitive Landscape -- Neo4j Agent Memory
+
+## Overview
+
+Neo4j Agent Memory (neo4j-labs/agent-memory) is the most direct open-source competitor. It provides a graph-native memory system for AI agents with three memory types: short-term (conversations), long-term (knowledge graph with POLE+O model), and reasoning memory (traces and tool usage).
+
+## What they have that MemoryHub doesn't (yet)
+
+- **Automatic entity extraction pipeline** (spaCy -> GLiNER -> LLM) that pulls structure from conversations without explicit writes.
+- **Reasoning traces as first-class memory** -- captures tool usage, reasoning steps, and outcomes.
+- **Short-term / conversation memory** alongside long-term (MemoryHub's #168 is designed for this).
+- **Framework-specific integrations** with 8+ frameworks (LangChain, PydanticAI, Google ADK, Strands, CrewAI, LlamaIndex, OpenAI Agents, Microsoft Agent).
+- **Entity resolution and deduplication** with configurable strategies.
+- **Eval harness** for labelled regression tests on memory quality.
+
+## What MemoryHub has that they don't
+
+- **Scope hierarchy with RBAC.** They have `user_identifier` for basic multi-tenancy; MemoryHub has user/project/organizational/enterprise with fine-grained operational scopes (memory:read, memory:write, memory:admin).
+- **Contradiction detection and curation.** They have deduplication; MemoryHub has a curation subsystem that catches conflicting memories and surfaces them for resolution.
+- **Compliance posture.** Their `:TOUCHED` audit edges are experimental (Neo4j Labs status); MemoryHub's EU AI Act readiness is a design-level commitment.
+- **No graph DB dependency.** They require Neo4j. MemoryHub runs on PostgreSQL + pgvector, which ships with OpenShift.
+- **Governed compaction** (on roadmap, #169). Not in their vocabulary.
+- **Memory tree with provenance.** Their model is flat entities with edges; MemoryHub has versioned, branching memory trees with explicit provenance chains.
+- **Campaign system** for cross-project knowledge sharing. No equivalent.
+
+## Key architectural difference
+
+Neo4j Agent Memory is a graph-first system that happens to support agents. MemoryHub is a governance-first system that happens to use graph structures. The priorities invert: they optimize for traversal expressiveness; we optimize for access control, provenance, and compliance. For regulated enterprises, MemoryHub's priorities are the right ones.
+
+
+---
+
+# Synthesis: Issues Filed
+
+| Issue | Title | Source |
+|---|---|---|
+| #235 | Memory promotion workflow (user -> project/org scope) | Every case study |
+| #236 | Team agent identity model with delegated user access | Every case study |
+| #237 | Behavioral memory for agent reconstruction | Every case study |
+| #238 | Workflow checkpoint state for recurring tasks | Every case study |
+| #239 | Convergent learning to consolidate duplicate memories | Every case study |
+| #240 | SDK extraction pipeline for agent trace observation | Neo4j Agent Memory comparison, Gartner context graphs |
+
+Additionally, #170 (graph-enhanced memory) was prioritized to near-term, informed by all three sources. Design guardrails from Sakhatsky's critique should be applied when scoping that work.

--- a/research/knowledge-graphs-vs-context-graphs.md
+++ b/research/knowledge-graphs-vs-context-graphs.md
@@ -1,0 +1,125 @@
+# Knowledge Graphs vs Context Graphs: Untangling the Confusion
+
+## Why people conflate them
+
+When someone says "we need to give our AI agents knowledge," two very different infrastructure conversations collapse into one. Both involve graphs. Both get filed under "AI grounding." Both show up in the same vendor pitches and Gartner reports. But they solve fundamentally different problems, and treating them as interchangeable leads to architectural decisions that leave half the problem unsolved.
+
+The short version: knowledge graphs encode what things ARE. Context graphs encode how things HAPPEN. An agent needs both to be useful, and they are not the same system.
+
+
+## Knowledge graphs: the semantic layer
+
+A knowledge graph is a structured representation of domain entities and their relationships. It encodes ontology -- the formal description of concepts, properties, and constraints in a domain.
+
+A simple example:
+
+```
+Customer --places--> Order --contains--> Product
+Product --belongs_to--> Category
+Customer --writes--> Review --for--> Product
+```
+
+This tells a system what exists, how things are classified, and how entities relate to each other. The entities and relationships are relatively static. A customer placing an order doesn't change the fact that customers can place orders.
+
+Knowledge graphs answer questions like:
+- What products are in the "electronics" category?
+- Which customers have ordered from this supplier?
+- How are these three entities connected?
+
+The key property: knowledge graphs describe the domain, not any particular decision or experience within it. They are the vocabulary. If you deleted every record of every decision ever made, the ontology would still be valid.
+
+Standards in this space include RDF, OWL, SPARQL, and the labeled property graph model used by Neo4j. Gartner calls this the "semantic layer."
+
+
+## Context graphs: the procedural layer
+
+A context graph captures how an organization actually operates -- the decisions, workflows, reasoning traces, and institutional memory that accumulate through experience.
+
+A context graph records things like:
+
+- "We approved a 20% discount for Acme Corp because their contract renewal was at risk and the regional VP signed off on 2026-03-15."
+- "The deploy failed because the staging environment wasn't updated first. This has happened three times; the team now checks staging as a standard pre-deploy step."
+- "User prefers concise responses and avoids hyperbolic language. Learned over 12 interactions."
+
+These are not domain facts. They are experiential records -- decisions that were made, why they were made, who made them, what precedent they set, and how understanding evolved over time.
+
+Context graphs answer questions like:
+- How was a similar situation handled last time?
+- What is this user's communication preference?
+- Why was this exception approved?
+- What tribal knowledge exists about this workflow?
+
+The key property: context graphs describe decisions and experiences, not the domain itself. They are the judgment. If you deleted the domain ontology, the decision records would still be meaningful -- you'd just lack the vocabulary to classify them.
+
+Gartner defines context graphs as purpose-built infrastructure for agentic AI, predicting that more than 50% of AI agent systems will use them by 2028. Their framing: context graphs augment knowledge graphs with the "why" and "how" that systems of record always miss.
+
+
+## The four levels of agent memory
+
+The context graph side of this distinction has its own depth. It's not just "chat history." Alex Booker and the team at Mastra have articulated a useful four-level framework that shows the progression from naive memory to sophisticated institutional recall.
+
+### Level 1: Conversation history
+
+The most common approach. With each request, the client sends a window of previous messages to the model. It works for 10-20 messages, but eventually the history becomes too large, context drifts, and starting a new thread means starting from scratch.
+
+This is context graph territory -- it captures what happened in a conversation -- but it's the most primitive version. No persistence across sessions, no selectivity about what matters.
+
+### Level 2: Working memory
+
+A structured scratch pad with predefined fields. The agent watches for values to fill in (user name, current goal, stated preferences) and carries them throughout the session. It augments the system prompt, keeping critical facts stable even as the conversation window slides.
+
+Still context graph territory. Working memory captures user preferences and session goals -- experiential knowledge, not domain ontology. Its limitation: you have to predefine the fields, which isn't very agentic.
+
+### Level 3: Semantic recall
+
+Vector search over past interactions. When a new message arrives, the system embeds it and queries a vector store for semantically similar past messages, selectively injecting relevant history into the context window. This works across threads and scales to long histories.
+
+This is where the knowledge graph / context graph conflation gets most tempting. Semantic recall uses the same embedding + vector search infrastructure that knowledge graph RAG uses. But the *content* being searched is experiential (past conversations, past decisions) rather than ontological (domain entities and relationships). The retrieval mechanism is shared; the knowledge type is different.
+
+### Level 4: Observational memory
+
+The most sophisticated level. Background observer and reflector agents continuously process the conversation, compressing raw messages into dense observations with priority indicators and temporal annotations. The reflector further compresses observations over time, mimicking how human memory retains what matters and lets irrelevant details fade.
+
+This is pure context graph infrastructure. It models institutional memory -- the accumulation and distillation of experiential knowledge over time. A knowledge graph doesn't do this because it doesn't capture experiences in the first place.
+
+### The takeaway
+
+All four levels are context graph concerns. None of them require a knowledge graph, and having a knowledge graph doesn't give you any of them. They solve different problems with different architectures.
+
+
+## How they work together
+
+Knowledge graphs and context graphs are complementary, not competing. Gartner is explicit on this point: "Knowledge graphs are not replaced by context graphs, but are augmented by them."
+
+Together, they give an AI agent two capabilities:
+
+**Understanding** (from the knowledge graph): The agent knows the domain -- what entities exist, how they're classified, how they relate. It has the vocabulary.
+
+**Judgment** (from the context graph): The agent knows how the organization operates -- what decisions have been made, why, what preferences exist, what precedents to follow. It has the institutional memory.
+
+An agent with only a knowledge graph can classify and traverse but can't make nuanced decisions based on organizational experience. An agent with only a context graph can recall past decisions and preferences but lacks the domain structure to reason about entities it hasn't encountered before.
+
+The strongest AI systems combine both: a semantic layer (knowledge graph) for domain understanding, and a procedural layer (context graph) for experiential judgment.
+
+
+## A practical test
+
+When you're in a conversation and someone says "knowledge graph" but means something experiential, or says "agent memory" but means domain ontology, apply this test:
+
+**Is this fact about the domain, or about a decision/experience?**
+
+- "A Customer can place many Orders" -> Domain fact -> Knowledge graph
+- "This customer prefers email over phone" -> Experiential knowledge -> Context graph
+- "Products belong to Categories" -> Domain structure -> Knowledge graph
+- "We stopped recommending Category X after the Q3 complaints" -> Decision with provenance -> Context graph
+- "An Order contains line items with quantities and prices" -> Domain schema -> Knowledge graph
+- "Last time we bulk-discounted this product line, margin dropped 12%" -> Institutional memory -> Context graph
+
+If the fact would survive deleting all operational history, it's domain knowledge. If it emerged from operational history, it's experiential memory. Different systems, different concerns, complementary value.
+
+
+## Sources
+
+- Gartner, "Context Graphs" research (via Atlan, March 2026): context graphs as distinct from knowledge graphs, decision tracing, four critical capabilities for agentic AI.
+- Alex Booker / Mastra, "Four Levels of Agent Memory" (2026): conversation history, working memory, semantic recall, observational memory.
+- Michael Sakhatsky, "You Probably Don't Need a Graph Database for Your Knowledge Graph" (April 2026): critique of the assumption chain from ontology to graph database; case for rules engines and logic programming.


### PR DESCRIPTION
## Summary

- Agent memory landscape analysis covering Every's Plus One pivot, Gartner context graphs, Neo4j Agent Memory, and Sakhatsky's graph DB critique
- Knowledge graphs vs context graphs explainer for stakeholder discussions
- Knowledge layer design proposal: `content_type` column on `memory_nodes`, graduation pipeline, RetrievalHub boundary preserved
- Storage architecture FAQ addressing PostgreSQL-vs-Neo4j questions

## Related Issues

Informed by and informs:
- #235 (memory promotion)
- #236 (team agent identity)
- #237 (behavioral memory)
- #238 (workflow state)
- #239 (convergent learning)
- #240 (extraction pipeline)
- #241 (pluggable storage -- future)
- #170 (graph-enhanced memory -- prioritized to near-term)

## Test plan

- [ ] Review research doc for accuracy and tone
- [ ] Review knowledge layer proposal open questions
- [ ] Review storage FAQ for neutrality
- [ ] Confirm no MemoryHub marketing leakage in the knowledge-vs-context explainer