### PR TITLE
mcp-server: Entity infrastructure and Phase 1 as_of gap fix (#170)

### DIFF
--- a/alembic/versions/015_add_entity_extraction.py
+++ b/alembic/versions/015_add_entity_extraction.py
@@ -1,0 +1,44 @@
+"""Add entity extraction indexes for Phase 2 of #170.
+
+Creates indexes to support entity-scoped memory nodes and MENTIONS
+relationships between memories and extracted entities.
+
+Revision ID: 015_add_entity_extraction
+Revises: 014_add_contradiction_resolution
+Create Date: 2026-05-18
+"""
+
+from alembic import op
+
+revision = "015_add_entity_extraction"
+down_revision = "014_add_contradiction_resolution"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # GIN index for full-text search on entity node content.
+    # Only entity-scoped nodes participate; the partial predicate
+    # keeps the index small.
+    op.execute(
+        """
+        CREATE INDEX ix_entity_nodes_content
+        ON memory_nodes USING gin(to_tsvector('english', content))
+        WHERE scope = 'entity'
+        """
+    )
+
+    # Partial index for active MENTIONS relationships.
+    # Accelerates the entity-aware search pre-filter join.
+    op.execute(
+        """
+        CREATE INDEX ix_memory_relationships_mentions
+        ON memory_relationships (source_id, target_id)
+        WHERE relationship_type = 'mentions' AND valid_until IS NULL
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS ix_memory_relationships_mentions")
+    op.execute("DROP INDEX IF EXISTS ix_entity_nodes_content")

--- a/memory-hub-mcp/src/tools/manage_graph.py
+++ b/memory-hub-mcp/src/tools/manage_graph.py
@@ -6,6 +6,7 @@ a single action-dispatched tool following the manage_project pattern.
 
 import logging
 import uuid
+from datetime import datetime
 from types import SimpleNamespace
 from typing import Annotated, Any
 
@@ -143,6 +144,16 @@ async def manage_graph(
             ),
         ),
     ] = False,
+    as_of: Annotated[
+        str | None,
+        Field(
+            description=(
+                "action='get_relationships': ISO-8601 timestamp to query edges "
+                "active at that point in time. Omit to return only currently "
+                "active edges."
+            ),
+        ),
+    ] = None,
     # ── get_similar params ───────────────────────────────────────────────────
     memory_id: Annotated[
         str | None,
@@ -246,7 +257,7 @@ async def manage_graph(
         elif action == "get_relationships":
             return await _handle_get_relationships(
                 ctx, claims, tenant, session,
-                node_id, relationship_type, direction, include_provenance, project_id,
+                node_id, relationship_type, direction, include_provenance, as_of, project_id,
             )
         else:  # get_similar
             return await _handle_get_similar(
@@ -290,6 +301,13 @@ async def _handle_create_relationship(
         raise ToolError(
             f"Invalid relationship_type {relationship_type!r}. "
             f"Must be one of: {', '.join(_VALID_TYPES)}."
+        )
+
+    if relationship_type == "mentions":
+        raise ToolError(
+            "The 'mentions' relationship type is system-managed and cannot be "
+            "created manually. MENTIONS edges are created automatically by the "
+            "entity extraction pipeline."
         )
 
     try:
@@ -368,6 +386,7 @@ async def _handle_get_relationships(
     relationship_type: str | None,
     direction: str,
     include_provenance: bool,
+    as_of: str | None,
     project_id: str | None,
 ) -> dict[str, Any]:
     """Return graph edges for a memory node, with optional provenance tracing."""
@@ -392,6 +411,13 @@ async def _handle_get_relationships(
             f"Must be one of: {', '.join(_VALID_TYPES)}."
         )
 
+    parsed_as_of: datetime | None = None
+    if as_of is not None:
+        try:
+            parsed_as_of = datetime.fromisoformat(as_of)
+        except ValueError:
+            raise ToolError(f"Invalid as_of format: {as_of!r}. Use ISO-8601 (e.g., '2026-04-01T00:00:00Z').")
+
     if ctx:
         await ctx.info(f"Getting {direction} relationships for {node_id}")
 
@@ -402,6 +428,7 @@ async def _handle_get_relationships(
             tenant_id=tenant,
             relationship_type=relationship_type,
             direction=direction,
+            as_of=parsed_as_of,
         )
     except MemoryNotFoundError:
         raise ToolError(f"Memory node {node_id} not found.")

--- a/memory-hub-mcp/src/tools/memory.py
+++ b/memory-hub-mcp/src/tools/memory.py
@@ -40,7 +40,7 @@ _READ_OPTS = frozenset({
 })
 _SIMILAR_OPTS = frozenset({"threshold", "max_results", "offset"})
 _RELATIONSHIPS_OPTS = frozenset({
-    "relationship_type", "direction", "include_provenance",
+    "relationship_type", "direction", "include_provenance", "as_of",
 })
 _FOCUS_HISTORY_OPTS = frozenset({"start_date", "end_date"})
 _LIST_PROJECTS_OPTS = frozenset({"filter"})

--- a/memory-hub-mcp/tests/test_tenant_isolation.py
+++ b/memory-hub-mcp/tests/test_tenant_isolation.py
@@ -1102,7 +1102,7 @@ async def test_get_relationships_cross_tenant_returns_not_found():
     )
 
     async def _fake_get_rels(
-        node_id, session, *, tenant_id, relationship_type=None, direction="both"
+        node_id, session, *, tenant_id, relationship_type=None, direction="both", as_of=None
     ):
         return store.get_relationships(node_id, tenant_id)
 
@@ -1201,7 +1201,7 @@ async def test_get_relationships_same_tenant_returns_edges():
     }
 
     async def _fake_get_rels(
-        node_id, session, *, tenant_id, relationship_type=None, direction="both"
+        node_id, session, *, tenant_id, relationship_type=None, direction="both", as_of=None
     ):
         # Same-tenant query: return one edge.
         return [fake_rel]

--- a/memory-hub-mcp/tests/tools/test_manage_graph.py
+++ b/memory-hub-mcp/tests/tools/test_manage_graph.py
@@ -517,3 +517,116 @@ async def test_get_similar_forwards_tenant_id_to_service():
         f"Expected tenant_id='tenant_a' in get_similar_memories_service kwargs, "
         f"got {similar_kwargs}"
     )
+
+
+# ── PR 1 entity infrastructure tests ─────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_create_relationship_rejects_mentions_type():
+    """create_relationship with relationship_type='mentions' raises ToolError
+    because mentions is system-managed."""
+    mock_session = AsyncMock()
+    mock_gen = AsyncMock()
+
+    auth_mod._current_session = {
+        "user_id": "wjackson",
+        "scopes": ["user"],
+        "identity_type": "user",
+    }
+    try:
+        with (
+            patch(
+                "src.tools.manage_graph.get_db_session",
+                return_value=(mock_session, mock_gen),
+            ),
+            patch(
+                "src.tools.manage_graph.release_db_session",
+                new_callable=AsyncMock,
+            ),
+            pytest.raises(ToolError, match="system-managed"),
+        ):
+            await manage_graph(
+                action="create_relationship",
+                source_id=str(uuid.uuid4()),
+                target_id=str(uuid.uuid4()),
+                relationship_type="mentions",
+            )
+    finally:
+        auth_mod._current_session = None
+
+
+@pytest.mark.asyncio
+async def test_get_relationships_forwards_as_of():
+    """get_relationships with as_of parameter forwards it as a datetime to the
+    service layer."""
+    from datetime import datetime, timezone
+
+    mock_session = AsyncMock()
+    mock_gen = AsyncMock()
+
+    auth_mod._current_session = {
+        "user_id": "wjackson",
+        "scopes": ["user"],
+        "identity_type": "user",
+    }
+    try:
+        with (
+            patch(
+                "src.tools.manage_graph.get_db_session",
+                return_value=(mock_session, mock_gen),
+            ),
+            patch(
+                "src.tools.manage_graph.release_db_session",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "src.tools.manage_graph.get_relationships_service",
+                new_callable=AsyncMock,
+                return_value=[],
+            ) as mock_service,
+            patch(
+                "src.tools.manage_graph.get_projects_for_user",
+                new_callable=AsyncMock,
+                return_value=set(),
+            ),
+            patch(
+                "src.tools.manage_graph.get_roles_for_user",
+                new_callable=AsyncMock,
+                return_value=set(),
+            ),
+        ):
+            await manage_graph(
+                action="get_relationships",
+                node_id=str(uuid.uuid4()),
+                as_of="2026-01-15T00:00:00Z",
+            )
+    finally:
+        auth_mod._current_session = None
+
+    _, kwargs = mock_service.call_args
+    as_of_value = kwargs.get("as_of")
+    assert as_of_value is not None
+    assert isinstance(as_of_value, datetime)
+    assert as_of_value.year == 2026
+    assert as_of_value.month == 1
+    assert as_of_value.day == 15
+
+
+@pytest.mark.asyncio
+async def test_get_relationships_rejects_invalid_as_of():
+    """get_relationships with invalid as_of format raises ToolError."""
+    auth_mod._current_session = {
+        "user_id": "wjackson",
+        "scopes": ["user"],
+        "identity_type": "user",
+    }
+    try:
+        with pytest.raises(ToolError, match="Invalid as_of format"):
+            await manage_graph(
+                action="get_relationships",
+                node_id=str(uuid.uuid4()),
+                as_of="not-a-date",
+            )
+    finally:
+        auth_mod._current_session = None

--- a/memory-hub-mcp/tests/tools/test_search_memory.py
+++ b/memory-hub-mcp/tests/tools/test_search_memory.py
@@ -1669,3 +1669,61 @@ async def test_graph_boost_weight_forwarded_to_service():
     assert focused_kwargs.get("graph_boost_weight") == 0.7, (
         f"Expected graph_boost_weight=0.7 forwarded, got {focused_kwargs}"
     )
+
+
+# ---------------------------------------------------------------------------
+# PR 1 — entity scope exclusion
+# ---------------------------------------------------------------------------
+
+
+def test_search_excludes_entity_scope_by_default():
+    """When scope is not specified (default), _build_search_filters excludes
+    entity-scoped nodes via a filter condition."""
+    from memoryhub_core.models.memory import MemoryNode
+    from memoryhub_core.services.memory import _build_search_filters
+
+    filters = _build_search_filters(
+        scope=None,
+        owner_id=None,
+        current_only=True,
+        authorized_scopes=None,
+        tenant_id="default",
+    )
+
+    assert filters is not None
+    # The filters list should contain a condition that excludes entity scope.
+    # Check for a filter that compares MemoryNode.scope != "entity"
+    has_entity_exclusion = False
+    for f in filters:
+        # Convert to string and check for the scope != entity pattern
+        clause_str = str(f.compile(compile_kwargs={"literal_binds": True}))
+        if "scope" in clause_str.lower() and "entity" in clause_str.lower() and "!=" in clause_str:
+            has_entity_exclusion = True
+            break
+
+    assert has_entity_exclusion, f"Expected entity scope exclusion in filters, got: {filters}"
+
+
+def test_search_includes_entity_scope_when_explicit():
+    """When scope='entity' is passed explicitly, _build_search_filters matches
+    entity-scoped nodes and does not exclude them."""
+    from memoryhub_core.services.memory import _build_search_filters
+
+    filters = _build_search_filters(
+        scope="entity",
+        owner_id=None,
+        current_only=True,
+        authorized_scopes=None,
+        tenant_id="default",
+    )
+
+    assert filters is not None
+    # When scope="entity" is set, the filter should include a positive match for entity
+    has_entity_match = False
+    for f in filters:
+        clause_str = str(f.compile(compile_kwargs={"literal_binds": True}))
+        if "scope" in clause_str.lower() and "entity" in clause_str.lower() and "=" in clause_str and "!=" not in clause_str:
+            has_entity_match = True
+            break
+
+    assert has_entity_match, f"Expected entity scope match in filters, got: {filters}"

--- a/planning/knowledge-layer.md
+++ b/planning/knowledge-layer.md
@@ -157,12 +157,16 @@ What this proposal explicitly does NOT do:
 MemoryHub's knowledge layer is the experience-to-assertion pipeline. RetrievalHub is the corpus-to-answer pipeline.
 
 
-## 8. Open Questions
+## 8. Open Questions (Resolved)
 
-1. **Should `content_type` be mutable via `update`, or only via `graduate`?** Recommendation: only via `graduate`. Prevents bypassing the governed graduation path.
+1. **Should `content_type` be mutable via `update`, or only via `graduate`?**
+   **Answer: only via `graduate`.** Direct mutation via `update` bypasses the governed graduation path -- no provenance chain is created, no evidence is recorded, no curator authorization is checked. If an agent can call `update(memory_id, options={content_type: "knowledge"})`, the entire graduation model is advisory. The `update` action should reject changes to `content_type`; the `graduate` action is the sole write path for that field.
 
-2. **Minimum weight floor for knowledge nodes?** Graduated knowledge could auto-set `weight >= 0.85` to ensure it ranks above experiential memories in mixed searches. Or leave weight orthogonal.
+2. **Minimum weight floor for knowledge nodes?**
+   **Answer: leave weight orthogonal.** Weight currently serves as a visibility threshold (full-content vs stub), not a ranking signal in RRF. Adding a floor conflates two signals and creates a hidden coupling between graduation and search visibility. The right mechanism for ranking knowledge higher is question 3 (knowledge boost in RRF), which is explicit, tunable, and composable. Graduation metadata (`metadata_.graduation`) already marks the node distinctly; a curator who wants a graduated fact to rank higher can set weight manually as a separate intentional act.
 
-3. **Knowledge boost in mixed search results?** Add a `knowledge_boost_weight` parameter (similar to `domain_boost_weight` in RRF) that lifts knowledge results when searching all content types.
+3. **Knowledge boost in mixed search results?**
+   **Answer: yes, as a fifth RRF signal.** Add `knowledge_boost_weight` to `search_memories_with_focus`, carved from the remaining budget exactly like `domain_boost_weight` and `graph_boost_weight` already are. Knowledge nodes receive rank 1 (highest); experiential nodes receive a penalty rank. Default `0.0` (disabled) for backward compatibility -- agents opt in by setting it > 0. This composes with all existing signals and requires no changes to `_build_search_filters`.
 
-4. **Naming: `graduate` vs `certify` vs `curate`?** `graduate` is consistent with the language in #235 and the research docs. `certify` implies a stronger guarantee than we intend. `curate` is overloaded (already used for the curation subsystem).
+4. **Naming: `graduate` vs `certify` vs `curate`?**
+   **Answer: `graduate`.** Consistent with the language in #235, the research docs, and this proposal. `certify` implies cryptographic or legal guarantee beyond what we provide. `curate` collides with the existing curation subsystem (`manage_curation` action, `CurationRule` model). `graduate` accurately describes the epistemic transition: a memory has earned a higher trust status through evidence and review, not been rubber-stamped.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "minio",
     "alembic",
     "redis>=5.0",
+    "httpx",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "alembic",
     "redis>=5.0",
     "httpx",
+    "psycopg2-binary",
 ]
 
 [project.optional-dependencies]

--- a/src/memoryhub_core/models/schemas.py
+++ b/src/memoryhub_core/models/schemas.py
@@ -19,6 +19,7 @@ class RelationshipType(StrEnum):
     supersedes = "supersedes"
     conflicts_with = "conflicts_with"
     related_to = "related_to"
+    mentions = "mentions"  # Phase 2: memory -> entity (system-managed)
 
 
 class MemoryScope(StrEnum):
@@ -30,6 +31,7 @@ class MemoryScope(StrEnum):
     ROLE = "role"
     ORGANIZATIONAL = "organizational"
     ENTERPRISE = "enterprise"
+    ENTITY = "entity"  # Phase 2: auto-extracted entity nodes
 
 
 class CampaignStatus(StrEnum):

--- a/src/memoryhub_core/services/memory.py
+++ b/src/memoryhub_core/services/memory.py
@@ -660,6 +660,11 @@ def _build_search_filters(
         filters.append(MemoryNode.is_current.is_(True))
     if scope is not None:
         filters.append(MemoryNode.scope == scope)
+    else:
+        # Entity nodes are infrastructure (extracted entities, not agent-written
+        # memories). Exclude them from normal search unless the caller explicitly
+        # requests scope="entity".
+        filters.append(MemoryNode.scope != "entity")
     if owner_id is not None:
         filters.append(MemoryNode.owner_id == owner_id)
 


### PR DESCRIPTION
## Summary

- Add `entity` scope and `mentions` relationship type to the data model for Phase 2 entity extraction
- Alembic migration 015: GIN index on entity node content + partial index for active MENTIONS relationships
- Close Phase 1 gap: expose `as_of` parameter on `manage_graph` `get_relationships` action for temporal edge queries
- Guard `mentions` relationship type from manual creation (system-managed by extraction pipeline)
- Exclude entity-scoped nodes from normal `search_memory` results unless caller explicitly requests `scope="entity"`

## Related issues

- Implements foundation for #170 (graph-enhanced memory, Phase 2)
- Closes Phase 1 gap where `as_of` was in the service layer but not exposed on the MCP tool

## Test plan

- [x] 390/390 tests pass (5 new tests added, 2 tenant isolation mocks fixed)
- [ ] `test_create_relationship_rejects_mentions_type` -- ToolError for manual mentions creation
- [ ] `test_get_relationships_forwards_as_of` -- ISO parse + forwarded to service
- [ ] `test_get_relationships_rejects_invalid_as_of` -- bad format raises ToolError
- [ ] `test_search_excludes_entity_scope_by_default` -- entity nodes hidden from normal search
- [ ] `test_search_includes_entity_scope_when_explicit` -- `scope="entity"` returns entity nodes
- [ ] Migration 015 runs cleanly on existing schema