### PR TITLE
mcp-server: Add compact response mode for search and list (#255)

### DIFF
--- a/memory-hub-mcp/src/tools/list_memory.py
+++ b/memory-hub-mcp/src/tools/list_memory.py
@@ -83,6 +83,16 @@ async def list_memory(
             ),
         ),
     ] = None,
+    verbose: Annotated[
+        bool,
+        Field(
+            description=(
+                "Return full metadata per result. When False, returns only "
+                "id + content, dramatically reducing token overhead. "
+                "The unified memory() dispatcher defaults to False for agent callers."
+            ),
+        ),
+    ] = True,
     ctx: Context = None,
 ) -> dict[str, Any]:
     """List memories in a scope without semantic search.
@@ -159,10 +169,17 @@ async def list_memory(
 
     formatted: list[dict[str, Any]] = []
     for item in results:
-        entry = item.model_dump(mode="json")
-        entry["result_type"] = "full" if isinstance(item, MemoryNodeRead) else "stub"
         if not include_branches and item.branch_type is not None:
             continue
+        if verbose:
+            entry = item.model_dump(mode="json")
+            entry["result_type"] = "full" if isinstance(item, MemoryNodeRead) else "stub"
+        else:
+            entry = {"id": str(item.id)}
+            if isinstance(item, MemoryNodeRead):
+                entry["content"] = item.content
+            else:
+                entry["content"] = item.stub
         formatted.append(entry)
 
     return {

--- a/memory-hub-mcp/src/tools/memory.py
+++ b/memory-hub-mcp/src/tools/memory.py
@@ -36,11 +36,11 @@ _SEARCH_OPTS = frozenset({
     "max_response_tokens", "raw_results", "weight_threshold",
     "current_only", "owner_id", "graph_depth",
     "graph_relationship_types", "graph_boost_weight", "entities",
-    "content_type",
+    "content_type", "verbose",
 })
 _LIST_OPTS = frozenset({
     "max_results", "cursor", "include_branches", "current_only",
-    "content_type",
+    "content_type", "verbose",
 })
 _READ_OPTS = frozenset({
     "include_versions", "history_offset", "history_max_versions", "hydrate",
@@ -270,17 +270,24 @@ async def memory(
 async def _dispatch_search(query, scope, project_id, opts, ctx):
     from src.tools.search_memory import search_memory
     _require("search", "query", query)
+    kwargs = _forward(opts, _SEARCH_OPTS)
+    # Compact by default at the dispatcher level -- agents get minimal
+    # token overhead unless they explicitly request verbose=True.
+    kwargs.setdefault("verbose", False)
     return await search_memory(
         query=query, scope=scope, project_id=project_id, ctx=ctx,
-        **_forward(opts, _SEARCH_OPTS),
+        **kwargs,
     )
 
 
 async def _dispatch_list(scope, project_id, opts, ctx):
     from src.tools.list_memory import list_memory
+    kwargs = _forward(opts, _LIST_OPTS)
+    # Compact by default at the dispatcher level.
+    kwargs.setdefault("verbose", False)
     return await list_memory(
         scope=scope, project_id=project_id, ctx=ctx,
-        **_forward(opts, _LIST_OPTS),
+        **kwargs,
     )
 
 
@@ -351,6 +358,8 @@ async def _dispatch_reconstruct(scope, project_id, opts, ctx):
     search_opts = _forward(opts, _RECONSTRUCT_OPTS)
     search_opts["content_type"] = "behavioral"
     search_opts["raw_results"] = True
+    # Compact by default at the dispatcher level.
+    search_opts.setdefault("verbose", False)
     # Default query for reconstruct: broad semantic search for all behavioral
     # memories. Callers can provide a more specific query via the search action
     # if they want to filter behavioral memories by topic.

--- a/memory-hub-mcp/src/tools/search_memory.py
+++ b/memory-hub-mcp/src/tools/search_memory.py
@@ -119,19 +119,58 @@ def _estimate_tokens(payload: dict[str, Any]) -> int:
     return max(1, len(json.dumps(payload, default=str)) // _CHARS_PER_TOKEN)
 
 
+def _compact_entry(
+    item: MemoryNodeRead | MemoryNodeStub,
+    entry_type: str,
+    relevance_score: float | None = None,
+) -> dict[str, Any]:
+    """Build a compact {id, content, result_type} projection.
+
+    Used when verbose=False to dramatically reduce token overhead.
+    Includes relevance_score when provided (raw_results mode).
+    """
+    entry: dict[str, Any] = {
+        "id": str(item.id),
+        "result_type": entry_type,
+    }
+    if isinstance(item, MemoryNodeRead):
+        entry["content"] = item.content
+    else:
+        entry["content"] = item.stub
+    if relevance_score is not None:
+        entry["relevance_score"] = round(relevance_score, 4)
+    return entry
+
+
 def _format_entry(
     item: MemoryNodeRead | MemoryNodeStub,
     relevance_score: float,
     nested_branches: list[tuple[MemoryNodeRead | MemoryNodeStub, float]],
+    verbose: bool = True,
 ) -> tuple[dict[str, Any], int]:
     """Build the JSON-ready dict for one result entry and estimate its cost.
 
     nested_branches is the list of branch results (with their scores) that
     should appear under this entry's "branches" field. Pass an empty list
     when not nesting.
+
+    When verbose=False, returns a compact {id, content, result_type} projection
+    with relevance_score included.
     """
+    entry_type = "full" if isinstance(item, MemoryNodeRead) else "stub"
+
+    if not verbose:
+        entry = _compact_entry(item, entry_type, relevance_score=relevance_score)
+        if nested_branches:
+            entry["branches"] = [
+                _compact_entry(b, "full" if isinstance(b, MemoryNodeRead) else "stub",
+                               relevance_score=bs)
+                for b, bs in nested_branches
+            ]
+        return entry, _estimate_tokens(entry)
+
     entry = item.model_dump(mode="json")
-    entry["result_type"] = "full" if isinstance(item, MemoryNodeRead) else "stub"
+    entry["result_type"] = entry_type
     entry["relevance_score"] = round(relevance_score, 4)
     # Guide agents from chunk hits to the parent memory's full content
     if item.branch_type == "chunk" and item.parent_id is not None:
@@ -156,10 +195,25 @@ def _format_entry_cached(
     item: MemoryNodeRead | MemoryNodeStub,
     nested_branches: list[tuple[MemoryNodeRead | MemoryNodeStub, float]],
     is_appendix: bool = False,
+    verbose: bool = True,
 ) -> tuple[dict[str, Any], int]:
-    """Build cache-optimized entry -- no relevance_score, adds is_appendix."""
+    """Build cache-optimized entry -- no relevance_score, adds is_appendix.
+
+    When verbose=False, returns a compact {id, content, result_type} projection.
+    """
+    entry_type = "full" if isinstance(item, MemoryNodeRead) else "stub"
+
+    if not verbose:
+        entry = _compact_entry(item, entry_type)
+        if nested_branches:
+            entry["branches"] = [
+                _compact_entry(b, "full" if isinstance(b, MemoryNodeRead) else "stub")
+                for b, _ in nested_branches
+            ]
+        return entry, _estimate_tokens(entry)
+
     entry = item.model_dump(mode="json")
-    entry["result_type"] = "full" if isinstance(item, MemoryNodeRead) else "stub"
+    entry["result_type"] = entry_type
     entry["is_appendix"] = is_appendix
     if item.branch_type == "chunk" and item.parent_id is not None:
         entry["parent_hint"] = (
@@ -593,6 +647,16 @@ async def search_memory(
             ),
         ),
     ] = False,
+    verbose: Annotated[
+        bool,
+        Field(
+            description=(
+                "Return full metadata per result. When False, returns only "
+                "id + content + result_type, dramatically reducing token overhead. "
+                "The unified memory() dispatcher defaults to False for agent callers."
+            ),
+        ),
+    ] = True,
     content_type: Annotated[
         str | None,
         Field(
@@ -960,13 +1024,16 @@ async def search_memory(
                         for b, s in child_branches
                     ]
                     entry, cost = _format_entry_cached(
-                        output_item, output_branches, is_appendix
+                        output_item, output_branches, is_appendix,
+                        verbose=verbose,
                     )
                     formatted.append(entry)
                     budget = max(0, budget - cost)
                     continue
 
-                entry, cost = _format_entry_cached(item, child_branches, is_appendix)
+                entry, cost = _format_entry_cached(
+                    item, child_branches, is_appendix, verbose=verbose,
+                )
                 if isinstance(item, MemoryNodeStub) or cost <= budget:
                     formatted.append(entry)
                     budget = max(0, budget - cost)
@@ -978,7 +1045,8 @@ async def search_memory(
                         for b, s in child_branches
                     ]
                     stub_entry, stub_cost = _format_entry_cached(
-                        stub_item, stub_branches, is_appendix
+                        stub_item, stub_branches, is_appendix,
+                        verbose=verbose,
                     )
                     formatted.append(stub_entry)
                     budget = max(0, budget - stub_cost)
@@ -999,14 +1067,17 @@ async def search_memory(
                         for b, s in child_branches
                     ]
                     entry, cost = _format_entry(
-                        output_item, relevance_score, output_branches
+                        output_item, relevance_score, output_branches,
+                        verbose=verbose,
                     )
                     formatted.append(entry)
                     budget = max(0, budget - cost)
                     continue
 
                 # Try the full form first.
-                entry, cost = _format_entry(item, relevance_score, child_branches)
+                entry, cost = _format_entry(
+                    item, relevance_score, child_branches, verbose=verbose,
+                )
                 if isinstance(item, MemoryNodeStub) or cost <= budget:
                     formatted.append(entry)
                     budget = max(0, budget - cost)
@@ -1021,7 +1092,8 @@ async def search_memory(
                         for b, s in child_branches
                     ]
                     stub_entry, stub_cost = _format_entry(
-                        stub_item, relevance_score, stub_branches
+                        stub_item, relevance_score, stub_branches,
+                        verbose=verbose,
                     )
                     formatted.append(stub_entry)
                     budget = max(0, budget - stub_cost)

--- a/memory-hub-mcp/tests/test_memory_dispatcher.py
+++ b/memory-hub-mcp/tests/test_memory_dispatcher.py
@@ -71,7 +71,7 @@ class TestActionValidation:
         assert "write" in msg
 
     def test_valid_actions_count(self):
-        assert len(_VALID_ACTIONS) == 20
+        assert len(_VALID_ACTIONS) == 24
 
 
 # ── Required param validation ──────────────────────────────────────────────
@@ -208,6 +208,8 @@ class TestDispatchRouting:
         assert call_kwargs["project_id"] == "proj"
         assert call_kwargs["max_results"] == 5
         assert call_kwargs["focus"] == "deployment"
+        # Dispatcher injects verbose=False by default (#255)
+        assert call_kwargs["verbose"] is False
 
     @pytest.mark.asyncio
     @patch("src.tools.list_memory.list_memory", new_callable=AsyncMock)
@@ -223,6 +225,8 @@ class TestDispatchRouting:
         assert call_kwargs["project_id"] == "my-proj"
         assert call_kwargs["max_results"] == 50
         assert call_kwargs["cursor"] == "2026-05-01T00:00:00"
+        # Dispatcher injects verbose=False by default (#255)
+        assert call_kwargs["verbose"] is False
 
     @pytest.mark.asyncio
     @patch("src.tools.read_memory.read_memory", new_callable=AsyncMock)
@@ -396,6 +400,55 @@ class TestDispatchRouting:
         )
         kw = mock_proj.call_args[1]
         assert kw["project_name"] == "explicit"
+
+
+# ── Compact default at dispatcher level (#255) ────────────────────────────
+
+class TestCompactDefault:
+    """The dispatcher injects verbose=False so agents get compact output,
+    while direct callers of search_memory/list_memory keep verbose=True."""
+
+    @pytest.mark.asyncio
+    @patch("src.tools.search_memory.search_memory", new_callable=AsyncMock)
+    async def test_search_defaults_verbose_false(self, mock_search):
+        """Dispatcher injects verbose=False when caller omits it."""
+        mock_search.return_value = {"results": []}
+        await memory(action="search", query="test")
+        kw = mock_search.call_args[1]
+        assert kw["verbose"] is False
+
+    @pytest.mark.asyncio
+    @patch("src.tools.search_memory.search_memory", new_callable=AsyncMock)
+    async def test_search_respects_explicit_verbose_true(self, mock_search):
+        """Caller can override to verbose=True via options."""
+        mock_search.return_value = {"results": []}
+        await memory(
+            action="search", query="test",
+            options={"verbose": True},
+        )
+        kw = mock_search.call_args[1]
+        assert kw["verbose"] is True
+
+    @pytest.mark.asyncio
+    @patch("src.tools.list_memory.list_memory", new_callable=AsyncMock)
+    async def test_list_defaults_verbose_false(self, mock_list):
+        """Dispatcher injects verbose=False when caller omits it."""
+        mock_list.return_value = {"results": [], "count": 0, "has_more": False}
+        await memory(action="list")
+        kw = mock_list.call_args[1]
+        assert kw["verbose"] is False
+
+    @pytest.mark.asyncio
+    @patch("src.tools.list_memory.list_memory", new_callable=AsyncMock)
+    async def test_list_respects_explicit_verbose_true(self, mock_list):
+        """Caller can override to verbose=True via options."""
+        mock_list.return_value = {"results": [], "count": 0, "has_more": False}
+        await memory(
+            action="list",
+            options={"verbose": True},
+        )
+        kw = mock_list.call_args[1]
+        assert kw["verbose"] is True
 
 
 # ── Options isolation ──────────────────────────────────────────────────────

--- a/memory-hub-mcp/tests/tools/test_list_compact.py
+++ b/memory-hub-mcp/tests/tools/test_list_compact.py
@@ -1,0 +1,165 @@
+"""Tests for list_memory compact response mode (#255)."""
+
+import inspect
+import uuid as _uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+import src.tools.auth as auth_mod
+from src.tools.list_memory import list_memory
+
+
+def _fake_list_item(content: str, weight: float = 0.8, *, branch_type=None):
+    """Build a MemoryNodeRead for list_memory test fixtures."""
+    from memoryhub_core.models.schemas import MemoryNodeRead, MemoryScope, StorageType
+
+    return MemoryNodeRead(
+        id=_uuid.uuid4(),
+        parent_id=None,
+        content=content,
+        stub=content[:80],
+        storage_type=StorageType.INLINE,
+        content_ref=None,
+        weight=weight,
+        scope=MemoryScope.USER,
+        branch_type=branch_type,
+        owner_id="wjackson",
+        tenant_id="default",
+        is_current=True,
+        version=1,
+        previous_version_id=None,
+        metadata=None,
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+        expires_at=None,
+        has_children=False,
+        has_rationale=False,
+        branch_count=0,
+    )
+
+
+async def _run_list(items, **kwargs):
+    """Run list_memory with patched dependencies and canned results."""
+    mock_session = AsyncMock()
+    mock_gen = AsyncMock()
+
+    auth_mod._current_session = {
+        "user_id": "wjackson",
+        "scopes": ["user"],
+        "identity_type": "user",
+    }
+    try:
+        with (
+            patch(
+                "src.tools.list_memory.get_db_session",
+                return_value=(mock_session, mock_gen),
+            ),
+            patch(
+                "src.tools.list_memory.release_db_session",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "src.tools.list_memory.list_memories",
+                new_callable=AsyncMock,
+                return_value=(items, None),
+            ),
+            patch(
+                "src.tools.list_memory.ROLE_ISOLATION_ENABLED",
+                False,
+            ),
+            patch(
+                "src.tools.list_memory.PROJECT_ISOLATION_ENABLED",
+                False,
+            ),
+        ):
+            return await list_memory(**kwargs)
+    finally:
+        auth_mod._current_session = None
+
+
+def test_list_memory_verbose_parameter_defaults_true():
+    """Verify the verbose parameter exists and defaults to True.
+
+    The tool function defaults to True for backward compatibility with
+    direct callers. The unified memory() dispatcher overrides this to
+    False so agents get compact output by default (#255).
+    """
+    sig = inspect.signature(list_memory)
+    params = sig.parameters
+    assert "verbose" in params
+    assert params["verbose"].default is True
+
+
+@pytest.mark.asyncio
+async def test_list_compact_explicit_returns_id_and_content():
+    """Explicit verbose=False returns compact {id, content} entries."""
+    item = _fake_list_item("Use Podman for containers")
+    result = await _run_list([item], verbose=False)
+
+    assert len(result["results"]) == 1
+    entry = result["results"][0]
+    assert "id" in entry
+    assert "content" in entry
+    assert entry["content"] == "Use Podman for containers"
+    # Compact mode omits metadata
+    assert "weight" not in entry
+    assert "scope" not in entry
+    assert "owner_id" not in entry
+    assert "result_type" not in entry
+    assert "created_at" not in entry
+
+
+@pytest.mark.asyncio
+async def test_list_verbose_true_returns_full_metadata():
+    """verbose=True returns the full model_dump with all metadata fields."""
+    item = _fake_list_item("Use Podman for containers", weight=0.9)
+    result = await _run_list([item], verbose=True)
+
+    entry = result["results"][0]
+    assert "id" in entry
+    assert "content" in entry
+    assert "weight" in entry
+    assert "scope" in entry
+    assert "owner_id" in entry
+    assert "result_type" in entry
+    assert entry["result_type"] == "full"
+
+
+@pytest.mark.asyncio
+async def test_list_compact_multiple_items():
+    """Compact mode works correctly for multiple items."""
+    items = [
+        _fake_list_item("First memory"),
+        _fake_list_item("Second memory"),
+        _fake_list_item("Third memory"),
+    ]
+    result = await _run_list(items, verbose=False)
+
+    assert len(result["results"]) == 3
+    for entry in result["results"]:
+        assert set(entry.keys()) == {"id", "content"}
+
+
+@pytest.mark.asyncio
+async def test_list_compact_excludes_branches_by_default():
+    """Compact mode still respects include_branches=False filtering."""
+    parent = _fake_list_item("Parent memory")
+    branch = _fake_list_item("Branch memory", branch_type="rationale")
+    result = await _run_list([parent, branch], verbose=False)
+
+    assert len(result["results"]) == 1
+    assert result["results"][0]["content"] == "Parent memory"
+
+
+@pytest.mark.asyncio
+async def test_list_response_envelope_unchanged():
+    """The response envelope (count, has_more, next_cursor) is unaffected
+    by compact mode."""
+    items = [_fake_list_item("A memory")]
+    result = await _run_list(items, verbose=False)
+
+    assert result["count"] == 1
+    assert result["has_more"] is False
+    assert result["next_cursor"] is None

--- a/memory-hub-mcp/tests/tools/test_search_memory.py
+++ b/memory-hub-mcp/tests/tools/test_search_memory.py
@@ -1672,6 +1672,103 @@ async def test_graph_boost_weight_forwarded_to_service():
 
 
 # ---------------------------------------------------------------------------
+# #255 — compact response mode (verbose=False default)
+# ---------------------------------------------------------------------------
+
+
+def test_search_memory_verbose_parameter_defaults_true():
+    """Verify the verbose parameter exists and defaults to True.
+
+    The tool function defaults to True for backward compatibility with
+    direct callers. The unified memory() dispatcher overrides this to
+    False so agents get compact output by default (#255).
+    """
+    sig = inspect.signature(search_memory)
+    params = sig.parameters
+    assert "verbose" in params
+    assert params["verbose"].default is True
+
+
+@pytest.mark.asyncio
+async def test_search_compact_explicit_returns_id_and_content():
+    """Explicit verbose=False returns compact {id, content, result_type} entries
+    without full metadata fields like weight, scope, owner_id, etc."""
+    full, score = _fake_full_result("Use Podman for containers", weight=0.9)
+    result = await _patched_search_call(
+        page_results=[(full, score)],
+        total_matching=1,
+        verbose=False,
+    ).run()
+
+    entry = result["results"][0]
+    assert "id" in entry
+    assert "content" in entry
+    assert entry["content"] == "Use Podman for containers"
+    assert entry["result_type"] == "full"
+    # Compact mode omits metadata fields
+    assert "weight" not in entry
+    assert "scope" not in entry
+    assert "owner_id" not in entry
+    assert "tenant_id" not in entry
+    assert "created_at" not in entry
+    assert "updated_at" not in entry
+
+
+@pytest.mark.asyncio
+async def test_search_verbose_true_returns_full_metadata():
+    """verbose=True returns the full model_dump with all metadata fields."""
+    full, score = _fake_full_result("Use Podman for containers", weight=0.9)
+    result = await _patched_search_call(
+        page_results=[(full, score)],
+        total_matching=1,
+        verbose=True,
+    ).run()
+
+    entry = result["results"][0]
+    assert "id" in entry
+    assert "content" in entry
+    assert "weight" in entry
+    assert "scope" in entry
+    assert "owner_id" in entry
+    assert "created_at" in entry
+
+
+@pytest.mark.asyncio
+async def test_search_compact_raw_results_includes_relevance_score():
+    """In compact mode with raw_results=True, relevance_score is included."""
+    full, score = _fake_full_result("memory", weight=0.9, score=0.85)
+    result = await _patched_search_call(
+        page_results=[(full, score)],
+        total_matching=1,
+        raw_results=True,
+        verbose=False,
+    ).run()
+
+    entry = result["results"][0]
+    assert "relevance_score" in entry
+    assert entry["relevance_score"] == 0.85
+    # But still compact - no metadata
+    assert "weight" not in entry
+    assert "scope" not in entry
+
+
+@pytest.mark.asyncio
+async def test_search_compact_stub_uses_stub_text():
+    """Compact mode for stubs uses the stub text as content."""
+    stub_result = _fake_search_result("Stub summary text", weight=0.3)
+    result = await _patched_search_call(
+        page_results=[stub_result],
+        total_matching=1,
+        verbose=False,
+    ).run()
+
+    entry = result["results"][0]
+    assert entry["content"] == "Stub summary text"
+    assert entry["result_type"] == "stub"
+    assert "weight" not in entry
+
+
+# ---------------------------------------------------------------------------
 # PR 1 — entity scope exclusion
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Add `verbose` parameter (default `True`) to `search_memory` and `list_memory` tools. When `verbose=False`, responses return only `id` and `content` (plus `relevance_score` for raw search results), stripping metadata fields like `scope`, `owner_id`, `created_at`, `weight`, and `content_type`.
- The `memory` dispatcher injects `verbose=False` by default for `search`, `list`, and `reconstruct` actions, so agents using the compact profile get minimal token overhead without explicit opt-in.
- Agents calling individual tools directly still get full metadata by default (`verbose=True`).

## Test plan

- [x] `test_search_memory.py` -- 6 new compact-mode tests (verbose default, compact explicit, verbose true, raw results compact, stub compact)
- [x] `test_list_compact.py` -- 6 new compact-mode tests (verbose default, compact explicit, verbose true, multiple items, branch exclusion, envelope unchanged)
- [x] `test_memory_dispatcher.py` -- 4 new `TestCompactDefault` tests verifying dispatcher injects `verbose=False` for search and list, and respects explicit `verbose=True`
- [x] All 114 compact/dispatcher/search/list tests pass