### PR TITLE
cli: Add checkpoint command for durable workflow state

### DIFF
--- a/memoryhub-cli/src/memoryhub_cli/main.py
+++ b/memoryhub-cli/src/memoryhub_cli/main.py
@@ -1502,5 +1502,78 @@ def session_focus_history(
     console.print(f"[dim]Total sessions: {total}[/dim]")
 
 
+@app.command()
+def checkpoint(
+    workflow_name: str = typer.Argument(..., help="Workflow identifier"),
+    state: str | None = typer.Option(
+        None, "--state", "-s", help="State as JSON string (upserts if given, reads if omitted)",
+    ),
+    scope: str = typer.Option(
+        "user", "--scope", help="Scope for the checkpoint: user, project",
+    ),
+    project_id: str | None = typer.Option(
+        None, "--project-id", "-p", help="Project ID (required for project scope)",
+    ),
+    output: OutputFormat = typer.Option(
+        OutputFormat.table, "--output", "-o", help="Output format: table, json, quiet",
+    ),
+):
+    """Read or write durable checkpoint state for workflow agents.
+
+    When --state is given (as a JSON string), upserts the checkpoint.
+    When --state is omitted, reads the current checkpoint state.
+    """
+    import json as json_mod
+
+    state_dict = None
+    if state is not None:
+        try:
+            state_dict = json_mod.loads(state)
+        except json_mod.JSONDecodeError as exc:
+            handle_error(
+                "invalid_json",
+                f"--state must be valid JSON: {exc}",
+                output,
+                EXIT_CLIENT_ERROR,
+            )
+
+    client = _get_client(output)
+    _project_id = project_id or _get_project_id_default()
+
+    async def _do():
+        async with client:
+            return await client.checkpoint(
+                workflow_name,
+                state=state_dict,
+                scope=scope,
+                project_id=_project_id,
+            )
+
+    result = _run_command(_do(), output)
+
+    if output == OutputFormat.json:
+        json_success(result)
+        return
+    if output == OutputFormat.quiet:
+        return
+
+    cp_state = result.get("state", {})
+    if result.get("created") is not None:
+        action = "Created" if result["created"] else "Updated"
+        console.print(f"[green]{action} checkpoint:[/green] {workflow_name}")
+        if result.get("memory_id"):
+            console.print(f"  Memory ID: {result['memory_id']}")
+    else:
+        console.print(f"[blue]Checkpoint:[/blue] {workflow_name}")
+
+    if cp_state:
+        state_preview = json_mod.dumps(cp_state, indent=2, default=str)
+        if len(state_preview) > 200:
+            state_preview = state_preview[:200] + "..."
+        console.print(f"  State: {state_preview}")
+    else:
+        console.print("  State: (empty)")
+
+
 if __name__ == "__main__":
     app()

--- a/memoryhub-cli/tests/test_checkpoint.py
+++ b/memoryhub-cli/tests/test_checkpoint.py
@@ -1,0 +1,210 @@
+"""Tests for the checkpoint CLI command."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from memoryhub_cli.main import app
+
+runner = CliRunner()
+
+
+# ── Helpers ─────────────────────────────────────────────────────────────────
+
+
+def _stub_client(checkpoint_return):
+    """Build a mock MemoryHubClient whose checkpoint() returns the given value."""
+    client = MagicMock()
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=False)
+    client.checkpoint = AsyncMock(return_value=checkpoint_return)
+    return client
+
+
+def _patch_client(client_mock):
+    """Context manager that patches _get_client and _get_project_id_default."""
+    return (
+        patch("memoryhub_cli.main._get_client", return_value=client_mock),
+        patch("memoryhub_cli.main._get_project_id_default", return_value=None),
+    )
+
+
+READ_RESPONSE = {
+    "workflow_name": "daily-digest",
+    "state": {"last_run": "2026-06-02", "cursor": 42},
+}
+
+UPSERT_CREATED = {
+    "workflow_name": "daily-digest",
+    "state": {"last_run": "2026-06-03"},
+    "created": True,
+    "memory_id": "abc-123-def",
+}
+
+UPSERT_UPDATED = {
+    "workflow_name": "daily-digest",
+    "state": {"last_run": "2026-06-03"},
+    "created": False,
+    "memory_id": "abc-123-def",
+}
+
+
+# ── Tests ───────────────────────────────────────────────────────────────────
+
+
+class TestCheckpointRead:
+    """checkpoint <workflow> without --state reads existing checkpoint."""
+
+    def test_read_checkpoint_table(self):
+        client = _stub_client(READ_RESPONSE)
+        p1, p2 = _patch_client(client)
+        with p1, p2:
+            result = runner.invoke(app, ["checkpoint", "daily-digest"])
+
+        assert result.exit_code == 0
+        assert "Checkpoint:" in result.output
+        assert "daily-digest" in result.output
+        assert "last_run" in result.output
+        client.checkpoint.assert_awaited_once_with(
+            "daily-digest", state=None, scope="user", project_id=None,
+        )
+
+    def test_read_empty_state(self):
+        client = _stub_client({"workflow_name": "wf", "state": {}})
+        p1, p2 = _patch_client(client)
+        with p1, p2:
+            result = runner.invoke(app, ["checkpoint", "wf"])
+
+        assert result.exit_code == 0
+        assert "(empty)" in result.output
+
+
+class TestCheckpointUpsert:
+    """checkpoint <workflow> --state '...' upserts."""
+
+    def test_upsert_created(self):
+        client = _stub_client(UPSERT_CREATED)
+        p1, p2 = _patch_client(client)
+        with p1, p2:
+            result = runner.invoke(
+                app,
+                ["checkpoint", "daily-digest", "--state", '{"last_run":"2026-06-03"}'],
+            )
+
+        assert result.exit_code == 0
+        assert "Created checkpoint:" in result.output
+        assert "abc-123-def" in result.output
+        client.checkpoint.assert_awaited_once_with(
+            "daily-digest",
+            state={"last_run": "2026-06-03"},
+            scope="user",
+            project_id=None,
+        )
+
+    def test_upsert_updated(self):
+        client = _stub_client(UPSERT_UPDATED)
+        p1, p2 = _patch_client(client)
+        with p1, p2:
+            result = runner.invoke(
+                app,
+                ["checkpoint", "daily-digest", "--state", '{"last_run":"2026-06-03"}'],
+            )
+
+        assert result.exit_code == 0
+        assert "Updated checkpoint:" in result.output
+
+    def test_scope_and_project_forwarded(self):
+        client = _stub_client(UPSERT_CREATED)
+        p1, p2 = _patch_client(client)
+        with p1, p2:
+            result = runner.invoke(
+                app,
+                [
+                    "checkpoint", "wf",
+                    "--state", '{"k": 1}',
+                    "--scope", "project",
+                    "--project-id", "my-proj",
+                ],
+            )
+
+        assert result.exit_code == 0
+        client.checkpoint.assert_awaited_once_with(
+            "wf",
+            state={"k": 1},
+            scope="project",
+            project_id="my-proj",
+        )
+
+
+class TestCheckpointInvalidJson:
+    """--state with non-JSON text should fail."""
+
+    def test_invalid_json_exits_with_error(self):
+        # _get_client should not even be called for invalid JSON
+        p1 = patch("memoryhub_cli.main._get_client", side_effect=AssertionError("should not be called"))
+        p2 = patch("memoryhub_cli.main._get_project_id_default", return_value=None)
+        with p1, p2:
+            result = runner.invoke(
+                app,
+                ["checkpoint", "wf", "--state", "not-json"],
+            )
+
+        assert result.exit_code == 1
+        assert "invalid_json" in result.output or "must be valid JSON" in result.output
+
+
+class TestCheckpointJsonOutput:
+    """--output json wraps result in the standard envelope."""
+
+    def test_json_read(self):
+        client = _stub_client(READ_RESPONSE)
+        p1, p2 = _patch_client(client)
+        with p1, p2:
+            result = runner.invoke(
+                app,
+                ["checkpoint", "daily-digest", "--output", "json"],
+            )
+
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert parsed["status"] == "ok"
+        assert parsed["data"]["workflow_name"] == "daily-digest"
+        assert parsed["data"]["state"]["cursor"] == 42
+
+    def test_json_upsert(self):
+        client = _stub_client(UPSERT_CREATED)
+        p1, p2 = _patch_client(client)
+        with p1, p2:
+            result = runner.invoke(
+                app,
+                [
+                    "checkpoint", "daily-digest",
+                    "--state", '{"last_run":"2026-06-03"}',
+                    "--output", "json",
+                ],
+            )
+
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert parsed["data"]["created"] is True
+        assert parsed["data"]["memory_id"] == "abc-123-def"
+
+
+class TestCheckpointQuietOutput:
+    """--output quiet produces no output."""
+
+    def test_quiet_read(self):
+        client = _stub_client(READ_RESPONSE)
+        p1, p2 = _patch_client(client)
+        with p1, p2:
+            result = runner.invoke(
+                app,
+                ["checkpoint", "daily-digest", "--output", "quiet"],
+            )
+
+        assert result.exit_code == 0
+        assert result.output.strip() == ""


### PR DESCRIPTION
## Summary
- Adds a `checkpoint` top-level CLI command wrapping `client.checkpoint()` from the SDK (#257 parity)
- Supports read mode (no `--state`) and upsert mode (`--state` with JSON string)
- Forwards `--scope` and `--project-id` to the SDK, with project-id defaulting from `.memoryhub.yaml`
- 9 unit tests covering: read, upsert (created/updated), scope+project forwarding, invalid JSON error, JSON output, and quiet output

## Test plan
- [x] `pytest tests/test_checkpoint.py -v` -- 9/9 pass
- [x] Full test suite `pytest tests/ -v` -- 84/84 pass
- [x] Code review -- no correctness bugs found