### PR TITLE
cli+sdk: Add describe_project for project detail view

### DIFF
--- a/memoryhub-cli/src/memoryhub_cli/main.py
+++ b/memoryhub-cli/src/memoryhub_cli/main.py
@@ -1395,6 +1395,47 @@ def project_remove_member(
     console.print(f"[green]Removed[/green] {user_id} from {project_name}")
 
 
+@project_app.command("describe")
+def project_describe(
+    project_id: str = typer.Argument(..., help="Project identifier"),
+    output: OutputFormat = typer.Option(
+        OutputFormat.table, "--output", "-o", help="Output format: table, json, quiet",
+    ),
+):
+    """Show detailed project information and member list."""
+    client = _get_client(output)
+
+    async def _do():
+        async with client:
+            return await client.describe_project(project_id)
+
+    result = _run_command(_do(), output)
+
+    if output == OutputFormat.json:
+        json_success(result)
+        return
+    if output == OutputFormat.quiet:
+        return
+
+    console.print(f"[bold]{result.get('name', project_id)}[/bold]")
+    if result.get("description"):
+        console.print(f"  {result['description']}")
+
+    members = result.get("members", [])
+    if members:
+        table = Table(title="Members")
+        table.add_column("User ID")
+        table.add_column("Role")
+        for member in members:
+            table.add_row(
+                str(member.get("user_id", "")),
+                str(member.get("role", "")),
+            )
+        console.print(table)
+    else:
+        console.print("  No members")
+
+
 # ── memoryhub session ─────────────────────────────────────────────────────────
 
 

--- a/memoryhub-cli/tests/test_describe_project.py
+++ b/memoryhub-cli/tests/test_describe_project.py
@@ -1,0 +1,123 @@
+"""Tests for `memoryhub project describe` CLI command."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+from typer.testing import CliRunner
+
+from memoryhub_cli.main import app
+
+runner = CliRunner()
+
+# ── Fixtures ─────────────────────────────────────────────────────────────────
+
+SAMPLE_PROJECT = {
+    "name": "memory-hub",
+    "description": "Kubernetes-native agent memory",
+    "members": [
+        {"user_id": "wjackson", "role": "admin"},
+        {"user_id": "agent-01", "role": "member"},
+    ],
+}
+
+SAMPLE_PROJECT_NO_DESC = {
+    "name": "empty-proj",
+    "members": [],
+}
+
+
+def _patch_describe(return_value):
+    """Patch MemoryHubClient to return *return_value* from describe_project."""
+    mock_client = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mock_client.describe_project = AsyncMock(return_value=return_value)
+    return patch("memoryhub_cli.main._get_client", return_value=mock_client)
+
+
+# ── Table output ─────────────────────────────────────────────────────────────
+
+
+class TestDescribeProjectTable:
+    def test_shows_project_name(self):
+        with _patch_describe(SAMPLE_PROJECT):
+            result = runner.invoke(app, ["project", "describe", "memory-hub"])
+
+        assert result.exit_code == 0
+        assert "memory-hub" in result.output
+
+    def test_shows_description(self):
+        with _patch_describe(SAMPLE_PROJECT):
+            result = runner.invoke(app, ["project", "describe", "memory-hub"])
+
+        assert result.exit_code == 0
+        assert "Kubernetes-native agent memory" in result.output
+
+    def test_shows_members_table(self):
+        with _patch_describe(SAMPLE_PROJECT):
+            result = runner.invoke(app, ["project", "describe", "memory-hub"])
+
+        assert result.exit_code == 0
+        assert "wjackson" in result.output
+        assert "admin" in result.output
+        assert "agent-01" in result.output
+        assert "member" in result.output
+
+    def test_no_members(self):
+        with _patch_describe(SAMPLE_PROJECT_NO_DESC):
+            result = runner.invoke(app, ["project", "describe", "empty-proj"])
+
+        assert result.exit_code == 0
+        assert "No members" in result.output
+
+    def test_no_description_omits_line(self):
+        with _patch_describe(SAMPLE_PROJECT_NO_DESC):
+            result = runner.invoke(app, ["project", "describe", "empty-proj"])
+
+        assert result.exit_code == 0
+        assert "empty-proj" in result.output
+        # Should not print a blank description line
+        assert "Kubernetes" not in result.output
+
+
+# ── JSON output ──────────────────────────────────────────────────────────────
+
+
+class TestDescribeProjectJSON:
+    def test_json_output(self):
+        with _patch_describe(SAMPLE_PROJECT):
+            result = runner.invoke(
+                app, ["project", "describe", "memory-hub", "--output", "json"]
+            )
+
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert parsed["data"]["name"] == "memory-hub"
+        assert len(parsed["data"]["members"]) == 2
+
+
+# ── Quiet output ─────────────────────────────────────────────────────────────
+
+
+class TestDescribeProjectQuiet:
+    def test_quiet_output_minimal(self):
+        with _patch_describe(SAMPLE_PROJECT):
+            result = runner.invoke(
+                app, ["project", "describe", "memory-hub", "--output", "quiet"]
+            )
+
+        assert result.exit_code == 0
+        # Quiet mode should not print the table or project name
+        assert "Members" not in result.output
+
+
+# ── Help text ────────────────────────────────────────────────────────────────
+
+
+class TestDescribeProjectHelp:
+    def test_describe_in_help(self):
+        result = runner.invoke(app, ["project", "--help"])
+        assert result.exit_code == 0
+        assert "describe" in result.output

--- a/sdk/src/memoryhub/client.py
+++ b/sdk/src/memoryhub/client.py
@@ -1139,6 +1139,24 @@ class MemoryHubClient:
             options={"user_id": user_id},
         )
 
+    async def describe_project(self, project_id: str) -> dict[str, Any]:
+        """Get detailed information about a project including members.
+
+        Args:
+            project_id: Project identifier.
+
+        Returns:
+            Dict with project details: name, description, members list.
+
+        Raises:
+            NotFoundError: Project does not exist.
+            PermissionDeniedError: Not a project member.
+        """
+        return await self._call_action(
+            "describe_project",
+            project_id=project_id,
+        )
+
     # ── Session focus (#61) ─────────────────────────────────────────
 
     async def get_session(self) -> dict[str, Any]:

--- a/sdk/tests/test_describe_project.py
+++ b/sdk/tests/test_describe_project.py
@@ -1,0 +1,116 @@
+"""Tests for MemoryHubClient.describe_project."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from unittest.mock import AsyncMock
+
+import pytest
+
+from memoryhub.client import MemoryHubClient
+
+
+# ── Fake MCP response types (mirrors test_client.py) ─────────────────────────
+
+
+@dataclass
+class FakeContent:
+    text: str
+    type: str = "text"
+
+
+@dataclass
+class FakeCallToolResult:
+    content: list = field(default_factory=list)
+    structured_content: dict | None = None
+    data: object = None
+    is_error: bool = False
+    meta: dict | None = None
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+
+SAMPLE_PROJECT = {
+    "name": "memory-hub",
+    "description": "Kubernetes-native agent memory",
+    "members": [
+        {"user_id": "wjackson", "role": "admin"},
+        {"user_id": "agent-01", "role": "member"},
+    ],
+}
+
+
+def _make_client() -> MemoryHubClient:
+    return MemoryHubClient(url="https://fake.example.com/mcp/", api_key="mh-dev-test")
+
+
+def _payload(mock_mcp) -> dict:
+    """Merge top-level args and options for easy assertions."""
+    args = mock_mcp.call_tool.call_args[0][1]
+    flat = {k: v for k, v in args.items() if k != "options"}
+    flat.update(args.get("options") or {})
+    return flat
+
+
+# ── Tests ────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_describe_project_dispatches_correct_action():
+    """describe_project sends action='describe_project' with project_id."""
+    c = _make_client()
+    mock_mcp = AsyncMock()
+    c._mcp = mock_mcp
+
+    mock_mcp.call_tool.return_value = FakeCallToolResult(
+        content=[FakeContent(text=json.dumps(SAMPLE_PROJECT))],
+    )
+
+    result = await c.describe_project("memory-hub")
+
+    tool_name = mock_mcp.call_tool.call_args[0][0]
+    assert tool_name == "memory"
+
+    payload = mock_mcp.call_tool.call_args[0][1]
+    assert payload["action"] == "describe_project"
+    assert payload["project_id"] == "memory-hub"
+
+
+@pytest.mark.asyncio
+async def test_describe_project_returns_raw_dict():
+    """Result is a raw dict, not a Pydantic model."""
+    c = _make_client()
+    mock_mcp = AsyncMock()
+    c._mcp = mock_mcp
+
+    mock_mcp.call_tool.return_value = FakeCallToolResult(
+        content=[FakeContent(text=json.dumps(SAMPLE_PROJECT))],
+    )
+
+    result = await c.describe_project("memory-hub")
+
+    assert isinstance(result, dict)
+    assert result["name"] == "memory-hub"
+    assert len(result["members"]) == 2
+    assert result["members"][0]["user_id"] == "wjackson"
+    assert result["members"][0]["role"] == "admin"
+
+
+@pytest.mark.asyncio
+async def test_describe_project_minimal_response():
+    """Handles a project with no description or members."""
+    c = _make_client()
+    mock_mcp = AsyncMock()
+    c._mcp = mock_mcp
+
+    minimal = {"name": "empty-proj", "members": []}
+    mock_mcp.call_tool.return_value = FakeCallToolResult(
+        content=[FakeContent(text=json.dumps(minimal))],
+    )
+
+    result = await c.describe_project("empty-proj")
+
+    assert result["name"] == "empty-proj"
+    assert result["members"] == []


### PR DESCRIPTION
## Summary

- Adds `MemoryHubClient.describe_project(project_id)` to the SDK, dispatching `action="describe_project"` via `_call_action` and returning a raw dict
- Adds `memoryhub project describe <project_id>` CLI command with table, json, and quiet output modes
- Includes unit tests for both SDK (3 tests) and CLI (8 tests), all passing

Closes parity gap for `describe_project` identified in #257.

## Test plan

- [x] SDK unit tests pass (`sdk/tests/test_describe_project.py` - 3 tests)
- [x] CLI unit tests pass (`memoryhub-cli/tests/test_describe_project.py` - 8 tests)
- [x] Full SDK test suite passes (248 passed, 8 skipped)
- [x] Full CLI test suite passes (83 passed)
- [ ] Manual e2e against live cluster (deferred per task instructions)