### PR TITLE
mcp-server: Entity service layer and entity-aware search (#170)

### DIFF
--- a/memory-hub-mcp/src/tools/memory.py
+++ b/memory-hub-mcp/src/tools/memory.py
@@ -33,7 +33,7 @@ _SEARCH_OPTS = frozenset({
     "domain_boost_weight", "include_branches", "mode",
     "max_response_tokens", "raw_results", "weight_threshold",
     "current_only", "owner_id", "graph_depth",
-    "graph_relationship_types", "graph_boost_weight",
+    "graph_relationship_types", "graph_boost_weight", "entities",
 })
 _READ_OPTS = frozenset({
     "include_versions", "history_offset", "history_max_versions", "hydrate",

--- a/memory-hub-mcp/src/tools/search_memory.py
+++ b/memory-hub-mcp/src/tools/search_memory.py
@@ -573,6 +573,17 @@ async def search_memory(
             le=1.0,
         ),
     ] = 0.2,
+    entities: Annotated[
+        list[str] | None,
+        Field(
+            description=(
+                "Filter to memories that mention these entity names. "
+                "Entity names are matched case-insensitively against extracted "
+                "entity nodes linked via MENTIONS relationships. "
+                "Composes with all other filters (scope, domain, graph_depth)."
+            ),
+        ),
+    ] = None,
     raw_results: Annotated[
         bool,
         Field(
@@ -759,6 +770,7 @@ async def search_memory(
                 graph_depth=graph_depth,
                 graph_relationship_types=graph_relationship_types,
                 graph_boost_weight=graph_boost_weight,
+                entity_names=entities,
             )
             graph_bundle = bundle
             results = bundle.results
@@ -785,6 +797,7 @@ async def search_memory(
                 campaign_ids=campaign_ids,
                 project_ids=project_ids,
                 role_names=role_names,
+                entity_names=entities,
             )
 
         # Count all matching memories under the same filter set so the agent
@@ -799,6 +812,7 @@ async def search_memory(
             campaign_ids=campaign_ids,
             project_ids=project_ids,
             role_names=role_names,
+            entity_names=entities,
         )
 
         # Apply post-retrieval domain boost only on the non-focus path.

--- a/memory-hub-mcp/tests/tools/test_entity_service.py
+++ b/memory-hub-mcp/tests/tools/test_entity_service.py
@@ -1,0 +1,201 @@
+"""Tests for entity service layer."""
+
+import uuid
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from memoryhub_core.models.memory import MemoryNode, MemoryRelationship
+from memoryhub_core.models.schemas import MemoryNodeRead, MemoryScope, RelationshipRead
+from memoryhub_core.services.entity import (
+    create_mentions_relationship,
+    find_entities_by_names,
+    find_or_create_entity,
+)
+
+
+@pytest.mark.asyncio
+async def test_find_or_create_entity_creates_new():
+    """When no existing entity matches, find_or_create_entity creates a new
+    MemoryNode with scope='entity', branch_type='entity:<type>', and weight=0.6."""
+    session = MagicMock()
+
+    # Mock both exact match and vector similarity queries to return None
+    mock_execute_exact = AsyncMock()
+    mock_execute_exact.scalar_one_or_none = MagicMock(return_value=None)
+
+    mock_execute_vec = AsyncMock()
+    mock_execute_vec.first = MagicMock(return_value=None)
+
+    call_count = 0
+    async def fake_execute(stmt):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return mock_execute_exact
+        return mock_execute_vec
+
+    session.execute = fake_execute
+    session.add = MagicMock()
+    session.commit = AsyncMock()
+    session.refresh = AsyncMock()
+
+    embedding_service = AsyncMock()
+    embedding_service.embed = AsyncMock(return_value=[0.1] * 384)
+
+    # Patch node_to_read since the function calls it at the end
+    with patch("memoryhub_core.services.entity.node_to_read") as mock_node_to_read:
+        mock_node_to_read.return_value = MagicMock(spec=MemoryNodeRead)
+
+        entity_read, was_created = await find_or_create_entity(
+            name="PostgreSQL",
+            entity_type="organization",
+            session=session,
+            embedding_service=embedding_service,
+            tenant_id="default",
+            owner_id="wjackson",
+        )
+
+    assert was_created is True
+    assert session.add.called
+    added_node = session.add.call_args[0][0]
+    assert isinstance(added_node, MemoryNode)
+    assert added_node.scope == "entity"
+    assert added_node.branch_type == "entity:organization"
+    assert added_node.content == "PostgreSQL"
+    assert added_node.weight == 0.6
+    assert added_node.tenant_id == "default"
+    assert added_node.owner_id == "wjackson"
+
+
+@pytest.mark.asyncio
+async def test_find_or_create_entity_rejects_invalid_type():
+    """Calling with entity_type not in VALID_ENTITY_TYPES raises ValueError."""
+    session = MagicMock()
+    embedding_service = AsyncMock()
+
+    with pytest.raises(ValueError, match="Invalid entity_type"):
+        await find_or_create_entity(
+            name="Test",
+            entity_type="invalid",
+            session=session,
+            embedding_service=embedding_service,
+            tenant_id="default",
+            owner_id="wjackson",
+        )
+
+
+@pytest.mark.asyncio
+async def test_find_or_create_entity_rejects_empty_name():
+    """Calling with empty or whitespace-only name raises ValueError."""
+    session = MagicMock()
+    embedding_service = AsyncMock()
+
+    with pytest.raises(ValueError, match="cannot be empty"):
+        await find_or_create_entity(
+            name="   ",
+            entity_type="person",
+            session=session,
+            embedding_service=embedding_service,
+            tenant_id="default",
+            owner_id="wjackson",
+        )
+
+
+@pytest.mark.asyncio
+async def test_create_mentions_relationship_idempotent():
+    """When an active MENTIONS edge already exists, create_mentions_relationship
+    returns it without calling create_relationship."""
+    memory_id = uuid.uuid4()
+    entity_id = uuid.uuid4()
+
+    # Mock existing relationship
+    existing_rel = MagicMock(spec=MemoryRelationship)
+    existing_rel.id = uuid.uuid4()
+    existing_rel.source_id = memory_id
+    existing_rel.target_id = entity_id
+    existing_rel.relationship_type = "mentions"
+    existing_rel.metadata_ = None
+    existing_rel.created_at = datetime.now(UTC)
+    existing_rel.created_by = "system"
+    existing_rel.tenant_id = "default"
+    existing_rel.valid_from = datetime.now(UTC)
+    existing_rel.valid_until = None
+
+    session = MagicMock()
+    mock_execute_rel = AsyncMock()
+    mock_execute_rel.scalar_one_or_none = MagicMock(return_value=existing_rel)
+
+    # Mock stub retrieval
+    mock_execute_stub = AsyncMock()
+    mock_execute_stub.scalar_one_or_none = MagicMock(return_value="memory stub")
+
+    async def fake_execute(stmt):
+        # Return existing relationship for first call, stubs for subsequent calls
+        if not hasattr(fake_execute, "call_count"):
+            fake_execute.call_count = 0
+        fake_execute.call_count += 1
+        if fake_execute.call_count == 1:
+            return mock_execute_rel
+        return mock_execute_stub
+
+    session.execute = fake_execute
+
+    with patch(
+        "memoryhub_core.services.entity.create_relationship"
+    ) as mock_create:
+        result = await create_mentions_relationship(
+            memory_id=memory_id,
+            entity_id=entity_id,
+            session=session,
+            tenant_id="default",
+        )
+
+    # Should return existing relationship without calling create_relationship
+    assert mock_create.call_count == 0
+    assert isinstance(result, RelationshipRead)
+    assert result.source_id == memory_id
+    assert result.target_id == entity_id
+
+
+@pytest.mark.asyncio
+async def test_find_entities_by_names_empty_list():
+    """When names is an empty list, find_entities_by_names returns empty
+    list without executing any query."""
+    session = MagicMock()
+    session.execute = AsyncMock()
+
+    result = await find_entities_by_names(
+        names=[],
+        session=session,
+        tenant_id="default",
+        owner_id="wjackson",
+    )
+
+    assert result == []
+    assert session.execute.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_find_entities_by_names_returns_ids():
+    """When matching entities exist, find_entities_by_names returns their IDs."""
+    id1 = uuid.uuid4()
+    id2 = uuid.uuid4()
+
+    session = MagicMock()
+    mock_execute = AsyncMock()
+    # Mock result rows as tuples
+    mock_execute.all = MagicMock(return_value=[(id1,), (id2,)])
+    session.execute = AsyncMock(return_value=mock_execute)
+
+    result = await find_entities_by_names(
+        names=["PostgreSQL", "Redis"],
+        session=session,
+        tenant_id="default",
+        owner_id="wjackson",
+    )
+
+    assert len(result) == 2
+    assert id1 in result
+    assert id2 in result

--- a/memory-hub-mcp/tests/tools/test_search_memory.py
+++ b/memory-hub-mcp/tests/tools/test_search_memory.py
@@ -1727,3 +1727,70 @@ def test_search_includes_entity_scope_when_explicit():
             break
 
     assert has_entity_match, f"Expected entity scope match in filters, got: {filters}"
+
+
+# ---------------------------------------------------------------------------
+# PR 2 — entity-aware search
+# ---------------------------------------------------------------------------
+
+
+def test_search_memory_has_entities_param():
+    """Structural test: verify search_memory accepts an entities parameter."""
+    sig = inspect.signature(search_memory)
+    params = sig.parameters
+
+    assert "entities" in params
+    assert params["entities"].default is None
+
+
+@pytest.mark.asyncio
+async def test_search_memory_forwards_entities_to_service():
+    """When entities is passed, the tool must forward entity_names to the
+    underlying service layer."""
+    from unittest.mock import MagicMock
+
+    mock_session = MagicMock()
+    mock_gen = AsyncMock()
+    fake_embedding_service = AsyncMock()
+    fake_claims = {
+        "sub": "wjackson",
+        "identity_type": "user",
+        "tenant_id": "default",
+        "scopes": ["memory:read:user"],
+    }
+
+    with (
+        patch(
+            "src.tools.search_memory.get_claims_from_context",
+            return_value=fake_claims,
+        ),
+        patch(
+            "src.tools.search_memory.get_db_session",
+            return_value=(mock_session, mock_gen),
+        ),
+        patch("src.tools.search_memory.release_db_session", new_callable=AsyncMock),
+        patch(
+            "src.tools.search_memory.get_embedding_service",
+            return_value=fake_embedding_service,
+        ),
+        patch(
+            "src.tools.search_memory.search_memories",
+            new_callable=AsyncMock,
+            return_value=[],
+        ) as mock_search,
+        patch(
+            "src.tools.search_memory.count_search_matches",
+            new_callable=AsyncMock,
+            return_value=0,
+        ) as mock_count,
+    ):
+        await search_memory(query="anything", entities=["PostgreSQL"])
+
+    _, search_kwargs = mock_search.call_args
+    assert search_kwargs.get("entity_names") == ["PostgreSQL"], (
+        f"Expected entity_names=['PostgreSQL'] in search_memories kwargs, got {search_kwargs}"
+    )
+    _, count_kwargs = mock_count.call_args
+    assert count_kwargs.get("entity_names") == ["PostgreSQL"], (
+        f"Expected entity_names=['PostgreSQL'] in count_search_matches kwargs, got {count_kwargs}"
+    )

--- a/src/memoryhub_core/config.py
+++ b/src/memoryhub_core/config.py
@@ -72,3 +72,7 @@ class AppSettings(BaseSettings):
     s3_threshold_bytes: int = 1024    # Content above this is chunked (and goes to S3 if configured)
     s3_prefix_chars: int = 1000       # Chars used for embedding on oversized content (~250 tokens)
     session_ttl_seconds: int = 3600   # API-key session lifetime; auto-extends on activity
+
+    # Phase 2 entity extraction (#170)
+    entity_extraction_enabled: bool = False
+    entity_extraction_concurrency: int = 10

--- a/src/memoryhub_core/services/entity.py
+++ b/src/memoryhub_core/services/entity.py
@@ -103,7 +103,6 @@ async def find_or_create_entity(
     if embedding:
         # Query for entity nodes with similar embeddings
         try:
-            from memoryhub_core.models.memory import MemoryNode
             distance_expr = MemoryNode.embedding.cosine_distance(embedding)
             vec_stmt = (
                 select(MemoryNode, distance_expr.label("distance"))

--- a/src/memoryhub_core/services/entity.py
+++ b/src/memoryhub_core/services/entity.py
@@ -1,0 +1,331 @@
+"""Entity extraction service — find-or-create entities and MENTIONS relationships.
+
+Provides deduplication, aliasing, and entity-memory linking for Phase 2 entity
+extraction (#170). All functions are async and accept an explicit AsyncSession.
+"""
+
+import logging
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from memoryhub_core.models.memory import MemoryNode, MemoryRelationship
+from memoryhub_core.models.schemas import MemoryNodeRead, RelationshipCreate, RelationshipRead
+from memoryhub_core.models.utils import generate_stub
+from memoryhub_core.services.embeddings import EmbeddingService
+from memoryhub_core.services.exceptions import MemoryNotFoundError
+from memoryhub_core.services.graph import create_relationship
+from memoryhub_core.services.memory import node_to_read
+
+logger = logging.getLogger(__name__)
+
+# Valid entity types from the Phase 2 design
+VALID_ENTITY_TYPES = frozenset({
+    "person", "object", "location", "event", "organization",
+})
+
+# Similarity threshold for entity deduplication via vector search.
+# Cosine distance < 0.08 (similarity > 0.92) is considered a match.
+ENTITY_DEDUP_THRESHOLD = 0.08
+
+
+async def find_or_create_entity(
+    name: str,
+    entity_type: str,
+    session: AsyncSession,
+    embedding_service: EmbeddingService,
+    *,
+    tenant_id: str,
+    owner_id: str,
+    aliases: list[str] | None = None,
+    confidence: float = 1.0,
+    extractor: str = "manual",
+) -> tuple[MemoryNodeRead, bool]:
+    """Find an existing entity node or create a new one.
+
+    Returns (entity_node, was_created). Deduplication strategy:
+    1. Exact match on lower(content) for this tenant+owner
+    2. Vector similarity (cosine distance < 0.08) if no exact match
+
+    If a match is found, merges any new aliases into the existing node's
+    metadata_["aliases"] list. If no match, creates a new entity node with
+    scope="entity" and branch_type=f"entity:{entity_type}".
+
+    Raises ValueError for invalid entity_type.
+    """
+    if entity_type not in VALID_ENTITY_TYPES:
+        raise ValueError(
+            f"Invalid entity_type '{entity_type}'. "
+            f"Must be one of: {', '.join(sorted(VALID_ENTITY_TYPES))}"
+        )
+
+    normalized_name = name.strip()
+    if not normalized_name:
+        raise ValueError("Entity name cannot be empty")
+
+    # Step 1: Exact match on canonical name (case-insensitive)
+    exact_stmt = select(MemoryNode).where(
+        MemoryNode.scope == "entity",
+        MemoryNode.tenant_id == tenant_id,
+        MemoryNode.owner_id == owner_id,
+        MemoryNode.deleted_at.is_(None),
+        MemoryNode.is_current.is_(True),
+    )
+    # SQLAlchemy func.lower for portable case-insensitive comparison
+    from sqlalchemy import func
+    exact_stmt = exact_stmt.where(func.lower(MemoryNode.content) == normalized_name.lower())
+    exact_stmt = exact_stmt.limit(1)
+    result = await session.execute(exact_stmt)
+    existing = result.scalar_one_or_none()
+
+    if existing is not None:
+        # Merge aliases if provided
+        new_aliases = set(aliases or [])
+        existing_aliases = set(existing.metadata_.get("aliases", []) if existing.metadata_ else [])
+        merged_aliases = sorted(existing_aliases | new_aliases)
+        if merged_aliases != sorted(existing_aliases):
+            # Update metadata to include new aliases
+            updated_metadata = existing.metadata_ or {}
+            updated_metadata["aliases"] = merged_aliases
+            existing.metadata_ = updated_metadata
+            await session.commit()
+            await session.refresh(existing)
+
+        entity_read = node_to_read(existing, has_children=False, has_rationale=False)
+        return entity_read, False
+
+    # Step 2: Vector similarity search (if embedding service available)
+    embedding = await embedding_service.embed(normalized_name)
+    if embedding:
+        # Query for entity nodes with similar embeddings
+        try:
+            from memoryhub_core.models.memory import MemoryNode
+            distance_expr = MemoryNode.embedding.cosine_distance(embedding)
+            vec_stmt = (
+                select(MemoryNode, distance_expr.label("distance"))
+                .where(
+                    MemoryNode.scope == "entity",
+                    MemoryNode.tenant_id == tenant_id,
+                    MemoryNode.owner_id == owner_id,
+                    MemoryNode.deleted_at.is_(None),
+                    MemoryNode.is_current.is_(True),
+                )
+                .order_by(distance_expr)
+                .limit(1)
+            )
+            vec_result = await session.execute(vec_stmt)
+            row = vec_result.first()
+
+            if row is not None:
+                candidate, distance = row[0], float(row[1])
+                if distance < ENTITY_DEDUP_THRESHOLD:
+                    # Match found via similarity — merge aliases
+                    new_aliases = set(aliases or [])
+                    existing_aliases = set(
+                        candidate.metadata_.get("aliases", []) if candidate.metadata_ else []
+                    )
+                    merged_aliases = sorted(existing_aliases | new_aliases | {normalized_name})
+                    updated_metadata = candidate.metadata_ or {}
+                    updated_metadata["aliases"] = merged_aliases
+                    candidate.metadata_ = updated_metadata
+                    await session.commit()
+                    await session.refresh(candidate)
+
+                    entity_read = node_to_read(candidate, has_children=False, has_rationale=False)
+                    return entity_read, False
+        except Exception:
+            # pgvector not available or query failed — continue to create
+            logger.debug(
+                "Vector similarity search failed for entity '%s'; creating new node",
+                normalized_name,
+                exc_info=True,
+            )
+
+    # Step 3: No match — create new entity node
+    now = datetime.now(UTC)
+    entity_id = uuid.uuid4()
+
+    stub = generate_stub(
+        content=normalized_name,
+        scope="entity",
+        weight=0.6,
+        branch_count=0,
+        has_rationale=False,
+    )
+
+    metadata = {
+        "aliases": aliases or [],
+        "extraction_confidence": confidence,
+        "extracted_by": extractor,
+    }
+
+    node = MemoryNode(
+        id=entity_id,
+        content=normalized_name,
+        stub=stub,
+        scope="entity",
+        scope_id=None,
+        branch_type=f"entity:{entity_type}",
+        weight=0.6,
+        owner_id=owner_id,
+        tenant_id=tenant_id,
+        parent_id=None,
+        metadata_=metadata,
+        domains=None,
+        embedding=embedding,
+        is_current=True,
+        version=1,
+        storage_type="inline",
+        content_ref=None,
+        created_at=now,
+        updated_at=now,
+    )
+
+    session.add(node)
+    await session.commit()
+    await session.refresh(node)
+
+    entity_read = node_to_read(node, has_children=False, has_rationale=False)
+    return entity_read, True
+
+
+async def create_mentions_relationship(
+    memory_id: uuid.UUID,
+    entity_id: uuid.UUID,
+    session: AsyncSession,
+    *,
+    tenant_id: str,
+    created_by: str = "system:entity_extraction",
+    metadata: dict[str, Any] | None = None,
+) -> RelationshipRead:
+    """Create a MENTIONS edge: memory -> entity.
+
+    Idempotent: if an active MENTIONS edge already exists between these nodes,
+    returns it without error. Uses the create_relationship service for actual
+    creation, catching IntegrityError for race conditions.
+
+    Raises MemoryNotFoundError if either node does not exist.
+    """
+    # Check for existing active MENTIONS edge
+    existing_stmt = select(MemoryRelationship).where(
+        MemoryRelationship.source_id == memory_id,
+        MemoryRelationship.target_id == entity_id,
+        MemoryRelationship.relationship_type == "mentions",
+        MemoryRelationship.valid_until.is_(None),
+    )
+    result = await session.execute(existing_stmt)
+    existing = result.scalar_one_or_none()
+
+    if existing is not None:
+        # Idempotent — edge already exists, return it
+        # Load stubs for the response
+        mem_stmt = select(MemoryNode.stub).where(MemoryNode.id == memory_id)
+        ent_stmt = select(MemoryNode.stub).where(MemoryNode.id == entity_id)
+        mem_stub = (await session.execute(mem_stmt)).scalar_one_or_none()
+        ent_stub = (await session.execute(ent_stmt)).scalar_one_or_none()
+
+        return RelationshipRead(
+            id=existing.id,
+            source_id=existing.source_id,
+            target_id=existing.target_id,
+            relationship_type=existing.relationship_type,
+            metadata_=existing.metadata_,
+            created_at=existing.created_at,
+            created_by=existing.created_by,
+            tenant_id=existing.tenant_id,
+            valid_from=existing.valid_from,
+            valid_until=existing.valid_until,
+            source_stub=mem_stub,
+            target_stub=ent_stub,
+        )
+
+    # Create new MENTIONS edge via the graph service
+    rel_create = RelationshipCreate(
+        source_id=memory_id,
+        target_id=entity_id,
+        relationship_type="mentions",
+        created_by=created_by,
+        metadata=metadata,
+    )
+
+    try:
+        return await create_relationship(rel_create, session)
+    except IntegrityError as exc:
+        # Race condition — another task created the edge between our check
+        # and our insert. Rollback and re-query for the existing edge.
+        await session.rollback()
+        retry_stmt = select(MemoryRelationship).where(
+            MemoryRelationship.source_id == memory_id,
+            MemoryRelationship.target_id == entity_id,
+            MemoryRelationship.relationship_type == "mentions",
+            MemoryRelationship.valid_until.is_(None),
+        )
+        retry_result = await session.execute(retry_stmt)
+        retry_edge = retry_result.scalar_one_or_none()
+
+        if retry_edge is not None:
+            # Load stubs for the response
+            mem_stmt = select(MemoryNode.stub).where(MemoryNode.id == memory_id)
+            ent_stmt = select(MemoryNode.stub).where(MemoryNode.id == entity_id)
+            mem_stub = (await session.execute(mem_stmt)).scalar_one_or_none()
+            ent_stub = (await session.execute(ent_stmt)).scalar_one_or_none()
+
+            return RelationshipRead(
+                id=retry_edge.id,
+                source_id=retry_edge.source_id,
+                target_id=retry_edge.target_id,
+                relationship_type=retry_edge.relationship_type,
+                metadata_=retry_edge.metadata_,
+                created_at=retry_edge.created_at,
+                created_by=retry_edge.created_by,
+                tenant_id=retry_edge.tenant_id,
+                valid_from=retry_edge.valid_from,
+                valid_until=retry_edge.valid_until,
+                source_stub=mem_stub,
+                target_stub=ent_stub,
+            )
+
+        # Edge still doesn't exist after race — re-raise original error
+        raise ValueError(
+            f"Failed to create MENTIONS edge ({memory_id} -> {entity_id})"
+        ) from exc
+
+
+async def find_entities_by_names(
+    names: list[str],
+    session: AsyncSession,
+    *,
+    tenant_id: str,
+    owner_id: str | None = None,
+) -> list[uuid.UUID]:
+    """Find entity node IDs matching any of the given names (case-insensitive).
+
+    Used by entity-aware search to pre-filter candidate memories. Returns a
+    list of entity IDs that match any of the provided names.
+    """
+    if not names:
+        return []
+
+    # Normalize names for case-insensitive matching
+    lowered_names = [n.lower() for n in names if n.strip()]
+    if not lowered_names:
+        return []
+
+    from sqlalchemy import func
+
+    stmt = select(MemoryNode.id).where(
+        MemoryNode.scope == "entity",
+        MemoryNode.tenant_id == tenant_id,
+        MemoryNode.deleted_at.is_(None),
+        func.lower(MemoryNode.content).in_(lowered_names),
+    )
+
+    if owner_id is not None:
+        stmt = stmt.where(MemoryNode.owner_id == owner_id)
+
+    result = await session.execute(stmt)
+    return [row[0] for row in result.all()]

--- a/src/memoryhub_core/services/memory.py
+++ b/src/memoryhub_core/services/memory.py
@@ -641,6 +641,7 @@ def _build_search_filters(
     campaign_ids: set[str] | None = None,
     project_ids: set[str] | None = None,
     role_names: set[str] | None = None,
+    entity_names: list[str] | None = None,
 ) -> list | None:
     """Build the SQL filter list shared by search_memories and count_search_matches.
 
@@ -725,6 +726,28 @@ def _build_search_filters(
             # caller with no campaign_ids). No scope matches → no results.
             return None
 
+    if entity_names:
+        from memoryhub_core.models.memory import MemoryRelationship
+        entity_subq = (
+            select(MemoryRelationship.source_id)
+            .join(
+                MemoryNode,
+                and_(
+                    MemoryNode.id == MemoryRelationship.target_id,
+                    MemoryNode.scope == "entity",
+                    func.lower(MemoryNode.content).in_([n.lower() for n in entity_names]),
+                    MemoryNode.tenant_id == tenant_id,
+                    MemoryNode.deleted_at.is_(None),
+                ),
+            )
+            .where(
+                MemoryRelationship.relationship_type == "mentions",
+                MemoryRelationship.valid_until.is_(None),
+                MemoryRelationship.tenant_id == tenant_id,
+            )
+        )
+        filters.append(MemoryNode.id.in_(entity_subq))
+
     return filters
 
 
@@ -739,6 +762,7 @@ async def count_search_matches(
     campaign_ids: set[str] | None = None,
     project_ids: set[str] | None = None,
     role_names: set[str] | None = None,
+    entity_names: list[str] | None = None,
 ) -> int:
     """Count memories matching the same filter set used by search_memories.
 
@@ -756,6 +780,7 @@ async def count_search_matches(
         campaign_ids=campaign_ids,
         project_ids=project_ids,
         role_names=role_names,
+        entity_names=entity_names,
     )
     if filters is None:
         return 0
@@ -778,6 +803,7 @@ async def search_memories(
     campaign_ids: set[str] | None = None,
     project_ids: set[str] | None = None,
     role_names: set[str] | None = None,
+    entity_names: list[str] | None = None,
 ) -> list[tuple[MemoryNodeRead | MemoryNodeStub, float]]:
     """Search memories using pgvector cosine similarity.
 
@@ -803,6 +829,7 @@ async def search_memories(
         campaign_ids=campaign_ids,
         project_ids=project_ids,
         role_names=role_names,
+        entity_names=entity_names,
     )
     if filters is None:
         return []
@@ -954,6 +981,7 @@ async def search_memories_with_focus(
     graph_depth: int = 0,
     graph_relationship_types: list[str] | None = None,
     graph_boost_weight: float = 0.2,
+    entity_names: list[str] | None = None,
 ) -> FocusedSearchResult:
     """Two-vector retrieval with session focus bias.
 
@@ -1002,6 +1030,7 @@ async def search_memories_with_focus(
             campaign_ids=campaign_ids,
             project_ids=project_ids,
             role_names=role_names,
+            entity_names=entity_names,
         )
         return FocusedSearchResult(results=plain)
 
@@ -1022,6 +1051,7 @@ async def search_memories_with_focus(
         campaign_ids=campaign_ids,
         project_ids=project_ids,
         role_names=role_names,
+        entity_names=entity_names,
     )
     if filters is None:
         return FocusedSearchResult(


### PR DESCRIPTION
## Summary

- Entity service (`services/entity.py`) with find-or-create deduplication, idempotent MENTIONS relationship creation, and entity name lookup
- Entity-aware search: `entities` parameter on `search_memory` that pre-filters results to memories mentioning named entities via MENTIONS relationship joins
- `entity_extraction_enabled` and `entity_extraction_concurrency` config settings for Phase 2 extraction pipeline control

## Design decisions

- **Entity ownership**: per-owner deduplication (option a from design doc). Cross-user dedup deferred.
- **MENTIONS direction**: source=memory, target=entity (memory mentions entity)
- **Entity weight**: 0.6 (lower than knowledge memories; entities are infrastructure)
- **Dedup strategy**: exact name match first, then vector similarity > 0.92

## Depends on

- #243 (entity infrastructure) -- merged

## Test plan

- [x] 398/398 tests pass (8 new tests added)
- [ ] `test_find_or_create_entity_creates_new` -- correct scope/branch_type/metadata
- [ ] `test_find_or_create_entity_rejects_invalid_type` -- ValueError for bad type
- [ ] `test_find_or_create_entity_rejects_empty_name` -- ValueError for empty
- [ ] `test_create_mentions_relationship_idempotent` -- returns existing edge
- [ ] `test_find_entities_by_names_empty_list` -- no query for empty input
- [ ] `test_find_entities_by_names_returns_ids` -- correct ID return
- [ ] `test_search_memory_has_entities_param` -- parameter accepted
- [ ] `test_search_memory_forwards_entities_to_service` -- forwarded correctly