### PR TITLE
cli: Add promote command for scope escalation

### DIFF
--- a/memoryhub-cli/src/memoryhub_cli/main.py
+++ b/memoryhub-cli/src/memoryhub_cli/main.py
@@ -619,6 +619,47 @@ def update(
 
 
 @app.command()
+def promote(
+    memory_id: str = typer.Argument(..., help="Memory UUID to promote"),
+    target_scope: str = typer.Argument(
+        ..., help="Target scope: project, organizational, enterprise",
+    ),
+    target_scope_id: str | None = typer.Option(
+        None, "--target-scope-id", help="Scope ID for the target (e.g., project ID)",
+    ),
+    project_id: str | None = typer.Option(
+        None, "--project-id", "-p", help="Project ID for context",
+    ),
+    output: OutputFormat = typer.Option(
+        OutputFormat.table, "--output", "-o", help="Output format: table, json, quiet",
+    ),
+):
+    """Promote a memory to a broader scope."""
+    client = _get_client(output)
+    _project_id = project_id or _get_project_id_default()
+
+    async def _do():
+        async with client:
+            return await client.promote(
+                memory_id,
+                target_scope,
+                target_scope_id=target_scope_id,
+                project_id=_project_id,
+            )
+
+    memory = _run_command(_do(), output)
+
+    if output == OutputFormat.json:
+        json_success(memory.model_dump())
+        return
+    if output == OutputFormat.quiet:
+        return
+
+    console.print(f"[green]Promoted:[/green] {memory.id}")
+    console.print(f"  Scope: {memory.scope} | Weight: {memory.weight:.2f}")
+
+
+@app.command()
 def history(
     memory_id: str = typer.Argument(..., help="Memory UUID"),
     max_versions: int = typer.Option(20, "--max", "-n", help="Maximum versions to show"),

--- a/memoryhub-cli/tests/test_promote.py
+++ b/memoryhub-cli/tests/test_promote.py
@@ -1,0 +1,135 @@
+"""Tests for the promote CLI command."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from memoryhub_cli.main import app
+
+runner = CliRunner()
+
+
+def _mock_memory(**overrides):
+    """Build a mock Memory object with sensible defaults."""
+    defaults = {
+        "id": "abc-123-def-456",
+        "scope": "organizational",
+        "weight": 0.80,
+        "content": "Promoted memory content",
+        "version": 1,
+    }
+    defaults.update(overrides)
+    mem = MagicMock()
+    for k, v in defaults.items():
+        setattr(mem, k, v)
+    mem.model_dump.return_value = defaults
+    return mem
+
+
+@pytest.fixture(autouse=True)
+def _stub_auth(monkeypatch):
+    """Bypass auth so every invoke reaches the command logic."""
+    monkeypatch.setattr("memoryhub_cli.main.get_api_key", lambda: "mh-dev-test")
+    monkeypatch.setattr("memoryhub_cli.main.get_server_url", lambda: "https://mem.example.com")
+    monkeypatch.setattr("memoryhub_cli.main._get_project_id_default", lambda: None)
+
+
+class TestPromote:
+    def test_table_output(self):
+        mock_mem = _mock_memory()
+        with patch("memoryhub_cli.main._get_client") as mock_gc:
+            client = AsyncMock()
+            client.promote.return_value = mock_mem
+            client.__aenter__ = AsyncMock(return_value=client)
+            client.__aexit__ = AsyncMock(return_value=False)
+            mock_gc.return_value = client
+
+            result = runner.invoke(app, ["promote", "abc-123", "organizational"])
+
+        assert result.exit_code == 0
+        assert "Promoted:" in result.output
+        assert "abc-123-def-456" in result.output
+        assert "organizational" in result.output
+        assert "0.80" in result.output
+
+    def test_json_output(self):
+        mock_mem = _mock_memory()
+        with patch("memoryhub_cli.main._get_client") as mock_gc:
+            client = AsyncMock()
+            client.promote.return_value = mock_mem
+            client.__aenter__ = AsyncMock(return_value=client)
+            client.__aexit__ = AsyncMock(return_value=False)
+            mock_gc.return_value = client
+
+            result = runner.invoke(app, ["promote", "abc-123", "organizational", "-o", "json"])
+
+        assert result.exit_code == 0
+        assert '"status": "ok"' in result.output
+        assert "abc-123-def-456" in result.output
+
+    def test_quiet_output(self):
+        mock_mem = _mock_memory()
+        with patch("memoryhub_cli.main._get_client") as mock_gc:
+            client = AsyncMock()
+            client.promote.return_value = mock_mem
+            client.__aenter__ = AsyncMock(return_value=client)
+            client.__aexit__ = AsyncMock(return_value=False)
+            mock_gc.return_value = client
+
+            result = runner.invoke(app, ["promote", "abc-123", "organizational", "-o", "quiet"])
+
+        assert result.exit_code == 0
+        assert result.output.strip() == ""
+
+    def test_missing_required_args(self):
+        result = runner.invoke(app, ["promote"])
+        assert result.exit_code != 0
+
+    def test_missing_target_scope(self):
+        result = runner.invoke(app, ["promote", "abc-123"])
+        assert result.exit_code != 0
+
+    def test_passes_target_scope_id(self):
+        mock_mem = _mock_memory()
+        with patch("memoryhub_cli.main._get_client") as mock_gc:
+            client = AsyncMock()
+            client.promote.return_value = mock_mem
+            client.__aenter__ = AsyncMock(return_value=client)
+            client.__aexit__ = AsyncMock(return_value=False)
+            mock_gc.return_value = client
+
+            result = runner.invoke(app, [
+                "promote", "abc-123", "project",
+                "--target-scope-id", "my-project",
+            ])
+
+        assert result.exit_code == 0
+        client.promote.assert_called_once_with(
+            "abc-123", "project",
+            target_scope_id="my-project",
+            project_id=None,
+        )
+
+    def test_passes_project_id(self):
+        mock_mem = _mock_memory()
+        with patch("memoryhub_cli.main._get_client") as mock_gc:
+            client = AsyncMock()
+            client.promote.return_value = mock_mem
+            client.__aenter__ = AsyncMock(return_value=client)
+            client.__aexit__ = AsyncMock(return_value=False)
+            mock_gc.return_value = client
+
+            result = runner.invoke(app, [
+                "promote", "abc-123", "organizational",
+                "-p", "memory-hub",
+            ])
+
+        assert result.exit_code == 0
+        client.promote.assert_called_once_with(
+            "abc-123", "organizational",
+            target_scope_id=None,
+            project_id="memory-hub",
+        )


### PR DESCRIPTION
## Summary
- Adds `memoryhub promote <memory_id> <target_scope>` command wrapping the SDK's `client.promote()` method
- Follows existing update/delete/read pattern: `_get_client` -> async `_do` -> `_run_command` with structured error handling
- Supports `--target-scope-id`, `--project-id`, and `--output` (table/json/quiet) options

## Test plan
- [x] 7 unit tests covering table, json, quiet output, missing args, and argument passthrough
- [x] Full test suite (82/82 passing) confirms no regressions

Closes #257 (parity item)