### PR TITLE
docs: Update tool API references, Accept header, and curation behavior

### DIFF
--- a/docs/curator-agent.md
+++ b/docs/curator-agent.md
@@ -27,15 +27,15 @@ This is the cheapest gate. It catches obvious problems before anything touches t
 
 pgvector cosine similarity query against existing memories in the same (owner_id, scope, is_current=true). Milliseconds.
 
-| Similarity | Action |
-|---|---|
-| > 0.95 | Reject with pointer to existing memory (near-duplicate) |
-| 0.80 - 0.95 | Flag in metadata, allow write |
-| < 0.80 | Allow write (distinct memory) |
+| Similarity | Action | Write succeeds? |
+|---|---|---|
+| > 0.95 | Reject with pointer to existing memory (exact duplicate) | No -- `ToolError` raised |
+| 0.80 - 0.95 | Flag as `possible_duplicate` in metadata, allow write | Yes -- advisory only |
+| < 0.80 | Allow write (distinct memory) | Yes |
 
 Thresholds are configurable via curation rules. Users with intentionally similar memories (e.g., dataset-specific notes) can raise the dedup threshold.
 
-Note the key difference from earlier designs: the 0.80-0.95 range does NOT escalate to an LLM. The memory is written with a curation flag, and the similar_count is returned to the agent.
+The 0.80-0.95 range is advisory: the memory is written successfully, a `possible_duplicate` flag is added to the curation metadata, and `similar_count` is returned in the response. The calling agent's LLM decides whether to investigate (via `manage_graph(action="get_similar", ...)`) or ignore the flag. This is a deliberate design choice -- the MCP server never blocks writes for ambiguous similarity. Only exact duplicates (>0.95) and secrets/PII matches are blocked.
 
 ### No inline sampling
 

--- a/memory-hub-mcp/.claude/commands/implement-mcp-item.md
+++ b/memory-hub-mcp/.claude/commands/implement-mcp-item.md
@@ -42,11 +42,10 @@ Update the test to cover:
 **Testing Pattern Reminder:**
 ```python
 from src.tools.my_tool import my_tool
-my_tool_fn = my_tool.fn  # Access underlying function
 
 @pytest.mark.asyncio
 async def test_my_tool():
-    result = await my_tool_fn(param="value")
+    result = await my_tool(param="value")
     assert result == "expected"
 ```
 

--- a/memory-hub-mcp/.fips-agents-cli/generators/tool/test.py.j2
+++ b/memory-hub-mcp/.fips-agents-cli/generators/tool/test.py.j2
@@ -9,9 +9,6 @@ from unittest.mock import MagicMock
 {% endif %}
 from src.tools.{{ module_path }} import {{ component_name }}
 
-# Access the underlying function for testing (FastMCP decorator pattern)
-{{ component_name }}_fn = {{ component_name }}.fn
-
 
 {% if async %}@pytest.mark.asyncio
 async def test_{{ component_name }}_basic():
@@ -19,7 +16,7 @@ async def test_{{ component_name }}_basic():
 {% endif %}    """Test basic {{ component_name }} functionality."""
 {% if with_context %}    ctx = {% if async %}AsyncMock(){% else %}MagicMock(){% endif %}
 {% endif %}    # TODO: Add test parameters
-    result = {% if async %}await {% endif %}{{ component_name }}_fn(
+    result = {% if async %}await {% endif %}{{ component_name }}(
         # Add parameters here
 {% if with_context %}        ctx=ctx,
 {% endif %}    )
@@ -38,7 +35,7 @@ async def test_{{ component_name }}_error_handling():
 {% endif %}    # TODO: Test error conditions
     # Example:
     # with pytest.raises(ToolError, match="expected error"):
-    #     {% if async %}await {% endif %}{{ component_name }}_fn(invalid_param{% if with_context %}, ctx=ctx{% endif %})
+    #     {% if async %}await {% endif %}{{ component_name }}(invalid_param{% if with_context %}, ctx=ctx{% endif %})
     pass
 
 
@@ -50,6 +47,6 @@ async def test_{{ component_name }}_validation():
 {% endif %}    # TODO: Test validation
     # from pydantic import ValidationError
     # with pytest.raises(ValidationError):
-    #     {% if async %}await {% endif %}{{ component_name }}_fn(invalid_value{% if with_context %}, ctx=ctx{% endif %})
+    #     {% if async %}await {% endif %}{{ component_name }}(invalid_value{% if with_context %}, ctx=ctx{% endif %})
     pass
 {% endif %}

--- a/memory-hub-mcp/AGENTS.md
+++ b/memory-hub-mcp/AGENTS.md
@@ -70,23 +70,18 @@ from tools.my_tool import my_tool
 
 ### Testing FastMCP Decorated Functions
 
-**IMPORTANT**: FastMCP decorators (`@mcp.tool`, `@mcp.resource`, `@mcp.prompt`) wrap functions in special objects. To test these functions directly, you must access the underlying function using the `.fn` attribute.
+In FastMCP 3, `@mcp.tool(...)` returns the function directly, so tests
+call the tool without `.fn`:
 
-**Correct Testing Pattern**:
 ```python
 # In tests/tools/test_my_tool.py
 from src.tools.my_tool import my_tool
 
-# Access the underlying function
-my_tool_fn = my_tool.fn
-
 @pytest.mark.asyncio
 async def test_my_tool():
-    result = await my_tool_fn(param1="value1", param2="value2")
+    result = await my_tool(param1="value1", param2="value2")
     assert result == "expected"
 ```
-
-**Why This Matters**: Attempting to call decorated functions directly in tests will fail because the decorator returns a `FunctionTool`, `Resource`, or `Prompt` object, not the original function.
 
 ### Dependency Management
 

--- a/memory-hub-mcp/README.md
+++ b/memory-hub-mcp/README.md
@@ -296,15 +296,15 @@ make test                                       # full suite
 .venv/bin/pytest --cov=src --cov-report=html    # with coverage
 ```
 
-The FastMCP decorators wrap tool functions in tool objects; tests access
-the underlying function via the `.fn` attribute:
+In FastMCP 3, `@mcp.tool(...)` returns the function directly, so tests
+call the tool without `.fn`:
 
 ```python
 from src.tools.search_memory import search_memory
 
 @pytest.mark.asyncio
 async def test_search():
-    result = await search_memory.fn(query="container preferences")
+    result = await search_memory(query="container preferences")
     assert "results" in result
 ```
 

--- a/memory-hub-mcp/TESTING.md
+++ b/memory-hub-mcp/TESTING.md
@@ -118,8 +118,13 @@ The Inspector provides a web UI to:
 # Get server info (streamable-http endpoint)
 curl -X POST https://<route-url>/mcp/ \
   -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
   -d '{"jsonrpc":"2.0","method":"initialize","params":{"protocolVersion":"1.0.0","capabilities":{},"clientInfo":{"name":"test","version":"1.0.0"}},"id":1}'
 ```
+
+> **Note:** The `Accept: application/json, text/event-stream` header is
+> required by FastMCP 3.x streamable-HTTP transport. Without it, the server
+> returns HTTP 406 Not Acceptable.
 
 ## Unit Tests
 
@@ -147,16 +152,15 @@ make test
 
 ### Testing FastMCP Decorated Functions
 
-FastMCP decorators wrap functions in special objects. Access the underlying function via `.fn` for direct testing:
+In FastMCP 3, `@mcp.tool(...)` returns the function directly. Tests call
+the tool without `.fn`:
 
 ```python
 from src.tools.my_tool import my_tool
 
-my_tool_fn = my_tool.fn  # Access underlying function
-
 @pytest.mark.asyncio
 async def test_my_tool():
-    result = await my_tool_fn(param1="value1")
+    result = await my_tool(param1="value1")
     assert result == "expected"
 ```
 

--- a/planning/kagenti-design-proposal-memory-services.md
+++ b/planning/kagenti-design-proposal-memory-services.md
@@ -138,7 +138,7 @@ spec:
     name: memoryhub-gateway-token
 ```
 
-Any agent on the platform — regardless of framework — can then discover and call MemoryHub's tools (`memory_search_memory`, `memory_write_memory`, etc.) through the standard `MCP_URL` endpoint.
+Any agent on the platform — regardless of framework — can then discover and call MemoryHub's tools through the standard `MCP_URL` endpoint. With the compact profile (default, `MEMORYHUB_TOOL_PROFILE=compact`), the gateway-prefixed tools are `memory_register_session` and `memory_memory` (action-dispatch). With the full profile (`MEMORYHUB_TOOL_PROFILE=full`), the prefixed tools are `memory_search_memory`, `memory_write_memory`, etc.
 
 **What this gives you:** Every agent gains access to governed memory. The MCP Gateway handles routing. Agents use their existing MCP client patterns. No new abstractions to learn.
 


### PR DESCRIPTION
## Summary

Fixes #252.

- Add required `Accept: application/json, text/event-stream` header to TESTING.md curl example with note about FastMCP 3.x HTTP 406 behavior
- Update Kagenti design proposal tool name references to show both compact (default) and full profile gateway-prefixed names
- Clarify curation near-duplicate behavior: 0.80-0.95 similarity range is advisory only (write succeeds with `possible_duplicate` flag), not blocking
- Fix outdated `.fn` testing pattern in README, TESTING.md, AGENTS.md, implement-mcp-item command, and tool test scaffold to match FastMCP 3 (decorator returns function directly)

## Test plan

- [ ] Verify curl example in TESTING.md includes Accept header
- [ ] Verify curator-agent.md threshold table has "Write succeeds?" column
- [ ] Verify no remaining `.fn` code examples in updated files
- [ ] Spot-check that prose references to "without `.fn`" are explanatory only