### PR TITLE
perf: Add cross-encoder cost/benefit benchmark

### DIFF
--- a/scripts/bench-cross-encoder.py
+++ b/scripts/bench-cross-encoder.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Cross-encoder cost/benefit benchmark.
+
+Measures re-ranking latency, relevance improvement (NDCG/MRR delta),
+and resource consumption at candidate set sizes of 10, 25, 50, 100.
+
+Prints an ASCII results table, emits a recommendation for the optimal
+candidate size, and writes raw + aggregated results to
+``benchmarks/cross-encoder-<timestamp>.json``.
+
+Usage::
+
+    python scripts/bench-cross-encoder.py
+
+Environment overrides::
+
+    MEMORYHUB_EMBEDDING_URL  override the embedding endpoint
+    MEMORYHUB_RERANKER_URL   override the reranker endpoint
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+import sys
+from dataclasses import asdict
+from pathlib import Path
+
+# Make the project root importable when running as a script.
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from tests.perf.cross_encoder_bench import (  # noqa: E402
+    CANDIDATE_SIZES,
+    N_FINAL,
+    AggregatedCandidateSize,
+    aggregate_by_size,
+    recommend_candidate_size,
+    run_cross_encoder_benchmark,
+)
+
+
+def log(msg: str) -> None:
+    print(msg, flush=True)  # noqa: T201
+
+
+def format_table(rows: list[AggregatedCandidateSize]) -> str:
+    header = (
+        f"{'size':>6}  {'n':>4}  "
+        f"{'NDCG(vec)':>10}  {'NDCG(rer)':>10}  {'delta':>8}  "
+        f"{'MRR(vec)':>9}  {'MRR(rer)':>9}  {'delta':>8}  "
+        f"{'lat(ms)':>8}  {'eff':>10}"
+    )
+    sep = "-" * len(header)
+    lines = [sep, header, sep]
+    for r in rows:
+        lines.append(
+            f"{r.candidate_size:>6}  {r.n_queries:>4}  "
+            f"{r.mean_vector_ndcg:>10.4f}  {r.mean_reranked_ndcg:>10.4f}  "
+            f"{r.mean_ndcg_delta:>+8.4f}  "
+            f"{r.mean_vector_mrr:>9.4f}  {r.mean_reranked_mrr:>9.4f}  "
+            f"{r.mean_mrr_delta:>+8.4f}  "
+            f"{r.mean_rerank_latency_ms:>8.1f}  "
+            f"{r.ndcg_delta_per_ms:>10.6f}"
+        )
+    lines.append(sep)
+    return "\n".join(lines)
+
+
+def main() -> int:
+    log("=" * 70)
+    log("Cross-Encoder Cost/Benefit Benchmark")
+    log("=" * 70)
+
+    dataset, results, timings = run_cross_encoder_benchmark(progress=log)
+    aggregated = aggregate_by_size(results)
+    recommendation = recommend_candidate_size(aggregated)
+
+    log("")
+    log(f"Results (N_FINAL={N_FINAL}):")
+    log(format_table(aggregated))
+    log("")
+    log(
+        f"Recommendation: candidate_size={recommendation['recommended_size']} "
+        f"(efficiency={recommendation['efficiency']:.6f} NDCG-delta/ms)"
+    )
+    log(f"  {recommendation['reason']}")
+
+    # Persist raw + aggregated for git history.
+    timestamp = dt.datetime.now(dt.UTC).strftime("%Y%m%dT%H%M%SZ")
+    out_dir = PROJECT_ROOT / "benchmarks"
+    out_dir.mkdir(exist_ok=True)
+    out_path = out_dir / f"cross-encoder-{timestamp}.json"
+
+    payload = {
+        "benchmark": "cross-encoder-cost-benefit",
+        "timestamp": timestamp,
+        "config": {
+            "candidate_sizes": CANDIDATE_SIZES,
+            "n_final": N_FINAL,
+            "n_queries": len(dataset.queries),
+            "n_memories": len(dataset.memories),
+        },
+        "results": {
+            "by_size": [asdict(r) for r in aggregated],
+            "recommendation": recommendation,
+        },
+        "timing": timings,
+        "runs": [asdict(r) for r in results],
+    }
+    out_path.write_text(json.dumps(payload, indent=2, sort_keys=True))
+    log("")
+    log(f"Wrote results to {out_path}")
+    log(f"Total run time: {sum(timings.values()):.1f}s")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/perf/cross_encoder_bench.py
+++ b/tests/perf/cross_encoder_bench.py
@@ -1,0 +1,312 @@
+"""Cross-encoder cost/benefit benchmark engine.
+
+Measures the relevance lift (NDCG, MRR) and latency cost of cross-encoder
+re-ranking at candidate set sizes of 10, 25, 50, and 100. For each query
+in the synthetic dataset, the benchmark:
+
+  1. Retrieves `candidate_size` memories by cosine similarity.
+  2. Computes vector-only quality metrics on the top N_FINAL results.
+  3. Re-ranks with the deployed cross-encoder, measures latency.
+  4. Computes re-ranked quality metrics on the top N_FINAL results.
+  5. Reports per-query deltas and an aggregate efficiency metric
+     (NDCG-delta per millisecond of re-ranking latency).
+
+Both ``tests/perf/test_cross_encoder.py`` and
+``scripts/bench-cross-encoder.py`` consume this module.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from tests.perf.metrics import mrr, ndcg_at_k, precision_at_k, recall_at_k
+from tests.perf.two_vector_bench import (
+    Dataset,
+    EmbeddingClient,
+    Memory,
+    Query,
+    RerankerClient,
+    cosine_topk,
+    load_dataset,
+    rerank_candidates,
+)
+
+# ── Constants ──────────────────────────────────────────────────────
+
+CANDIDATE_SIZES = [10, 25, 50, 100]
+N_FINAL = 10  # final result count for metrics
+
+
+# ── Result data classes ────────────────────────────────────────────
+
+
+@dataclass
+class CandidateSizeResult:
+    """One query evaluated at one candidate size."""
+
+    query_id: str
+    query_topic: str
+    candidate_size: int
+    # Vector-only metrics (top N_FINAL from cosine ranking)
+    vector_recall: float
+    vector_precision: float
+    vector_mrr: float
+    vector_ndcg: float
+    # Reranked metrics (top N_FINAL after cross-encoder)
+    reranked_recall: float
+    reranked_precision: float
+    reranked_mrr: float
+    reranked_ndcg: float
+    # Deltas (reranked - vector)
+    recall_delta: float
+    precision_delta: float
+    mrr_delta: float
+    ndcg_delta: float
+    # Latency
+    rerank_latency_ms: float
+
+
+@dataclass
+class AggregatedCandidateSize:
+    """Mean metrics across all queries for one candidate size."""
+
+    candidate_size: int
+    n_queries: int
+    mean_vector_ndcg: float
+    mean_reranked_ndcg: float
+    mean_ndcg_delta: float
+    mean_vector_mrr: float
+    mean_reranked_mrr: float
+    mean_mrr_delta: float
+    mean_rerank_latency_ms: float
+    ndcg_delta_per_ms: float  # efficiency: mean_ndcg_delta / mean_rerank_latency_ms
+
+
+# ── Core functions ─────────────────────────────────────────────────
+
+
+def get_relevant_ids(query: Query, dataset: Dataset) -> set[str]:
+    """Determine which memories are relevant to a query based on topic match."""
+    return {m.id for m in dataset.memories if m.topic == query.topic}
+
+
+def batched_rerank(
+    query_text: str,
+    candidates: list[Memory],
+    reranker: RerankerClient,
+) -> list[str]:
+    """Rerank candidates in batches of MAX_BATCH, merge by score.
+
+    When candidate_size exceeds the reranker's per-call limit (32), we
+    split into chunks, rerank each independently, then merge all
+    (index, score) pairs by descending score to produce a single
+    global ranking.
+    """
+    max_batch = RerankerClient.MAX_BATCH
+    if len(candidates) <= max_batch:
+        return rerank_candidates(query_text, candidates, reranker)
+
+    # Split into chunks and rerank each
+    all_scored: list[tuple[str, float]] = []
+    for start in range(0, len(candidates), max_batch):
+        chunk = candidates[start : start + max_batch]
+        resp = reranker.rerank(query_text, [m.content for m in chunk])
+        for item in resp:
+            mem_id = chunk[item["index"]].id
+            all_scored.append((mem_id, item["score"]))
+
+    # Sort by descending score across all chunks
+    all_scored.sort(key=lambda pair: pair[1], reverse=True)
+    return [mid for mid, _ in all_scored]
+
+
+def evaluate_query_at_size(
+    query: Query,
+    dataset: Dataset,
+    reranker: RerankerClient,
+    candidate_size: int,
+    relevant_ids: set[str],
+) -> CandidateSizeResult:
+    """Run one query at one candidate size, measure everything."""
+    # 1. Cosine top-k to get the candidate pool
+    candidates = cosine_topk(query.embedding, dataset.memories, candidate_size)
+
+    # 2. Vector-only: take first N_FINAL from cosine ranking
+    vector_ids = [m.id for m in candidates[:N_FINAL]]
+
+    # 3. Compute vector-only metrics
+    v_recall = recall_at_k(vector_ids, relevant_ids, N_FINAL)
+    v_precision = precision_at_k(vector_ids, relevant_ids, N_FINAL)
+    v_mrr = mrr(vector_ids, relevant_ids)
+    v_ndcg = ndcg_at_k(vector_ids, relevant_ids, N_FINAL)
+
+    # 4. Rerank candidates, timing the call
+    t0 = time.perf_counter()
+    reranked_ids = batched_rerank(query.text, candidates, reranker)
+    rerank_ms = (time.perf_counter() - t0) * 1000.0
+
+    # 5. Reranked: take first N_FINAL
+    reranked_top = reranked_ids[:N_FINAL]
+
+    # 6. Compute reranked metrics
+    r_recall = recall_at_k(reranked_top, relevant_ids, N_FINAL)
+    r_precision = precision_at_k(reranked_top, relevant_ids, N_FINAL)
+    r_mrr = mrr(reranked_top, relevant_ids)
+    r_ndcg = ndcg_at_k(reranked_top, relevant_ids, N_FINAL)
+
+    return CandidateSizeResult(
+        query_id=query.id,
+        query_topic=query.topic,
+        candidate_size=candidate_size,
+        vector_recall=v_recall,
+        vector_precision=v_precision,
+        vector_mrr=v_mrr,
+        vector_ndcg=v_ndcg,
+        reranked_recall=r_recall,
+        reranked_precision=r_precision,
+        reranked_mrr=r_mrr,
+        reranked_ndcg=r_ndcg,
+        recall_delta=r_recall - v_recall,
+        precision_delta=r_precision - v_precision,
+        mrr_delta=r_mrr - v_mrr,
+        ndcg_delta=r_ndcg - v_ndcg,
+        rerank_latency_ms=rerank_ms,
+    )
+
+
+def aggregate_by_size(
+    results: list[CandidateSizeResult],
+) -> list[AggregatedCandidateSize]:
+    """Group results by candidate_size and compute means."""
+    groups: dict[int, list[CandidateSizeResult]] = {}
+    for r in results:
+        groups.setdefault(r.candidate_size, []).append(r)
+
+    aggregated: list[AggregatedCandidateSize] = []
+    for size in sorted(groups):
+        group = groups[size]
+        n = len(group)
+        mean_v_ndcg = sum(r.vector_ndcg for r in group) / n
+        mean_r_ndcg = sum(r.reranked_ndcg for r in group) / n
+        mean_ndcg_d = sum(r.ndcg_delta for r in group) / n
+        mean_v_mrr = sum(r.vector_mrr for r in group) / n
+        mean_r_mrr = sum(r.reranked_mrr for r in group) / n
+        mean_mrr_d = sum(r.mrr_delta for r in group) / n
+        mean_lat = sum(r.rerank_latency_ms for r in group) / n
+        efficiency = mean_ndcg_d / mean_lat if mean_lat > 0 else 0.0
+
+        aggregated.append(
+            AggregatedCandidateSize(
+                candidate_size=size,
+                n_queries=n,
+                mean_vector_ndcg=mean_v_ndcg,
+                mean_reranked_ndcg=mean_r_ndcg,
+                mean_ndcg_delta=mean_ndcg_d,
+                mean_vector_mrr=mean_v_mrr,
+                mean_reranked_mrr=mean_r_mrr,
+                mean_mrr_delta=mean_mrr_d,
+                mean_rerank_latency_ms=mean_lat,
+                ndcg_delta_per_ms=efficiency,
+            )
+        )
+
+    return aggregated
+
+
+def recommend_candidate_size(
+    aggregated: list[AggregatedCandidateSize],
+) -> dict:
+    """Pick optimal candidate size by NDCG-delta-per-ms efficiency.
+
+    Returns a dict with the recommended size, the reason, and the
+    efficiency score.  When all deltas are non-positive (re-ranking
+    hurts or is neutral), the recommendation is the smallest size
+    with a note explaining why.
+    """
+    if not aggregated:
+        return {
+            "recommended_size": CANDIDATE_SIZES[0],
+            "reason": "no data",
+            "efficiency": 0.0,
+        }
+
+    # Filter to sizes where reranking actually helped
+    positive = [a for a in aggregated if a.mean_ndcg_delta > 0]
+    if not positive:
+        smallest = min(aggregated, key=lambda a: a.candidate_size)
+        return {
+            "recommended_size": smallest.candidate_size,
+            "reason": (
+                "re-ranking did not improve NDCG at any candidate size; "
+                "recommend smallest to minimize wasted latency"
+            ),
+            "efficiency": smallest.ndcg_delta_per_ms,
+        }
+
+    best = max(positive, key=lambda a: a.ndcg_delta_per_ms)
+    return {
+        "recommended_size": best.candidate_size,
+        "reason": (
+            f"best NDCG-delta-per-ms efficiency at candidate_size={best.candidate_size}: "
+            f"+{best.mean_ndcg_delta:.4f} NDCG in {best.mean_rerank_latency_ms:.1f}ms"
+        ),
+        "efficiency": best.ndcg_delta_per_ms,
+    }
+
+
+# ── Top-level driver ───────────────────────────────────────────────
+
+
+def run_cross_encoder_benchmark(
+    progress: Callable[[str], None] | None = None,
+) -> tuple[Dataset, list[CandidateSizeResult], dict]:
+    """Full benchmark: load dataset, run all queries x all candidate sizes.
+
+    Returns (dataset, all_results, timings).
+    """
+    log = progress or (lambda msg: None)
+    timings: dict[str, float] = {}
+
+    # 1. Load and embed dataset
+    log("loading and embedding dataset")
+    t0 = time.perf_counter()
+    embedder = EmbeddingClient()
+    try:
+        dataset = load_dataset(embedder)
+    finally:
+        embedder.close()
+    timings["embed_dataset_seconds"] = time.perf_counter() - t0
+    log(
+        f"  embedded {len(dataset.memories)} memories, "
+        f"{len(dataset.queries)} queries "
+        f"({timings['embed_dataset_seconds']:.1f}s)"
+    )
+
+    # 2. Run all queries x all candidate sizes
+    log("running cross-encoder benchmark")
+    t1 = time.perf_counter()
+    all_results: list[CandidateSizeResult] = []
+    reranker = RerankerClient()
+    try:
+        for idx, query in enumerate(dataset.queries, start=1):
+            relevant = get_relevant_ids(query, dataset)
+            for size in CANDIDATE_SIZES:
+                log(
+                    f"  query {idx}/{len(dataset.queries)} ({query.id}), "
+                    f"candidates={size}"
+                )
+                result = evaluate_query_at_size(
+                    query, dataset, reranker, size, relevant
+                )
+                all_results.append(result)
+    finally:
+        reranker.close()
+    timings["benchmark_seconds"] = time.perf_counter() - t1
+    log(
+        f"  produced {len(all_results)} results "
+        f"({timings['benchmark_seconds']:.1f}s)"
+    )
+
+    return dataset, all_results, timings

--- a/tests/perf/metrics.py
+++ b/tests/perf/metrics.py
@@ -1,0 +1,62 @@
+"""Shared retrieval quality metrics for perf benchmarks.
+
+Extracted from two_vector_bench.py so both the two-vector and
+cross-encoder benchmarks use the same metric implementations.
+"""
+
+from __future__ import annotations
+
+import math
+
+
+def recall_at_k(retrieved_ids: list[str], relevant_ids: set[str], k: int) -> float:
+    """Fraction of relevant items recovered in the top-k.
+
+    Note: with 50 relevant memories per topic and k=10, the maximum
+    achievable Recall@10 is 10/50=0.2. Compare relative values across
+    pipelines, not absolute.
+    """
+    if not relevant_ids:
+        return 0.0
+    top = retrieved_ids[:k]
+    hit = sum(1 for mid in top if mid in relevant_ids)
+    return hit / len(relevant_ids)
+
+
+def precision_at_k(
+    retrieved_ids: list[str], relevant_ids: set[str], k: int
+) -> float:
+    """Fraction of top-k items that are relevant."""
+    top = retrieved_ids[:k]
+    if not top:
+        return 0.0
+    hit = sum(1 for mid in top if mid in relevant_ids)
+    return hit / len(top)
+
+
+def mrr(retrieved_ids: list[str], relevant_ids: set[str]) -> float:
+    """Mean reciprocal rank: 1 / position of first relevant result."""
+    for rank, mid in enumerate(retrieved_ids, start=1):
+        if mid in relevant_ids:
+            return 1.0 / rank
+    return 0.0
+
+
+def ndcg_at_k(retrieved_ids: list[str], relevant_ids: set[str], k: int) -> float:
+    """Normalized discounted cumulative gain with binary relevance.
+
+    DCG  = sum(rel_i / log2(i + 2)) for i in range(k)
+    IDCG = sum(1 / log2(i + 2))     for i in range(min(k, |relevant|))
+    NDCG = DCG / IDCG; returns 0.0 if IDCG is 0.
+    """
+    top = retrieved_ids[:k]
+    dcg = 0.0
+    for i, mid in enumerate(top):
+        if mid in relevant_ids:
+            dcg += 1.0 / math.log2(i + 2)
+
+    n_ideal = min(k, len(relevant_ids))
+    if n_ideal == 0:
+        return 0.0
+    idcg = sum(1.0 / math.log2(i + 2) for i in range(n_ideal))
+    return dcg / idcg

--- a/tests/perf/test_cross_encoder.py
+++ b/tests/perf/test_cross_encoder.py
@@ -1,0 +1,239 @@
+"""Tests for the cross-encoder cost/benefit benchmark engine.
+
+Unit tests exercise the metrics and aggregation logic with synthetic
+data and never touch the network. Live smoke tests (auto-marked ``perf``
+by conftest.py) hit the deployed embedding and reranker services.
+
+Run offline tests only::
+
+    pytest tests/perf/test_cross_encoder.py -k "not single_query"
+
+Run everything (requires cluster access)::
+
+    pytest tests/perf/test_cross_encoder.py -v
+"""
+
+from __future__ import annotations
+
+import math
+
+from tests.perf.cross_encoder_bench import (
+    CANDIDATE_SIZES,
+    AggregatedCandidateSize,
+    CandidateSizeResult,
+    aggregate_by_size,
+    recommend_candidate_size,
+)
+from tests.perf.metrics import ndcg_at_k
+
+
+# ── NDCG unit tests ────────────────────────────────────────────────
+
+
+def test_ndcg_perfect_ranking():
+    """All relevant items ranked first -> NDCG = 1.0."""
+    assert ndcg_at_k(["a", "b", "c", "x", "y"], {"a", "b", "c"}, k=5) == 1.0
+
+
+def test_ndcg_inverse_ranking():
+    """Relevant items at end -> NDCG < 1.0."""
+    score = ndcg_at_k(["x", "y", "a", "b", "c"], {"a", "b", "c"}, k=5)
+    assert 0 < score < 1.0
+
+
+def test_ndcg_empty_relevant():
+    """No relevant items -> NDCG = 0.0."""
+    assert ndcg_at_k(["a", "b", "c"], set(), k=3) == 0.0
+
+
+def test_ndcg_no_retrieved():
+    """Empty retrieval -> NDCG = 0.0."""
+    assert ndcg_at_k([], {"a"}, k=5) == 0.0
+
+
+def test_ndcg_partial_overlap():
+    """One relevant item at position 2 out of 3 relevant total."""
+    score = ndcg_at_k(["x", "a", "y"], {"a", "b", "c"}, k=3)
+    # DCG  = 0 + 1/log2(3) + 0 = 1/log2(3)
+    # IDCG = 1/log2(2) + 1/log2(3) + 1/log2(4)
+    dcg = 1.0 / math.log2(3)
+    idcg = 1.0 / math.log2(2) + 1.0 / math.log2(3) + 1.0 / math.log2(4)
+    assert math.isclose(score, dcg / idcg, abs_tol=1e-9)
+
+
+def test_ndcg_k_larger_than_retrieved():
+    """k > len(retrieved) uses only available positions."""
+    score = ndcg_at_k(["a", "b"], {"a", "b", "c"}, k=10)
+    # Both retrieved items are relevant, but only 2 positions available
+    dcg = 1.0 / math.log2(2) + 1.0 / math.log2(3)
+    # IDCG uses min(k=10, |relevant|=3) = 3 ideal positions
+    idcg = 1.0 / math.log2(2) + 1.0 / math.log2(3) + 1.0 / math.log2(4)
+    assert math.isclose(score, dcg / idcg, abs_tol=1e-9)
+
+
+# ── Aggregation unit tests ─────────────────────────────────────────
+
+
+def _make_result(
+    query_id: str,
+    size: int,
+    v_ndcg: float = 0.5,
+    r_ndcg: float = 0.7,
+    v_mrr: float = 0.4,
+    r_mrr: float = 0.6,
+    latency: float = 50.0,
+) -> CandidateSizeResult:
+    """Factory for synthetic CandidateSizeResult records."""
+    return CandidateSizeResult(
+        query_id=query_id,
+        query_topic="deployment",
+        candidate_size=size,
+        vector_recall=0.1,
+        vector_precision=0.5,
+        vector_mrr=v_mrr,
+        vector_ndcg=v_ndcg,
+        reranked_recall=0.14,
+        reranked_precision=0.6,
+        reranked_mrr=r_mrr,
+        reranked_ndcg=r_ndcg,
+        recall_delta=0.04,
+        precision_delta=0.1,
+        mrr_delta=r_mrr - v_mrr,
+        ndcg_delta=r_ndcg - v_ndcg,
+        rerank_latency_ms=latency,
+    )
+
+
+def test_aggregate_groups_by_size():
+    """Aggregation groups by candidate_size and averages metrics."""
+    results = [
+        _make_result("q1", 10, v_ndcg=0.4, r_ndcg=0.6, latency=30.0),
+        _make_result("q2", 10, v_ndcg=0.5, r_ndcg=0.8, latency=40.0),
+        _make_result("q1", 25, v_ndcg=0.3, r_ndcg=0.7, latency=60.0),
+    ]
+    agg = aggregate_by_size(results)
+    assert len(agg) == 2  # sizes 10 and 25
+
+    size_10 = next(a for a in agg if a.candidate_size == 10)
+    assert size_10.n_queries == 2
+    assert math.isclose(size_10.mean_vector_ndcg, 0.45, abs_tol=1e-9)
+    assert math.isclose(size_10.mean_reranked_ndcg, 0.70, abs_tol=1e-9)
+    assert math.isclose(size_10.mean_ndcg_delta, 0.25, abs_tol=1e-9)
+    assert math.isclose(size_10.mean_rerank_latency_ms, 35.0, abs_tol=1e-9)
+    # efficiency = 0.25 / 35.0
+    assert math.isclose(size_10.ndcg_delta_per_ms, 0.25 / 35.0, abs_tol=1e-9)
+
+    size_25 = next(a for a in agg if a.candidate_size == 25)
+    assert size_25.n_queries == 1
+
+
+def test_aggregate_sorted_by_size():
+    """Aggregation returns results sorted by candidate_size ascending."""
+    results = [
+        _make_result("q1", 100),
+        _make_result("q1", 10),
+        _make_result("q1", 50),
+    ]
+    agg = aggregate_by_size(results)
+    sizes = [a.candidate_size for a in agg]
+    assert sizes == [10, 50, 100]
+
+
+# ── Recommendation unit tests ──────────────────────────────────────
+
+
+def test_recommend_picks_best_efficiency():
+    """Recommendation picks the size with highest NDCG-delta-per-ms."""
+    aggregated = [
+        AggregatedCandidateSize(
+            candidate_size=10, n_queries=40,
+            mean_vector_ndcg=0.5, mean_reranked_ndcg=0.6,
+            mean_ndcg_delta=0.10, mean_vector_mrr=0.4, mean_reranked_mrr=0.5,
+            mean_mrr_delta=0.1, mean_rerank_latency_ms=30.0,
+            ndcg_delta_per_ms=0.10 / 30.0,
+        ),
+        AggregatedCandidateSize(
+            candidate_size=25, n_queries=40,
+            mean_vector_ndcg=0.5, mean_reranked_ndcg=0.7,
+            mean_ndcg_delta=0.20, mean_vector_mrr=0.4, mean_reranked_mrr=0.6,
+            mean_mrr_delta=0.2, mean_rerank_latency_ms=50.0,
+            ndcg_delta_per_ms=0.20 / 50.0,
+        ),
+        AggregatedCandidateSize(
+            candidate_size=50, n_queries=40,
+            mean_vector_ndcg=0.5, mean_reranked_ndcg=0.72,
+            mean_ndcg_delta=0.22, mean_vector_mrr=0.4, mean_reranked_mrr=0.62,
+            mean_mrr_delta=0.22, mean_rerank_latency_ms=120.0,
+            ndcg_delta_per_ms=0.22 / 120.0,
+        ),
+    ]
+    rec = recommend_candidate_size(aggregated)
+    # Size 25 has best efficiency: 0.20/50 = 0.004 vs 0.10/30 = 0.0033
+    assert rec["recommended_size"] == 25
+    assert rec["efficiency"] > 0
+
+
+def test_recommend_handles_no_improvement():
+    """When reranking never helps, recommend smallest size."""
+    aggregated = [
+        AggregatedCandidateSize(
+            candidate_size=10, n_queries=10,
+            mean_vector_ndcg=0.5, mean_reranked_ndcg=0.49,
+            mean_ndcg_delta=-0.01, mean_vector_mrr=0.4, mean_reranked_mrr=0.39,
+            mean_mrr_delta=-0.01, mean_rerank_latency_ms=30.0,
+            ndcg_delta_per_ms=-0.01 / 30.0,
+        ),
+        AggregatedCandidateSize(
+            candidate_size=50, n_queries=10,
+            mean_vector_ndcg=0.5, mean_reranked_ndcg=0.48,
+            mean_ndcg_delta=-0.02, mean_vector_mrr=0.4, mean_reranked_mrr=0.38,
+            mean_mrr_delta=-0.02, mean_rerank_latency_ms=100.0,
+            ndcg_delta_per_ms=-0.02 / 100.0,
+        ),
+    ]
+    rec = recommend_candidate_size(aggregated)
+    assert rec["recommended_size"] == 10
+    assert "did not improve" in rec["reason"]
+
+
+def test_recommend_empty_input():
+    """Empty aggregation falls back to first default candidate size."""
+    rec = recommend_candidate_size([])
+    assert rec["recommended_size"] == CANDIDATE_SIZES[0]
+    assert rec["reason"] == "no data"
+
+
+# ── Live smoke test ────────────────────────────────────────────────
+
+
+def test_single_query_all_candidate_sizes():
+    """Smoke test: one query through all 4 candidate sizes.
+
+    Exercises the full pipeline end-to-end against deployed services.
+    Runs one query to keep latency manageable while still validating
+    that embedding, cosine retrieval, batched reranking, and metric
+    computation all work together.
+    """
+    from tests.perf.cross_encoder_bench import evaluate_query_at_size, get_relevant_ids
+    from tests.perf.two_vector_bench import EmbeddingClient, RerankerClient, load_dataset
+
+    embedder = EmbeddingClient()
+    try:
+        dataset = load_dataset(embedder)
+    finally:
+        embedder.close()
+
+    query = next(q for q in dataset.queries if q.id == "deployment-s1")
+    relevant = get_relevant_ids(query, dataset)
+
+    reranker = RerankerClient()
+    try:
+        for size in CANDIDATE_SIZES:
+            result = evaluate_query_at_size(query, dataset, reranker, size, relevant)
+            assert result.candidate_size == size
+            assert result.rerank_latency_ms > 0
+            assert 0 <= result.reranked_ndcg <= 1.0
+            assert 0 <= result.vector_ndcg <= 1.0
+            assert result.query_id == "deployment-s1"
+    finally:
+        reranker.close()

--- a/tests/perf/test_two_vector_retrieval.py
+++ b/tests/perf/test_two_vector_retrieval.py
@@ -22,6 +22,7 @@ import math
 
 from tests.perf.fixtures.queries import QUERIES
 from tests.perf.fixtures.topics import TOPICS, all_memories
+from tests.perf.metrics import mrr, precision_at_k, recall_at_k
 from tests.perf.two_vector_bench import (
     EmbeddingClient,
     Memory,
@@ -31,14 +32,11 @@ from tests.perf.two_vector_bench import (
     cosine_sim,
     evaluate_query,
     load_dataset,
-    mrr,
     pipeline_baseline,
     pipeline_new1_rrf_blend,
     pipeline_new2_augmented_query,
     pipeline_new3_rerank_only,
-    precision_at_k,
     rank_dict,
-    recall_at_k,
     reciprocal_rank_fusion,
     relevant_ids_for_query,
 )

--- a/tests/perf/two_vector_bench.py
+++ b/tests/perf/two_vector_bench.py
@@ -383,44 +383,16 @@ def pipeline_new2_augmented_query(
 
 
 # ── Metrics ─────────────────────────────────────────────────────────
+# recall_at_k, precision_at_k, and mrr are re-exported from the shared
+# metrics module so existing callers (tests, scripts) that import them
+# from this module continue to work.
+
+from tests.perf.metrics import mrr, precision_at_k, recall_at_k  # noqa: F811,E402
 
 
 def relevant_ids_for_query(query: Query, dataset: Dataset) -> set[str]:
     """Memories whose ground-truth topic matches the query's target topic."""
     return {m.id for m in dataset.memories if m.topic == query.topic}
-
-
-def recall_at_k(retrieved_ids: list[str], relevant_ids: set[str], k: int) -> float:
-    """Fraction of relevant items recovered in the top-k.
-
-    Note: with 50 relevant memories per topic and k=10, the maximum
-    achievable Recall@10 is 10/50=0.2. Compare relative values across
-    pipelines, not absolute.
-    """
-    if not relevant_ids:
-        return 0.0
-    top = retrieved_ids[:k]
-    hit = sum(1 for mid in top if mid in relevant_ids)
-    return hit / len(relevant_ids)
-
-
-def precision_at_k(
-    retrieved_ids: list[str], relevant_ids: set[str], k: int
-) -> float:
-    """Fraction of top-k items that are relevant."""
-    top = retrieved_ids[:k]
-    if not top:
-        return 0.0
-    hit = sum(1 for mid in top if mid in relevant_ids)
-    return hit / len(top)
-
-
-def mrr(retrieved_ids: list[str], relevant_ids: set[str]) -> float:
-    """Mean reciprocal rank: 1 / position of first relevant result."""
-    for rank, mid in enumerate(retrieved_ids, start=1):
-        if mid in relevant_ids:
-            return 1.0 / rank
-    return 0.0
 
 
 # ── Sweep runner ────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Extracts shared retrieval metrics (`recall_at_k`, `precision_at_k`, `mrr`) from `two_vector_bench.py` into `tests/perf/metrics.py` and adds `ndcg_at_k` (binary relevance NDCG)
- Implements cross-encoder cost/benefit benchmark engine that sweeps candidate set sizes [10, 25, 50, 100] and measures NDCG/MRR improvement vs reranking latency
- Includes batched reranking for candidate sets exceeding `MAX_BATCH=32`
- Produces optimal candidate size recommendation based on NDCG-delta-per-ms efficiency

Closes #274.

## Changes

- `tests/perf/metrics.py` (NEW): shared metric functions extracted from two_vector_bench.py + NDCG
- `tests/perf/cross_encoder_bench.py` (NEW): benchmark engine with `evaluate_query_at_size`, `batched_rerank`, `aggregate_by_size`, `recommend_candidate_size`, `run_cross_encoder_benchmark`
- `tests/perf/test_cross_encoder.py` (NEW): 11 offline unit tests + 1 live smoke test
- `scripts/bench-cross-encoder.py` (NEW): standalone runner with ASCII tables and JSON output
- `two_vector_bench.py`: import metrics from shared module (backward-compatible re-exports)

## Test plan

- [x] 11 offline cross-encoder tests pass (`pytest tests/perf/test_cross_encoder.py -k "not single_query"`)
- [x] 19 offline two-vector tests pass (no regressions from metrics extraction)
- [ ] Live smoke test requires deployed embedding + reranker services
- [ ] Full benchmark run via `python scripts/bench-cross-encoder.py` (produces `benchmarks/cross-encoder-*.json`)