### PR TITLE
entity-extraction: Add LLM Stage 3 fallback extractor (#249)

### DIFF
--- a/prompts/entity_extraction.yaml
+++ b/prompts/entity_extraction.yaml
@@ -1,0 +1,43 @@
+name: "Entity Extraction"
+description: >
+  Structured extraction prompt for the Stage 3 LLM fallback in the entity
+  extraction pipeline (#249). Extracts POLE+O entities and inter-entity
+  relationships from agent memory content.
+
+parameters:
+  - temperature: 0.0
+  - max_tokens: 2000
+
+variables:
+  - name: "text"
+    type: "string"
+    description: "The memory content to extract entities and relationships from."
+    required: true
+
+system_prompt: |
+  You are an entity extraction system. Extract entities and relationships
+  from the given text. Return a JSON object with two arrays:
+
+  "entities": each with:
+    - "name": the canonical name of the entity
+    - "type": one of "person", "organization", "location", "event", "object"
+    - "confidence": a float between 0.0 and 1.0
+
+  "relationships": each with:
+    - "source_name": name of the source entity (must match an entity name above)
+    - "target_name": name of the target entity (must match an entity name above)
+    - "relationship_type": a short label like "uses", "works_at", "part_of",
+      "located_in", "created_by", "depends_on", "related_to"
+
+  Rules:
+  - Only extract entities that are clearly named in the text.
+  - Use "object" for software, tools, technologies, frameworks, databases, and
+    abstract technical concepts.
+  - Use the most specific relationship type that fits. Fall back to "related_to"
+    when no specific type applies.
+  - Do not invent entities or relationships not supported by the text.
+  - Do not include generic pronouns or unnamed references as entities.
+  - Relationship source_name and target_name must exactly match an entity name
+    in the entities array.
+
+template: "{text}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "psycopg2-binary",
     "spacy>=3.7",
     "gliner>=0.2.7",
+    "pyyaml",
 ]
 
 [project.optional-dependencies]

--- a/src/memoryhub_core/config.py
+++ b/src/memoryhub_core/config.py
@@ -82,3 +82,10 @@ class AppSettings(BaseSettings):
     gliner_confidence_threshold: float = 0.5
     gliner_stage2_trigger_count: int = 2
     gliner_stage2_trigger_confidence: float = 0.8
+
+    # LLM Stage 3 (#249)
+    llm_extraction_url: str = ""
+    llm_extraction_model: str = ""
+    llm_extraction_timeout: int = 60
+    llm_stage3_trigger_count: int = 2
+    llm_stage3_trigger_confidence: float = 0.7

--- a/src/memoryhub_core/services/exceptions.py
+++ b/src/memoryhub_core/services/exceptions.py
@@ -119,6 +119,18 @@ class EmbeddingServiceUnavailableError(EmbeddingServiceError):
         super().__init__(f"Embedding service unavailable: {reason}")
 
 
+class LLMExtractionServiceError(Exception):
+    """Base class for LLM extraction service failures."""
+
+
+class LLMExtractionServiceUnavailableError(LLMExtractionServiceError):
+    """Raised when the LLM extraction service is unreachable or timed out."""
+
+    def __init__(self, reason: str) -> None:
+        self.reason = reason
+        super().__init__(f"LLM extraction service unavailable: {reason}")
+
+
 class CrossTenantRelationshipError(Exception):
     """Raised when a relationship would span two different tenants.
 

--- a/src/memoryhub_core/services/extraction.py
+++ b/src/memoryhub_core/services/extraction.py
@@ -1,19 +1,31 @@
-"""Entity extraction pipeline -- spaCy NER + GLiNER2 zero-shot cascade.
+"""Entity extraction pipeline -- spaCy NER + GLiNER2 zero-shot + LLM fallback cascade.
 
-Two-stage extraction cascade (#170 Phase 2, #248). Stage 1 (spaCy) runs
-always for fast person/org/location/event extraction. Stage 2 (GLiNER2)
-fires only when Stage 1 finds fewer than 2 high-confidence entities,
-adding zero-shot extraction for objects, technologies, and domain terms.
+Three-stage extraction cascade (#170 Phase 2, #248, #249):
+
+- Stage 1 (spaCy) runs always for fast person/org/location/event extraction.
+- Stage 2 (GLiNER2) fires when Stage 1 finds fewer than 2 high-confidence
+  entities, adding zero-shot extraction for objects, technologies, and
+  domain terms.
+- Stage 3 (LLM) fires when Stages 1+2 combined still have low coverage.
+  This is the only stage that extracts inter-entity relationships (not just
+  memory-to-entity MENTIONS edges).
 
 Entities are created via find_or_create_entity and linked to the source
 memory via MENTIONS relationships. Designed for async background execution
 after write commits.
 """
 
+import asyncio
+import json
 import logging
+import re
 import uuid
+from pathlib import Path
 from typing import Any
 
+import httpx
+import yaml
+from pydantic import BaseModel, Field, field_validator
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from memoryhub_core.config import AppSettings
@@ -176,7 +188,314 @@ def run_gliner_ner(text: str) -> list[dict[str, Any]]:
 
 
 # ---------------------------------------------------------------------------
-# Cascade: Stage 1 -> Stage 2 (conditional)
+# Stage 3: LLM fallback NER + relationship extraction
+# ---------------------------------------------------------------------------
+
+_VALID_POLE_TYPES = {"person", "organization", "location", "event", "object"}
+_LLM_CONFIDENCE_FLOOR = 0.5
+_LLM_MAX_FORMAT_RETRIES = 3
+_LLM_MAX_SERVICE_RETRIES = 2
+
+# ---------------------------------------------------------------------------
+# Pydantic validation models for LLM structured output
+# ---------------------------------------------------------------------------
+
+
+class _ExtractedEntity(BaseModel):
+    name: str = Field(min_length=1)
+    type: str
+    confidence: float = Field(ge=0.0, le=1.0)
+
+    @field_validator("type")
+    @classmethod
+    def normalize_type(cls, v: str) -> str:
+        return v.lower().strip()
+
+
+class _ExtractedRelationship(BaseModel):
+    source_name: str = Field(min_length=1)
+    target_name: str = Field(min_length=1)
+    relationship_type: str = "related_to"
+
+
+class _ExtractionResult(BaseModel):
+    entities: list[_ExtractedEntity] = []
+    relationships: list[_ExtractedRelationship] = []
+
+
+# ---------------------------------------------------------------------------
+# Best-effort JSON parsing (fallback chain from CDC pipeline patterns)
+# ---------------------------------------------------------------------------
+
+
+def _strip_code_fences(text: str) -> str:
+    text = re.sub(r"^```(?:json)?\s*\n?", "", text.strip(), flags=re.IGNORECASE)
+    return re.sub(r"\n?```\s*$", "", text.strip()).strip()
+
+
+def _parse_json_best_effort(text: str) -> dict[str, Any] | None:
+    """Parse JSON with progressive fallbacks.
+
+    Chain: direct parse -> strip code fences -> regex extraction -> None.
+    """
+    cleaned = _strip_code_fences(text)
+    try:
+        return json.loads(cleaned)
+    except json.JSONDecodeError:
+        pass
+    m = re.search(r"\{[\s\S]*\}", cleaned)
+    if m:
+        try:
+            return json.loads(m.group())
+        except json.JSONDecodeError:
+            pass
+    return None
+
+
+# ---------------------------------------------------------------------------
+# LLM extractor with retry-with-correction and circuit breaker
+# ---------------------------------------------------------------------------
+
+_llm_extractor = None
+
+
+class _LLMExtractor:
+    """LLM-based entity and relationship extractor for Stage 3.
+
+    Resilience layers (adapted from CDC data-acceptance-testing pipeline):
+    - Best-effort JSON parsing (code fence stripping, regex extraction)
+    - Pydantic schema validation via _ExtractionResult
+    - Retry with correction: on format failure, inject the bad response
+      and a correction message, then retry (the model responds well to
+      seeing its own mistake)
+    - Separate service-error handling with exponential backoff
+    """
+
+    def __init__(self) -> None:
+        settings = AppSettings()
+        self.url = settings.llm_extraction_url.rstrip("/")
+        self.model = settings.llm_extraction_model
+        self._client = httpx.AsyncClient(
+            timeout=settings.llm_extraction_timeout,
+            verify=False,  # cluster-internal TLS
+        )
+        self._system_prompt = self._load_prompt()
+
+    def _load_prompt(self) -> str:
+        """Load system prompt from prompts/entity_extraction.yaml."""
+        prompt_path = (
+            Path(__file__).resolve().parents[2]
+            / "prompts" / "entity_extraction.yaml"
+        )
+        with open(prompt_path) as f:
+            data = yaml.safe_load(f)
+        return data["system_prompt"]
+
+    async def extract(
+        self, text: str,
+    ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+        """Extract entities and relationships from text via LLM.
+
+        Uses retry-with-correction on format/validation failures and
+        exponential backoff on service errors.
+        """
+        from memoryhub_core.services.exceptions import LLMExtractionServiceError
+
+        messages = [
+            {"role": "system", "content": self._system_prompt},
+            {"role": "user", "content": text},
+        ]
+        last_error: Exception | None = None
+
+        for attempt in range(_LLM_MAX_FORMAT_RETRIES):
+            raw_content = await self._call_llm(messages)
+
+            parsed = _parse_json_best_effort(raw_content)
+            if parsed is None:
+                reason = "Response was not valid JSON"
+                logger.warning(
+                    "LLM extraction format error (attempt %d/%d): %s",
+                    attempt + 1, _LLM_MAX_FORMAT_RETRIES, reason,
+                )
+                messages = self._inject_correction(
+                    messages, raw_content, reason,
+                )
+                last_error = LLMExtractionServiceError(reason)
+                if attempt < _LLM_MAX_FORMAT_RETRIES - 1:
+                    await asyncio.sleep(2 ** attempt)
+                continue
+
+            try:
+                result = _ExtractionResult.model_validate(parsed)
+            except Exception as exc:
+                reason = f"Schema validation failed: {exc}"
+                logger.warning(
+                    "LLM extraction validation error (attempt %d/%d): %s",
+                    attempt + 1, _LLM_MAX_FORMAT_RETRIES, reason,
+                )
+                messages = self._inject_correction(
+                    messages, raw_content, reason,
+                )
+                last_error = LLMExtractionServiceError(reason)
+                if attempt < _LLM_MAX_FORMAT_RETRIES - 1:
+                    await asyncio.sleep(2 ** attempt)
+                continue
+
+            entities = self._to_entity_dicts(result.entities)
+            relationships = self._to_relationship_dicts(result.relationships)
+            return entities, relationships
+
+        raise last_error or LLMExtractionServiceError(
+            "LLM extraction failed after all retries"
+        )
+
+    async def _call_llm(self, messages: list[dict[str, Any]]) -> str:
+        """Make the HTTP call to vLLM with service-error retry."""
+        from memoryhub_core.services.exceptions import (
+            LLMExtractionServiceError,
+            LLMExtractionServiceUnavailableError,
+        )
+
+        last_error: Exception | None = None
+
+        for attempt in range(_LLM_MAX_SERVICE_RETRIES):
+            try:
+                response = await self._client.post(
+                    f"{self.url}/v1/chat/completions",
+                    json={
+                        "model": self.model,
+                        "messages": messages,
+                        "temperature": 0.0,
+                        "max_tokens": 2000,
+                        "response_format": {"type": "json_object"},
+                    },
+                )
+                response.raise_for_status()
+            except httpx.ConnectError as exc:
+                last_error = LLMExtractionServiceUnavailableError(
+                    "Could not connect to LLM extraction service"
+                )
+                last_error.__cause__ = exc
+            except httpx.TimeoutException as exc:
+                last_error = LLMExtractionServiceUnavailableError(
+                    "LLM extraction request timed out"
+                )
+                last_error.__cause__ = exc
+            except httpx.HTTPStatusError as exc:
+                status = exc.response.status_code
+                if status in (429, 502, 503, 504):
+                    last_error = LLMExtractionServiceUnavailableError(
+                        f"LLM service returned {status}"
+                    )
+                    last_error.__cause__ = exc
+                else:
+                    raise LLMExtractionServiceError(
+                        f"LLM extraction failed with status {status}"
+                    ) from exc
+            else:
+                try:
+                    return response.json()["choices"][0]["message"]["content"]
+                except (KeyError, IndexError, TypeError) as exc:
+                    raise LLMExtractionServiceError(
+                        f"Unexpected response structure: {exc}"
+                    ) from exc
+
+            if attempt < _LLM_MAX_SERVICE_RETRIES - 1:
+                delay = (2 ** attempt) * 2.0  # 2s, 4s
+                logger.warning(
+                    "LLM service error (attempt %d/%d): %s — retrying in %.0fs",
+                    attempt + 1, _LLM_MAX_SERVICE_RETRIES,
+                    last_error, delay,
+                )
+                await asyncio.sleep(delay)
+
+        raise last_error or LLMExtractionServiceUnavailableError(
+            "LLM service unavailable after all retries"
+        )
+
+    def _inject_correction(
+        self,
+        messages: list[dict[str, Any]],
+        bad_response: str,
+        reason: str,
+    ) -> list[dict[str, Any]]:
+        """Build a new message list with the bad response and correction."""
+        return messages + [
+            {"role": "assistant", "content": bad_response},
+            {
+                "role": "user",
+                "content": (
+                    f"That response did not match the required schema: "
+                    f"{reason}. Return a JSON object with two arrays: "
+                    f'"entities" (each with name, type, confidence) and '
+                    f'"relationships" (each with source_name, target_name, '
+                    f"relationship_type). Types must be one of: "
+                    f"person, organization, location, event, object."
+                ),
+            },
+        ]
+
+    def _to_entity_dicts(
+        self, entities: list[_ExtractedEntity],
+    ) -> list[dict[str, Any]]:
+        """Convert validated Pydantic entities to the stage dict format."""
+        seen: set[tuple[str, str]] = set()
+        result: list[dict[str, Any]] = []
+        for e in entities:
+            if e.type not in _VALID_POLE_TYPES:
+                continue
+            if e.confidence < _LLM_CONFIDENCE_FLOOR:
+                continue
+            key = (e.name.lower(), e.type)
+            if key in seen:
+                continue
+            seen.add(key)
+            result.append({
+                "name": e.name,
+                "type": e.type,
+                "label": e.type,
+                "start": -1,
+                "end": -1,
+                "confidence": e.confidence,
+            })
+        return result
+
+    def _to_relationship_dicts(
+        self, relationships: list[_ExtractedRelationship],
+    ) -> list[dict[str, Any]]:
+        """Convert validated Pydantic relationships to the stage dict format."""
+        return [
+            {
+                "source_name": r.source_name,
+                "target_name": r.target_name,
+                "relationship_type": r.relationship_type,
+            }
+            for r in relationships
+        ]
+
+
+def _get_llm_extractor() -> _LLMExtractor:
+    """Lazy-initialize and return the module-level LLM extractor."""
+    global _llm_extractor
+    if _llm_extractor is None:
+        _llm_extractor = _LLMExtractor()
+    return _llm_extractor
+
+
+async def run_llm_ner(text: str) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Run LLM extraction and return (entities, relationships).
+
+    Unlike Stages 1/2 which return only entities, Stage 3 also extracts
+    inter-entity relationships.
+    """
+    if not text or not text.strip():
+        return [], []
+    extractor = _get_llm_extractor()
+    return await extractor.extract(text)
+
+
+# ---------------------------------------------------------------------------
+# Cascade: Stage 1 -> Stage 2 (conditional) -> Stage 3 (conditional)
 # ---------------------------------------------------------------------------
 
 def _should_run_stage2(stage1_entities: list[dict[str, Any]]) -> bool:
@@ -192,6 +511,18 @@ def _should_run_stage2(stage1_entities: list[dict[str, Any]]) -> bool:
 def _tag_extractor(entities: list[dict[str, Any]], extractor: str) -> list[dict[str, Any]]:
     """Return a copy of each entity dict tagged with its source extractor name."""
     return [{**e, "extractor": extractor} for e in entities]
+
+
+def _should_run_stage3(all_entities: list[dict[str, Any]]) -> bool:
+    """Return True if combined Stage 1+2 coverage is too low and Stage 3 should run."""
+    settings = AppSettings()
+    if not settings.llm_extraction_url:
+        return False
+    high_confidence = sum(
+        1 for e in all_entities
+        if e.get("confidence", 0) >= settings.llm_stage3_trigger_confidence
+    )
+    return high_confidence < settings.llm_stage3_trigger_count
 
 
 def _merge_entities(
@@ -220,9 +551,11 @@ async def extract_entities_from_memory(
 ) -> dict[str, Any]:
     """Extract entities from memory content and create entity nodes + MENTIONS edges.
 
-    Runs the two-stage cascade: Stage 1 (spaCy) always runs; Stage 2
-    (GLiNER2) fires when Stage 1 yields fewer than 2 high-confidence entities.
-    Returns a summary dict with extracted entity info for logging.
+    Runs the three-stage cascade: Stage 1 (spaCy) always runs; Stage 2
+    (GLiNER2) fires when Stage 1 yields fewer than 2 high-confidence
+    entities; Stage 3 (LLM) fires when Stages 1+2 combined still have
+    low coverage. Stage 3 is the only stage that also extracts inter-entity
+    relationships. Returns a summary dict with extracted entity info for logging.
     """
     stage1_entities = _tag_extractor(run_spacy_ner(content), "spacy")
 
@@ -247,6 +580,24 @@ async def extract_entities_from_memory(
             memory_id, len(stage1_entities),
         )
         all_entities = stage1_entities
+
+    # Stage 3: LLM fallback (conditional)
+    llm_relationships: list[dict[str, Any]] = []
+    if _should_run_stage3(all_entities):
+        try:
+            stage3_entities, llm_relationships = await run_llm_ner(content)
+            stage3_tagged = _tag_extractor(stage3_entities, "llm")
+            all_entities = _merge_entities(all_entities, stage3_tagged)
+            logger.debug(
+                "Stage 3 (LLM) added %d entities, %d relationships for memory %s",
+                len(stage3_tagged), len(llm_relationships), memory_id,
+            )
+        except Exception:
+            logger.warning(
+                "LLM Stage 3 failed for memory %s; using Stage 1+2 results only",
+                memory_id,
+                exc_info=True,
+            )
 
     if not all_entities:
         return {"memory_id": str(memory_id), "entities": [], "count": 0}
@@ -289,6 +640,42 @@ async def extract_entities_from_memory(
                 raw["name"], raw["type"], memory_id,
                 exc_info=True,
             )
+
+    # Create inter-entity relationships from Stage 3 LLM extraction
+    if llm_relationships:
+        entity_name_to_id: dict[str, uuid.UUID] = {}
+        for e in created_entities:
+            entity_name_to_id[e["name"].lower()] = uuid.UUID(e["entity_id"])
+
+        for rel in llm_relationships:
+            try:
+                source_id = entity_name_to_id.get(rel["source_name"].lower())
+                target_id = entity_name_to_id.get(rel["target_name"].lower())
+                if source_id is None or target_id is None:
+                    continue
+                if source_id == target_id:
+                    continue
+
+                from memoryhub_core.models.schemas import RelationshipCreate
+                from memoryhub_core.services.graph import create_relationship
+
+                rel_create = RelationshipCreate(
+                    source_id=source_id,
+                    target_id=target_id,
+                    relationship_type="related_to",
+                    created_by="system:entity_extraction",
+                    metadata={
+                        "llm_relationship_type": rel.get("relationship_type", "related_to"),
+                        "extractor": "llm",
+                    },
+                )
+                await create_relationship(rel_create, session)
+            except Exception:
+                logger.warning(
+                    "Failed to create inter-entity relationship %s -> %s for memory %s",
+                    rel.get("source_name"), rel.get("target_name"), memory_id,
+                    exc_info=True,
+                )
 
     return {
         "memory_id": str(memory_id),

--- a/tests/test_services/test_extraction.py
+++ b/tests/test_services/test_extraction.py
@@ -1,18 +1,25 @@
 """Tests for the entity extraction pipeline."""
 
+import json
 import uuid
 from collections import namedtuple
-from unittest.mock import patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
 
 from memoryhub_core.services.embeddings import MockEmbeddingService
 from memoryhub_core.services.extraction import (
+    _ExtractionResult,
     _merge_entities,
+    _parse_json_best_effort,
     _should_run_stage2,
+    _should_run_stage3,
+    _strip_code_fences,
     _tag_extractor,
     extract_entities_from_memory,
     run_gliner_ner,
+    run_llm_ner,
     run_spacy_ner,
 )
 
@@ -348,6 +355,17 @@ class FakeGLiNERModel:
 
     def predict_entities(self, text, labels, threshold=0.5):
         return self._entities
+
+
+class FakeLLMExtractor:
+    """Deterministic LLM extractor replacement for unit tests."""
+
+    def __init__(self, entities=None, relationships=None):
+        self._entities = entities or []
+        self._relationships = relationships or []
+
+    async def extract(self, text):
+        return self._entities, self._relationships
 
 
 def test_run_gliner_ner_extracts_entities():
@@ -687,3 +705,978 @@ async def test_cascade_dedup_between_stages(async_session):
     extractor_map = {e["name"]: e["extractor"] for e in result["entities"]}
     assert extractor_map["Alice"] == "spacy"
     assert extractor_map["PostgreSQL"] == "gliner"
+
+
+# ── Stage 3 trigger logic tests ──────────────────────────────────────────
+
+
+def test_should_run_stage3_no_url_configured():
+    """Stage 3 never fires when no LLM URL is configured."""
+    with patch.dict("os.environ", {"MEMORYHUB_LLM_EXTRACTION_URL": ""}, clear=False):
+        assert _should_run_stage3([]) is False
+
+
+def test_should_run_stage3_with_no_entities():
+    """Stage 3 fires when URL is configured and no entities exist."""
+    with patch.dict("os.environ", {"MEMORYHUB_LLM_EXTRACTION_URL": "http://llm:8000"}, clear=False):
+        assert _should_run_stage3([]) is True
+
+
+def test_should_run_stage3_with_low_coverage():
+    """Stage 3 fires when only 1 high-confidence entity (below trigger_count=2)."""
+    entities = [{"name": "Alice", "type": "person", "confidence": 0.8}]
+    with patch.dict("os.environ", {"MEMORYHUB_LLM_EXTRACTION_URL": "http://llm:8000"}, clear=False):
+        assert _should_run_stage3(entities) is True
+
+
+def test_should_run_stage3_skipped_with_sufficient_coverage():
+    """Stage 3 is skipped when >= 2 high-confidence entities exist."""
+    entities = [
+        {"name": "Alice", "type": "person", "confidence": 0.9},
+        {"name": "Acme", "type": "organization", "confidence": 0.8},
+    ]
+    with patch.dict("os.environ", {"MEMORYHUB_LLM_EXTRACTION_URL": "http://llm:8000"}, clear=False):
+        assert _should_run_stage3(entities) is False
+
+
+def test_should_run_stage3_low_confidence_doesnt_count():
+    """Entities below llm_stage3_trigger_confidence (0.7) don't count toward threshold."""
+    entities = [
+        {"name": "Alice", "type": "person", "confidence": 0.8},
+        {"name": "maybe", "type": "object", "confidence": 0.5},
+    ]
+    with patch.dict("os.environ", {"MEMORYHUB_LLM_EXTRACTION_URL": "http://llm:8000"}, clear=False):
+        assert _should_run_stage3(entities) is True
+
+
+# ── LLM Stage 3 NER tests ───────────────────────────────────────────────
+
+
+def _make_llm_response(entities, relationships=None):
+    """Create a mock httpx.Response with vLLM-format JSON content."""
+    content = json.dumps({
+        "entities": entities,
+        "relationships": relationships or [],
+    })
+    # httpx.Response.raise_for_status() requires a request to be set
+    request = httpx.Request("POST", "http://llm:8000/v1/chat/completions")
+    return httpx.Response(200, json={
+        "choices": [{"message": {"content": content}}],
+    }, request=request)
+
+
+@pytest.mark.asyncio
+async def test_run_llm_ner_extracts_entities_and_relationships():
+    """LLM stage returns both entities and relationships."""
+    import memoryhub_core.services.extraction as ext
+
+    old = ext._llm_extractor
+    ext._llm_extractor = None
+
+    response = _make_llm_response(
+        entities=[
+            {"name": "MemoryHub", "type": "object", "confidence": 0.95},
+            {"name": "PostgreSQL", "type": "object", "confidence": 0.92},
+            {"name": "Wes", "type": "person", "confidence": 0.99},
+        ],
+        relationships=[
+            {"source_name": "MemoryHub", "target_name": "PostgreSQL", "relationship_type": "uses"},
+            {"source_name": "Wes", "target_name": "MemoryHub", "relationship_type": "uses"},
+        ],
+    )
+
+    with (
+        patch.dict("os.environ", {
+            "MEMORYHUB_LLM_EXTRACTION_URL": "http://llm:8000",
+            "MEMORYHUB_LLM_EXTRACTION_MODEL": "test-model",
+        }),
+        patch("httpx.AsyncClient.post", new_callable=AsyncMock, return_value=response),
+        patch("yaml.safe_load", return_value={"system_prompt": "Extract entities."}),
+        patch("builtins.open", MagicMock()),
+    ):
+        entities, rels = await run_llm_ner("Wes built MemoryHub on PostgreSQL")
+
+    ext._llm_extractor = old
+
+    assert len(entities) == 3
+    names = {e["name"] for e in entities}
+    assert names == {"MemoryHub", "PostgreSQL", "Wes"}
+
+    assert len(rels) == 2
+    rel_types = {(r["source_name"], r["target_name"]): r["relationship_type"] for r in rels}
+    assert rel_types[("MemoryHub", "PostgreSQL")] == "uses"
+    assert rel_types[("Wes", "MemoryHub")] == "uses"
+
+
+@pytest.mark.asyncio
+async def test_run_llm_ner_empty_text():
+    """Empty text returns empty entities and relationships without calling LLM."""
+    entities, rels = await run_llm_ner("")
+    assert entities == []
+    assert rels == []
+
+
+@pytest.mark.asyncio
+async def test_run_llm_ner_whitespace_text():
+    """Whitespace-only text returns empty entities and relationships."""
+    entities, rels = await run_llm_ner("   ")
+    assert entities == []
+    assert rels == []
+
+
+@pytest.mark.asyncio
+async def test_run_llm_ner_filters_invalid_types():
+    """Entities with types outside POLE+O vocabulary are dropped."""
+    import memoryhub_core.services.extraction as ext
+
+    old = ext._llm_extractor
+    ext._llm_extractor = None
+
+    response = _make_llm_response(
+        entities=[
+            {"name": "Alice", "type": "person", "confidence": 0.9},
+            {"name": "Flux", "type": "INVALID_TYPE", "confidence": 0.9},
+        ],
+    )
+
+    with (
+        patch.dict("os.environ", {
+            "MEMORYHUB_LLM_EXTRACTION_URL": "http://llm:8000",
+            "MEMORYHUB_LLM_EXTRACTION_MODEL": "test-model",
+        }),
+        patch("httpx.AsyncClient.post", new_callable=AsyncMock, return_value=response),
+        patch("yaml.safe_load", return_value={"system_prompt": "Extract entities."}),
+        patch("builtins.open", MagicMock()),
+    ):
+        entities, rels = await run_llm_ner("Alice uses Flux capacitor")
+
+    ext._llm_extractor = old
+
+    assert len(entities) == 1
+    assert entities[0]["name"] == "Alice"
+
+
+@pytest.mark.asyncio
+async def test_run_llm_ner_filters_low_confidence():
+    """Entities below 0.5 confidence floor are dropped."""
+    import memoryhub_core.services.extraction as ext
+
+    old = ext._llm_extractor
+    ext._llm_extractor = None
+
+    response = _make_llm_response(
+        entities=[
+            {"name": "Alice", "type": "person", "confidence": 0.9},
+            {"name": "Maybe", "type": "object", "confidence": 0.3},
+        ],
+    )
+
+    with (
+        patch.dict("os.environ", {
+            "MEMORYHUB_LLM_EXTRACTION_URL": "http://llm:8000",
+            "MEMORYHUB_LLM_EXTRACTION_MODEL": "test-model",
+        }),
+        patch("httpx.AsyncClient.post", new_callable=AsyncMock, return_value=response),
+        patch("yaml.safe_load", return_value={"system_prompt": "Extract entities."}),
+        patch("builtins.open", MagicMock()),
+    ):
+        entities, rels = await run_llm_ner("Alice uses Maybe thing")
+
+    ext._llm_extractor = old
+
+    assert len(entities) == 1
+    assert entities[0]["name"] == "Alice"
+
+
+@pytest.mark.asyncio
+async def test_run_llm_ner_deduplicates():
+    """Duplicate entities (same name+type) are deduplicated, keeping first."""
+    import memoryhub_core.services.extraction as ext
+
+    old = ext._llm_extractor
+    ext._llm_extractor = None
+
+    response = _make_llm_response(
+        entities=[
+            {"name": "Alice", "type": "person", "confidence": 0.95},
+            {"name": "alice", "type": "person", "confidence": 0.80},
+        ],
+    )
+
+    with (
+        patch.dict("os.environ", {
+            "MEMORYHUB_LLM_EXTRACTION_URL": "http://llm:8000",
+            "MEMORYHUB_LLM_EXTRACTION_MODEL": "test-model",
+        }),
+        patch("httpx.AsyncClient.post", new_callable=AsyncMock, return_value=response),
+        patch("yaml.safe_load", return_value={"system_prompt": "Extract entities."}),
+        patch("builtins.open", MagicMock()),
+    ):
+        entities, rels = await run_llm_ner("Alice met alice again")
+
+    ext._llm_extractor = old
+
+    assert len(entities) == 1
+    assert entities[0]["name"] == "Alice"
+    assert entities[0]["confidence"] == 0.95
+
+
+# ── Full cascade tests including Stage 3 ─────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_cascade_runs_stage3_when_coverage_low(async_session):
+    """When Stages 1+2 produce no entities, Stage 3 LLM fires."""
+    embedding_service = MockEmbeddingService()
+    memory_id = uuid.uuid4()
+
+    from datetime import UTC, datetime
+
+    from memoryhub_core.models.memory import MemoryNode
+
+    now = datetime.now(UTC)
+    async_session.add(MemoryNode(
+        id=memory_id,
+        content="MemoryHub uses PostgreSQL for storage.",
+        stub="MemoryHub uses...",
+        scope="user",
+        weight=0.9,
+        owner_id="test-user",
+        tenant_id="test-tenant",
+        is_current=True,
+        version=1,
+        storage_type="inline",
+        created_at=now,
+        updated_at=now,
+    ))
+    await async_session.commit()
+
+    fake_nlp = FakeNlp([])
+    fake_gliner = FakeGLiNERModel([])
+
+    llm_entities = [
+        {"name": "MemoryHub", "type": "object", "label": "object", "start": -1, "end": -1, "confidence": 0.95},
+        {"name": "PostgreSQL", "type": "object", "label": "object", "start": -1, "end": -1, "confidence": 0.92},
+    ]
+
+    with (
+        patch("memoryhub_core.services.extraction._get_nlp", return_value=fake_nlp),
+        patch("memoryhub_core.services.extraction._get_gliner", return_value=fake_gliner),
+        patch(
+            "memoryhub_core.services.extraction.run_llm_ner",
+            new_callable=AsyncMock, return_value=(llm_entities, []),
+        ),
+        patch.dict("os.environ", {"MEMORYHUB_LLM_EXTRACTION_URL": "http://llm:8000"}, clear=False),
+    ):
+        result = await extract_entities_from_memory(
+            memory_id=memory_id,
+            content="MemoryHub uses PostgreSQL for storage.",
+            session=async_session,
+            embedding_service=embedding_service,
+            tenant_id="test-tenant",
+            owner_id="test-user",
+        )
+
+    assert result["count"] == 2
+    extractors = {e["extractor"] for e in result["entities"]}
+    assert "llm" in extractors
+
+
+@pytest.mark.asyncio
+async def test_cascade_skips_stage3_when_coverage_sufficient(async_session):
+    """When Stage 1 finds enough entities, Stage 3 is not called."""
+    embedding_service = MockEmbeddingService()
+    memory_id = uuid.uuid4()
+
+    from datetime import UTC, datetime
+
+    from memoryhub_core.models.memory import MemoryNode
+
+    now = datetime.now(UTC)
+    async_session.add(MemoryNode(
+        id=memory_id,
+        content="Alice from Acme Corp visited New York.",
+        stub="Alice from Acme...",
+        scope="user",
+        weight=0.9,
+        owner_id="test-user",
+        tenant_id="test-tenant",
+        is_current=True,
+        version=1,
+        storage_type="inline",
+        created_at=now,
+        updated_at=now,
+    ))
+    await async_session.commit()
+
+    fake_nlp = FakeNlp([
+        SpacyEntity("Alice", "PERSON", 0, 5),
+        SpacyEntity("Acme Corp", "ORG", 11, 20),
+        SpacyEntity("New York", "GPE", 29, 37),
+    ])
+
+    llm_called = False
+    original_run_llm_ner = run_llm_ner
+
+    async def tracking_run_llm_ner(text):
+        nonlocal llm_called
+        llm_called = True
+        return await original_run_llm_ner(text)
+
+    with (
+        patch("memoryhub_core.services.extraction._get_nlp", return_value=fake_nlp),
+        patch("memoryhub_core.services.extraction.run_llm_ner", side_effect=tracking_run_llm_ner),
+        patch.dict("os.environ", {"MEMORYHUB_LLM_EXTRACTION_URL": "http://llm:8000"}, clear=False),
+    ):
+        result = await extract_entities_from_memory(
+            memory_id=memory_id,
+            content="Alice from Acme Corp visited New York.",
+            session=async_session,
+            embedding_service=embedding_service,
+            tenant_id="test-tenant",
+            owner_id="test-user",
+        )
+
+    assert result["count"] == 3
+    assert not llm_called, "LLM Stage 3 should not have been called when coverage is sufficient"
+    extractors = {e["extractor"] for e in result["entities"]}
+    assert extractors == {"spacy"}
+
+
+@pytest.mark.asyncio
+async def test_cascade_skips_stage3_when_no_url(async_session):
+    """Stage 3 is skipped when MEMORYHUB_LLM_EXTRACTION_URL is empty."""
+    embedding_service = MockEmbeddingService()
+    memory_id = uuid.uuid4()
+
+    from datetime import UTC, datetime
+
+    from memoryhub_core.models.memory import MemoryNode
+
+    now = datetime.now(UTC)
+    async_session.add(MemoryNode(
+        id=memory_id,
+        content="Something without entities.",
+        stub="Something...",
+        scope="user",
+        weight=0.9,
+        owner_id="test-user",
+        tenant_id="test-tenant",
+        is_current=True,
+        version=1,
+        storage_type="inline",
+        created_at=now,
+        updated_at=now,
+    ))
+    await async_session.commit()
+
+    fake_nlp = FakeNlp([])
+    fake_gliner = FakeGLiNERModel([])
+
+    llm_called = False
+
+    async def tracking_run_llm_ner(text):
+        nonlocal llm_called
+        llm_called = True
+        return [], []
+
+    with (
+        patch("memoryhub_core.services.extraction._get_nlp", return_value=fake_nlp),
+        patch("memoryhub_core.services.extraction._get_gliner", return_value=fake_gliner),
+        patch("memoryhub_core.services.extraction.run_llm_ner", side_effect=tracking_run_llm_ner),
+        patch.dict("os.environ", {"MEMORYHUB_LLM_EXTRACTION_URL": ""}, clear=False),
+    ):
+        result = await extract_entities_from_memory(
+            memory_id=memory_id,
+            content="Something without entities.",
+            session=async_session,
+            embedding_service=embedding_service,
+            tenant_id="test-tenant",
+            owner_id="test-user",
+        )
+
+    assert result["count"] == 0
+    assert not llm_called, "LLM Stage 3 should not be called when no URL is configured"
+
+
+@pytest.mark.asyncio
+async def test_cascade_stage3_failure_falls_back(async_session):
+    """If LLM fails, Stage 1+2 results are still used."""
+    embedding_service = MockEmbeddingService()
+    memory_id = uuid.uuid4()
+
+    from datetime import UTC, datetime
+
+    from memoryhub_core.models.memory import MemoryNode
+
+    now = datetime.now(UTC)
+    async_session.add(MemoryNode(
+        id=memory_id,
+        content="Alice went somewhere.",
+        stub="Alice went...",
+        scope="user",
+        weight=0.9,
+        owner_id="test-user",
+        tenant_id="test-tenant",
+        is_current=True,
+        version=1,
+        storage_type="inline",
+        created_at=now,
+        updated_at=now,
+    ))
+    await async_session.commit()
+
+    # Stage 1: finds Alice (1 entity, triggers all stages)
+    fake_nlp = FakeNlp([SpacyEntity("Alice", "PERSON", 0, 5)])
+    # Stage 2: finds nothing
+    fake_gliner = FakeGLiNERModel([])
+
+    with (
+        patch("memoryhub_core.services.extraction._get_nlp", return_value=fake_nlp),
+        patch("memoryhub_core.services.extraction._get_gliner", return_value=fake_gliner),
+        patch(
+            "memoryhub_core.services.extraction.run_llm_ner",
+            new_callable=AsyncMock, side_effect=RuntimeError("LLM unreachable"),
+        ),
+        patch.dict("os.environ", {"MEMORYHUB_LLM_EXTRACTION_URL": "http://llm:8000"}, clear=False),
+    ):
+        result = await extract_entities_from_memory(
+            memory_id=memory_id,
+            content="Alice went somewhere.",
+            session=async_session,
+            embedding_service=embedding_service,
+            tenant_id="test-tenant",
+            owner_id="test-user",
+        )
+
+    assert result["count"] == 1
+    assert result["entities"][0]["name"] == "Alice"
+    assert result["entities"][0]["extractor"] == "spacy"
+
+
+# ── Inter-entity relationship tests ──────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_stage3_creates_inter_entity_relationships(async_session):
+    """Stage 3 creates related_to edges between entities with LLM type in metadata."""
+    embedding_service = MockEmbeddingService()
+    memory_id = uuid.uuid4()
+
+    from datetime import UTC, datetime
+
+    from sqlalchemy import select
+
+    from memoryhub_core.models.memory import MemoryNode, MemoryRelationship
+
+    now = datetime.now(UTC)
+    async_session.add(MemoryNode(
+        id=memory_id,
+        content="MemoryHub uses PostgreSQL",
+        stub="MemoryHub uses...",
+        scope="user",
+        weight=0.9,
+        owner_id="test-user",
+        tenant_id="test-tenant",
+        is_current=True,
+        version=1,
+        storage_type="inline",
+        created_at=now,
+        updated_at=now,
+    ))
+    await async_session.commit()
+
+    fake_nlp = FakeNlp([])
+    fake_gliner = FakeGLiNERModel([])
+
+    llm_entities = [
+        {"name": "MemoryHub", "type": "object", "label": "object", "start": -1, "end": -1, "confidence": 0.95},
+        {"name": "PostgreSQL", "type": "object", "label": "object", "start": -1, "end": -1, "confidence": 0.92},
+    ]
+    llm_relationships = [
+        {"source_name": "MemoryHub", "target_name": "PostgreSQL", "relationship_type": "uses"},
+    ]
+
+    with (
+        patch("memoryhub_core.services.extraction._get_nlp", return_value=fake_nlp),
+        patch("memoryhub_core.services.extraction._get_gliner", return_value=fake_gliner),
+        patch(
+            "memoryhub_core.services.extraction.run_llm_ner",
+            new_callable=AsyncMock,
+            return_value=(llm_entities, llm_relationships),
+        ),
+        patch.dict("os.environ", {"MEMORYHUB_LLM_EXTRACTION_URL": "http://llm:8000"}, clear=False),
+    ):
+        result = await extract_entities_from_memory(
+            memory_id=memory_id,
+            content="MemoryHub uses PostgreSQL",
+            session=async_session,
+            embedding_service=embedding_service,
+            tenant_id="test-tenant",
+            owner_id="test-user",
+        )
+
+    assert result["count"] == 2
+
+    # Verify inter-entity relationship was created
+    rel_stmt = select(MemoryRelationship).where(
+        MemoryRelationship.relationship_type == "related_to",
+    )
+    rels = (await async_session.execute(rel_stmt)).scalars().all()
+    assert len(rels) == 1
+    assert rels[0].metadata_["llm_relationship_type"] == "uses"
+    assert rels[0].metadata_["extractor"] == "llm"
+    assert rels[0].created_by == "system:entity_extraction"
+
+
+@pytest.mark.asyncio
+async def test_stage3_skips_relationship_when_entity_missing(async_session):
+    """Relationships referencing non-existent entities are silently skipped."""
+    embedding_service = MockEmbeddingService()
+    memory_id = uuid.uuid4()
+
+    from datetime import UTC, datetime
+
+    from sqlalchemy import select
+
+    from memoryhub_core.models.memory import MemoryNode, MemoryRelationship
+
+    now = datetime.now(UTC)
+    async_session.add(MemoryNode(
+        id=memory_id,
+        content="MemoryHub uses something",
+        stub="MemoryHub...",
+        scope="user",
+        weight=0.9,
+        owner_id="test-user",
+        tenant_id="test-tenant",
+        is_current=True,
+        version=1,
+        storage_type="inline",
+        created_at=now,
+        updated_at=now,
+    ))
+    await async_session.commit()
+
+    fake_nlp = FakeNlp([])
+    fake_gliner = FakeGLiNERModel([])
+
+    # LLM returns 1 entity but relationship references a non-extracted entity
+    llm_entities = [
+        {"name": "MemoryHub", "type": "object", "label": "object", "start": -1, "end": -1, "confidence": 0.95},
+    ]
+    llm_relationships = [
+        {"source_name": "MemoryHub", "target_name": "NonExistent", "relationship_type": "uses"},
+    ]
+
+    with (
+        patch("memoryhub_core.services.extraction._get_nlp", return_value=fake_nlp),
+        patch("memoryhub_core.services.extraction._get_gliner", return_value=fake_gliner),
+        patch(
+            "memoryhub_core.services.extraction.run_llm_ner",
+            new_callable=AsyncMock,
+            return_value=(llm_entities, llm_relationships),
+        ),
+        patch.dict("os.environ", {"MEMORYHUB_LLM_EXTRACTION_URL": "http://llm:8000"}, clear=False),
+    ):
+        result = await extract_entities_from_memory(
+            memory_id=memory_id,
+            content="MemoryHub uses something",
+            session=async_session,
+            embedding_service=embedding_service,
+            tenant_id="test-tenant",
+            owner_id="test-user",
+        )
+
+    assert result["count"] == 1
+
+    # No related_to relationships should be created
+    rel_stmt = select(MemoryRelationship).where(
+        MemoryRelationship.relationship_type == "related_to",
+    )
+    rels = (await async_session.execute(rel_stmt)).scalars().all()
+    assert len(rels) == 0
+
+
+# ── Best-effort JSON parsing tests ──────────────────────────────────────
+
+
+def test_strip_code_fences_json_block():
+    raw = '```json\n{"entities": []}\n```'
+    assert _strip_code_fences(raw) == '{"entities": []}'
+
+
+def test_strip_code_fences_plain_block():
+    raw = '```\n{"entities": []}\n```'
+    assert _strip_code_fences(raw) == '{"entities": []}'
+
+
+def test_strip_code_fences_no_fences():
+    raw = '{"entities": []}'
+    assert _strip_code_fences(raw) == '{"entities": []}'
+
+
+def test_parse_json_best_effort_direct():
+    result = _parse_json_best_effort('{"entities": []}')
+    assert result == {"entities": []}
+
+
+def test_parse_json_best_effort_code_fenced():
+    result = _parse_json_best_effort('```json\n{"score": 5}\n```')
+    assert result == {"score": 5}
+
+
+def test_parse_json_best_effort_embedded_in_prose():
+    text = 'Here is the result: {"entities": [{"name": "Alice"}]} hope that helps'
+    result = _parse_json_best_effort(text)
+    assert result == {"entities": [{"name": "Alice"}]}
+
+
+def test_parse_json_best_effort_garbage():
+    assert _parse_json_best_effort("not json at all") is None
+
+
+def test_parse_json_best_effort_empty():
+    assert _parse_json_best_effort("") is None
+
+
+# ── Pydantic validation model tests ─────────────────────────────────────
+
+
+def test_extraction_result_valid():
+    data = {
+        "entities": [
+            {"name": "Alice", "type": "person", "confidence": 0.9},
+        ],
+        "relationships": [
+            {
+                "source_name": "Alice",
+                "target_name": "Acme",
+                "relationship_type": "works_at",
+            },
+        ],
+    }
+    result = _ExtractionResult.model_validate(data)
+    assert len(result.entities) == 1
+    assert result.entities[0].name == "Alice"
+    assert len(result.relationships) == 1
+
+
+def test_extraction_result_empty_arrays():
+    result = _ExtractionResult.model_validate({"entities": [], "relationships": []})
+    assert result.entities == []
+    assert result.relationships == []
+
+
+def test_extraction_result_missing_arrays_defaults():
+    result = _ExtractionResult.model_validate({})
+    assert result.entities == []
+    assert result.relationships == []
+
+
+def test_extraction_result_normalizes_type():
+    data = {"entities": [{"name": "X", "type": "PERSON", "confidence": 0.9}]}
+    result = _ExtractionResult.model_validate(data)
+    assert result.entities[0].type == "person"
+
+
+def test_extraction_result_rejects_empty_name():
+    data = {"entities": [{"name": "", "type": "person", "confidence": 0.9}]}
+    with pytest.raises(ValueError):
+        _ExtractionResult.model_validate(data)
+
+
+def test_extraction_result_rejects_bad_confidence():
+    data = {"entities": [{"name": "X", "type": "person", "confidence": 1.5}]}
+    with pytest.raises(ValueError):
+        _ExtractionResult.model_validate(data)
+
+
+# ── Retry-with-correction tests ─────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_llm_retries_on_invalid_json_then_succeeds():
+    """LLM returns garbage on first try, valid JSON on second."""
+    import memoryhub_core.services.extraction as ext
+
+    old = ext._llm_extractor
+    ext._llm_extractor = None
+
+    good_json = json.dumps({
+        "entities": [{"name": "Alice", "type": "person", "confidence": 0.9}],
+        "relationships": [],
+    })
+
+    call_count = 0
+
+    async def mock_post(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            body = json.dumps({
+                "choices": [{"message": {"content": "not valid json"}}],
+            }).encode()
+        else:
+            body = json.dumps({
+                "choices": [{"message": {"content": good_json}}],
+            }).encode()
+        return httpx.Response(
+            200, content=body,
+            request=httpx.Request("POST", "http://llm:8000"),
+        )
+
+    with (
+        patch.dict("os.environ", {
+            "MEMORYHUB_LLM_EXTRACTION_URL": "http://llm:8000",
+            "MEMORYHUB_LLM_EXTRACTION_MODEL": "test-model",
+        }),
+        patch("httpx.AsyncClient.post", new_callable=AsyncMock, side_effect=mock_post),
+        patch("yaml.safe_load", return_value={"system_prompt": "Extract."}),
+        patch("builtins.open", MagicMock()),
+    ):
+        entities, rels = await run_llm_ner("Alice is here")
+
+    ext._llm_extractor = old
+
+    assert call_count == 2
+    assert len(entities) == 1
+    assert entities[0]["name"] == "Alice"
+
+
+@pytest.mark.asyncio
+async def test_llm_retries_on_schema_failure_then_succeeds():
+    """LLM returns wrong schema on first try, correct on second."""
+    import memoryhub_core.services.extraction as ext
+
+    old = ext._llm_extractor
+    ext._llm_extractor = None
+
+    call_count = 0
+
+    async def mock_post(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            # Valid JSON but confidence out of range
+            bad = json.dumps({
+                "entities": [
+                    {"name": "X", "type": "person", "confidence": 5.0},
+                ],
+            })
+        else:
+            bad = json.dumps({
+                "entities": [
+                    {"name": "Alice", "type": "person", "confidence": 0.9},
+                ],
+                "relationships": [],
+            })
+        body = json.dumps({
+            "choices": [{"message": {"content": bad}}],
+        }).encode()
+        return httpx.Response(
+            200, content=body,
+            request=httpx.Request("POST", "http://llm:8000"),
+        )
+
+    with (
+        patch.dict("os.environ", {
+            "MEMORYHUB_LLM_EXTRACTION_URL": "http://llm:8000",
+            "MEMORYHUB_LLM_EXTRACTION_MODEL": "test-model",
+        }),
+        patch("httpx.AsyncClient.post", new_callable=AsyncMock, side_effect=mock_post),
+        patch("yaml.safe_load", return_value={"system_prompt": "Extract."}),
+        patch("builtins.open", MagicMock()),
+    ):
+        entities, rels = await run_llm_ner("Alice is here")
+
+    ext._llm_extractor = old
+
+    assert call_count == 2
+    assert len(entities) == 1
+
+
+@pytest.mark.asyncio
+async def test_llm_exhausts_retries_on_persistent_bad_format():
+    """All retries fail with bad format -> raises LLMExtractionServiceError."""
+    import memoryhub_core.services.extraction as ext
+    from memoryhub_core.services.exceptions import LLMExtractionServiceError
+
+    old = ext._llm_extractor
+    ext._llm_extractor = None
+
+    async def mock_post(*args, **kwargs):
+        body = json.dumps({
+            "choices": [{"message": {"content": "not json"}}],
+        }).encode()
+        return httpx.Response(
+            200, content=body,
+            request=httpx.Request("POST", "http://llm:8000"),
+        )
+
+    with (
+        patch.dict("os.environ", {
+            "MEMORYHUB_LLM_EXTRACTION_URL": "http://llm:8000",
+            "MEMORYHUB_LLM_EXTRACTION_MODEL": "test-model",
+        }),
+        patch("httpx.AsyncClient.post", new_callable=AsyncMock, side_effect=mock_post),
+        patch("yaml.safe_load", return_value={"system_prompt": "Extract."}),
+        patch("builtins.open", MagicMock()),
+        pytest.raises(LLMExtractionServiceError, match="not valid JSON"),
+    ):
+        await run_llm_ner("some text")
+
+    ext._llm_extractor = old
+
+
+@pytest.mark.asyncio
+async def test_llm_correction_message_includes_bad_response():
+    """Verify the correction flow appends the bad response to messages."""
+    import memoryhub_core.services.extraction as ext
+
+    old = ext._llm_extractor
+    ext._llm_extractor = None
+
+    captured_messages = []
+
+    async def mock_post(*args, **kwargs):
+        payload = kwargs.get("json") or args[1]
+        captured_messages.append(payload["messages"])
+        good = json.dumps({
+            "entities": [{"name": "A", "type": "person", "confidence": 0.9}],
+            "relationships": [],
+        })
+        content = "garbage" if len(captured_messages) == 1 else good
+        body = json.dumps({
+            "choices": [{"message": {"content": content}}],
+        }).encode()
+        return httpx.Response(
+            200, content=body,
+            request=httpx.Request("POST", "http://llm:8000"),
+        )
+
+    with (
+        patch.dict("os.environ", {
+            "MEMORYHUB_LLM_EXTRACTION_URL": "http://llm:8000",
+            "MEMORYHUB_LLM_EXTRACTION_MODEL": "test-model",
+        }),
+        patch("httpx.AsyncClient.post", new_callable=AsyncMock, side_effect=mock_post),
+        patch("yaml.safe_load", return_value={"system_prompt": "Extract."}),
+        patch("builtins.open", MagicMock()),
+    ):
+        await run_llm_ner("test text")
+
+    ext._llm_extractor = old
+
+    # Second call should have correction messages
+    assert len(captured_messages) == 2
+    retry_msgs = captured_messages[1]
+    # Should have: system, user, assistant (bad), user (correction)
+    assert len(retry_msgs) == 4
+    assert retry_msgs[2]["role"] == "assistant"
+    assert retry_msgs[2]["content"] == "garbage"
+    assert retry_msgs[3]["role"] == "user"
+    assert "did not match the required schema" in retry_msgs[3]["content"]
+
+
+@pytest.mark.asyncio
+async def test_llm_service_error_retries_on_503():
+    """503 from vLLM triggers service-level retry."""
+    import memoryhub_core.services.extraction as ext
+    from memoryhub_core.services.exceptions import (
+        LLMExtractionServiceUnavailableError,
+    )
+
+    old = ext._llm_extractor
+    ext._llm_extractor = None
+
+    async def mock_post(*args, **kwargs):
+        return httpx.Response(
+            503, content=b"Service Unavailable",
+            request=httpx.Request("POST", "http://llm:8000"),
+        )
+
+    with (
+        patch.dict("os.environ", {
+            "MEMORYHUB_LLM_EXTRACTION_URL": "http://llm:8000",
+            "MEMORYHUB_LLM_EXTRACTION_MODEL": "test-model",
+        }),
+        patch("httpx.AsyncClient.post", new_callable=AsyncMock, side_effect=mock_post),
+        patch("yaml.safe_load", return_value={"system_prompt": "Extract."}),
+        patch("builtins.open", MagicMock()),
+        pytest.raises(LLMExtractionServiceUnavailableError, match="503"),
+    ):
+        await run_llm_ner("test text")
+
+    ext._llm_extractor = old
+
+
+@pytest.mark.asyncio
+async def test_llm_service_error_does_not_retry_on_400():
+    """Non-retryable HTTP errors (400) raise immediately without retry."""
+    import memoryhub_core.services.extraction as ext
+    from memoryhub_core.services.exceptions import LLMExtractionServiceError
+
+    old = ext._llm_extractor
+    ext._llm_extractor = None
+
+    call_count = 0
+
+    async def mock_post(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        return httpx.Response(
+            400, content=b"Bad Request",
+            request=httpx.Request("POST", "http://llm:8000"),
+        )
+
+    with (
+        patch.dict("os.environ", {
+            "MEMORYHUB_LLM_EXTRACTION_URL": "http://llm:8000",
+            "MEMORYHUB_LLM_EXTRACTION_MODEL": "test-model",
+        }),
+        patch("httpx.AsyncClient.post", new_callable=AsyncMock, side_effect=mock_post),
+        patch("yaml.safe_load", return_value={"system_prompt": "Extract."}),
+        patch("builtins.open", MagicMock()),
+        pytest.raises(LLMExtractionServiceError, match="400"),
+    ):
+        await run_llm_ner("test text")
+
+    ext._llm_extractor = old
+    assert call_count == 1  # no retry on 400
+
+
+@pytest.mark.asyncio
+async def test_llm_handles_code_fenced_response():
+    """LLM wraps JSON in code fences -> best-effort parser handles it."""
+    import memoryhub_core.services.extraction as ext
+
+    old = ext._llm_extractor
+    ext._llm_extractor = None
+
+    fenced = '```json\n{"entities": [{"name": "Bob", "type": "person", "confidence": 0.95}], "relationships": []}\n```'
+
+    async def mock_post(*args, **kwargs):
+        body = json.dumps({
+            "choices": [{"message": {"content": fenced}}],
+        }).encode()
+        return httpx.Response(
+            200, content=body,
+            request=httpx.Request("POST", "http://llm:8000"),
+        )
+
+    with (
+        patch.dict("os.environ", {
+            "MEMORYHUB_LLM_EXTRACTION_URL": "http://llm:8000",
+            "MEMORYHUB_LLM_EXTRACTION_MODEL": "test-model",
+        }),
+        patch("httpx.AsyncClient.post", new_callable=AsyncMock, side_effect=mock_post),
+        patch("yaml.safe_load", return_value={"system_prompt": "Extract."}),
+        patch("builtins.open", MagicMock()),
+    ):
+        entities, rels = await run_llm_ner("Bob is here")
+
+    ext._llm_extractor = old
+
+    assert len(entities) == 1
+    assert entities[0]["name"] == "Bob"


### PR DESCRIPTION
## Summary

- Add LLM-based Stage 3 fallback to the entity extraction pipeline, completing the three-stage cascade (spaCy -> GLiNER2 -> LLM)
- Stage 3 is the only stage that extracts inter-entity relationships (not just memory-to-entity MENTIONS edges)
- Resilience layers adapted from CDC pipeline: best-effort JSON parsing, Pydantic validation, retry-with-correction (model sees its own bad output), and separate service-error retry with exponential backoff
- Tested against GPT-OSS 20B on mcp-rhoai cluster

## Test plan

- [x] 62 unit tests pass (24 pre-existing + 38 new)
- [x] Lint clean (ruff)
- [x] No secrets (gitleaks)
- [x] Live endpoint test against GPT-OSS 20B confirmed structured JSON extraction
- [ ] Integration test with deployed service (post-merge, requires `MEMORYHUB_LLM_EXTRACTION_URL` configured)

Closes #249