### PR TITLE
schema: Add relevant_until column and temporal classification

### DIFF
--- a/alembic/versions/022_add_relevant_until.py
+++ b/alembic/versions/022_add_relevant_until.py
@@ -1,0 +1,37 @@
+"""Add relevant_until column to memory_nodes.
+
+Semantic expiry timestamp for memory content, distinct from expires_at
+(storage lifecycle). NULL means no semantic expiry (evergreen or
+version-bound). Populated by the temporal classifier at write time.
+
+Revision ID: 022_add_relevant_until
+Revises: 021_add_extraction_failures
+Create Date: 2026-06-30
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "022_add_relevant_until"
+down_revision = "021_add_extraction_failures"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "memory_nodes",
+        sa.Column("relevant_until", sa.TIMESTAMP(timezone=True), nullable=True),
+    )
+    op.create_index(
+        "ix_memory_nodes_relevant_until",
+        "memory_nodes",
+        ["relevant_until"],
+        postgresql_where=sa.text("relevant_until IS NOT NULL"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_memory_nodes_relevant_until", "memory_nodes")
+    op.drop_column("memory_nodes", "relevant_until")

--- a/memory-hub-mcp/src/tools/memory.py
+++ b/memory-hub-mcp/src/tools/memory.py
@@ -40,7 +40,7 @@ _SEARCH_OPTS = frozenset({
     "max_response_tokens", "raw_results", "weight_threshold",
     "current_only", "owner_id", "graph_depth",
     "graph_relationship_types", "graph_boost_weight", "entities",
-    "content_type", "verbose",
+    "content_type", "verbose", "temporal_status",
 })
 _LIST_OPTS = frozenset({
     "max_results", "cursor", "include_branches", "current_only",
@@ -59,7 +59,7 @@ _RECONSTRUCT_OPTS = frozenset({"owner_id"})
 _WRITE_OPTS = frozenset({
     "weight", "parent_id", "branch_type", "metadata", "domains",
     "project_description", "force", "owner_id", "content_type",
-    "driver_id",
+    "driver_id", "relevant_until",
 })
 _UPDATE_OPTS = frozenset({"weight", "metadata", "domains", "driver_id"})
 _SET_RULE_OPTS = frozenset({

--- a/memory-hub-mcp/src/tools/search_memory.py
+++ b/memory-hub-mcp/src/tools/search_memory.py
@@ -668,6 +668,17 @@ async def search_memory(
             ),
         ),
     ] = None,
+    temporal_status: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Filter by temporal status. 'current' shows memories with no "
+                "semantic expiry or expiry in the future. 'expired' shows memories "
+                "past their relevant_until date. 'expiring_soon' shows memories "
+                "expiring within 7 days. 'all' disables the filter (default)."
+            ),
+        ),
+    ] = None,
     ctx: Context = None,
 ) -> dict[str, Any]:
     """Search memories using semantic similarity.
@@ -858,6 +869,7 @@ async def search_memory(
                 graph_boost_weight=graph_boost_weight,
                 entity_names=entities,
                 content_type=content_type,
+                temporal_status=temporal_status,
             )
             graph_bundle = bundle
             results = bundle.results
@@ -886,6 +898,7 @@ async def search_memory(
                 role_names=role_names,
                 entity_names=entities,
                 content_type=content_type,
+                temporal_status=temporal_status,
             )
 
         # Count all matching memories under the same filter set so the agent
@@ -901,6 +914,7 @@ async def search_memory(
             project_ids=project_ids,
             role_names=role_names,
             entity_names=entities,
+            temporal_status=temporal_status,
         )
 
         # Apply post-retrieval domain boost only on the non-focus path.

--- a/memory-hub-mcp/src/tools/write_memory.py
+++ b/memory-hub-mcp/src/tools/write_memory.py
@@ -190,6 +190,17 @@ async def write_memory(
             ),
         ),
     ] = None,
+    relevant_until: Annotated[
+        str | None,
+        Field(
+            description=(
+                "ISO 8601 timestamp for semantic expiry (e.g. '2026-12-31T23:59:59Z'). "
+                "When set, indicates when this memory's content becomes stale. "
+                "Distinct from storage lifecycle (expires_at). Omit to let the "
+                "temporal classifier auto-detect from content."
+            ),
+        ),
+    ] = None,
     ctx: Context = None,
 ) -> dict[str, Any]:
     """Create a new memory node or branch in the memory tree.
@@ -339,6 +350,22 @@ async def write_memory(
                 f"Invalid parent_id format: '{parent_id}'. Must be a valid UUID."
             ) from None
 
+    # Parse relevant_until string to datetime if provided.
+    parsed_relevant_until = None
+    if relevant_until is not None:
+        from datetime import datetime as dt, UTC as _UTC
+
+        try:
+            parsed_relevant_until = dt.fromisoformat(relevant_until)
+            # Ensure timezone-aware
+            if parsed_relevant_until.tzinfo is None:
+                parsed_relevant_until = parsed_relevant_until.replace(tzinfo=_UTC)
+        except (ValueError, TypeError):
+            raise ToolError(
+                f"Invalid relevant_until format: '{relevant_until}'. "
+                "Must be a valid ISO 8601 timestamp (e.g. '2026-12-31T23:59:59Z')."
+            ) from None
+
     # Build the create schema with validation
     try:
         node_create = MemoryNodeCreate(
@@ -354,6 +381,7 @@ async def write_memory(
             domains=domains,
             scope_id=scope_id_value,
             content_type=content_type,
+            relevant_until=parsed_relevant_until,
         )
     except ValidationError as exc:
         errors = exc.errors()

--- a/memory-hub-mcp/tests/test_relevant_until.py
+++ b/memory-hub-mcp/tests/test_relevant_until.py
@@ -1,0 +1,19 @@
+"""Tests for relevant_until and temporal_status MCP tool integration."""
+
+from src.tools.memory import _SEARCH_OPTS, _WRITE_OPTS
+
+
+class TestOptionForwarding:
+    """Verify the unified dispatcher forwards relevant_until and temporal_status."""
+
+    def test_write_opts_contains_relevant_until(self):
+        assert "relevant_until" in _WRITE_OPTS
+
+    def test_search_opts_contains_temporal_status(self):
+        assert "temporal_status" in _SEARCH_OPTS
+
+    def test_write_opts_is_frozen(self):
+        assert isinstance(_WRITE_OPTS, frozenset)
+
+    def test_search_opts_is_frozen(self):
+        assert isinstance(_SEARCH_OPTS, frozenset)

--- a/src/memoryhub_core/models/memory.py
+++ b/src/memoryhub_core/models/memory.py
@@ -91,6 +91,10 @@ class MemoryNode(TimestampMixin, Base):
     # TTL for superseded versions (current versions never expire)
     expires_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True, default=None)
 
+    # Semantic expiry: when the content becomes stale (distinct from expires_at
+    # which is storage lifecycle). NULL = evergreen or version-bound.
+    relevant_until: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True, default=None)
+
     # Embedding (384 dims for sentence-transformers/all-MiniLM-L6-v2)
     embedding: Mapped[list[float] | None] = mapped_column(Vector(384), nullable=True)
 
@@ -146,6 +150,11 @@ class MemoryNode(TimestampMixin, Base):
             "ix_memory_nodes_expires_at",
             "expires_at",
             postgresql_where=text("expires_at IS NOT NULL"),
+        ),
+        Index(
+            "ix_memory_nodes_relevant_until",
+            "relevant_until",
+            postgresql_where=text("relevant_until IS NOT NULL"),
         ),
     )
 

--- a/src/memoryhub_core/models/schemas.py
+++ b/src/memoryhub_core/models/schemas.py
@@ -82,6 +82,10 @@ class MemoryNodeCreate(BaseModel):
         default=None, description="Crosscutting knowledge domain tags (e.g., 'React', 'Spring Boot')"
     )
     content_type: ContentType = Field(default=ContentType.EXPERIENTIAL, description="Memory classification type")
+    relevant_until: datetime | None = Field(
+        default=None,
+        description="Semantic expiry timestamp. NULL means evergreen or version-bound.",
+    )
 
 
 class MemoryNodeUpdate(BaseModel):
@@ -136,6 +140,8 @@ class MemoryNodeRead(BaseModel):
     created_at: datetime
     updated_at: datetime
     expires_at: datetime | None = None
+    relevant_until: datetime | None = None
+    temporal_status: str | None = None  # computed by service layer
     has_children: bool = False  # populated by service layer, not from ORM
     has_rationale: bool = False  # populated by service layer, not from ORM
     branch_count: int = 0  # populated by service layer via COUNT(*) over children

--- a/src/memoryhub_core/services/memory.py
+++ b/src/memoryhub_core/services/memory.py
@@ -187,6 +187,7 @@ async def create_memory(
         metadata_=node_metadata,
         domains=data.domains,
         content_type=data.content_type,
+        relevant_until=data.relevant_until,
         embedding=embedding,
         is_current=True,
         version=1,

--- a/src/memoryhub_core/services/memory.py
+++ b/src/memoryhub_core/services/memory.py
@@ -1773,6 +1773,10 @@ def node_to_read(
     current_version_id: uuid.UUID | None = None,
 ) -> MemoryNodeRead:
     """Convert a MemoryNode ORM instance to a MemoryNodeRead schema."""
+    from memoryhub_core.services.temporal import compute_temporal_status
+
+    relevant_until = getattr(node, "relevant_until", None)
+
     return MemoryNodeRead(
         id=node.id,
         parent_id=node.parent_id,
@@ -1796,6 +1800,8 @@ def node_to_read(
         created_at=node.created_at,
         updated_at=node.updated_at,
         expires_at=node.expires_at,
+        relevant_until=relevant_until,
+        temporal_status=compute_temporal_status(relevant_until),
         has_children=has_children,
         has_rationale=has_rationale,
         branch_count=branch_count,

--- a/src/memoryhub_core/services/memory.py
+++ b/src/memoryhub_core/services/memory.py
@@ -690,6 +690,7 @@ def _build_search_filters(
     role_names: set[str] | None = None,
     entity_names: list[str] | None = None,
     content_type: str | None = None,
+    temporal_status: str | None = None,
 ) -> list | None:
     """Build the SQL filter list shared by search_memories and count_search_matches.
 
@@ -799,6 +800,34 @@ def _build_search_filters(
     if content_type is not None:
         filters.append(MemoryNode.content_type == content_type)
 
+    # Temporal status filter: restrict results by relevant_until semantics.
+    if temporal_status is not None and temporal_status != "all":
+        now_expr = func.now()
+        if temporal_status == "current":
+            # NULL (evergreen/version-bound) or future
+            filters.append(
+                or_(
+                    MemoryNode.relevant_until.is_(None),
+                    MemoryNode.relevant_until > now_expr,
+                )
+            )
+        elif temporal_status == "expired":
+            filters.append(
+                and_(
+                    MemoryNode.relevant_until.isnot(None),
+                    MemoryNode.relevant_until <= now_expr,
+                )
+            )
+        elif temporal_status == "expiring_soon":
+            seven_days = now_expr + timedelta(days=7)
+            filters.append(
+                and_(
+                    MemoryNode.relevant_until.isnot(None),
+                    MemoryNode.relevant_until > now_expr,
+                    MemoryNode.relevant_until <= seven_days,
+                )
+            )
+
     return filters
 
 
@@ -815,6 +844,7 @@ async def count_search_matches(
     role_names: set[str] | None = None,
     entity_names: list[str] | None = None,
     content_type: str | None = None,
+    temporal_status: str | None = None,
 ) -> int:
     """Count memories matching the same filter set used by search_memories.
 
@@ -834,6 +864,7 @@ async def count_search_matches(
         role_names=role_names,
         entity_names=entity_names,
         content_type=content_type,
+        temporal_status=temporal_status,
     )
     if filters is None:
         return 0
@@ -858,6 +889,7 @@ async def search_memories(
     role_names: set[str] | None = None,
     entity_names: list[str] | None = None,
     content_type: str | None = None,
+    temporal_status: str | None = None,
 ) -> list[tuple[MemoryNodeRead | MemoryNodeStub, float]]:
     """Search memories using pgvector cosine similarity.
 
@@ -885,6 +917,7 @@ async def search_memories(
         role_names=role_names,
         entity_names=entity_names,
         content_type=content_type,
+        temporal_status=temporal_status,
     )
     if filters is None:
         return []
@@ -975,6 +1008,7 @@ async def list_memories(
     project_ids: set[str] | None = None,
     role_names: set[str] | None = None,
     content_type: str | None = None,
+    temporal_status: str | None = None,
 ) -> tuple[list[MemoryNodeRead | MemoryNodeStub], str | None]:
     """Enumerate memories without semantic ranking.
 
@@ -988,6 +1022,7 @@ async def list_memories(
         project_ids=project_ids,
         role_names=role_names,
         content_type=content_type,
+        temporal_status=temporal_status,
     )
     if filters is None:
         return [], None
@@ -1115,6 +1150,7 @@ async def search_memories_with_focus(
     graph_boost_weight: float = 0.2,
     entity_names: list[str] | None = None,
     content_type: str | None = None,
+    temporal_status: str | None = None,
 ) -> FocusedSearchResult:
     """Two-vector retrieval with session focus bias.
 
@@ -1165,6 +1201,7 @@ async def search_memories_with_focus(
             role_names=role_names,
             entity_names=entity_names,
             content_type=content_type,
+            temporal_status=temporal_status,
         )
         return FocusedSearchResult(results=plain)
 
@@ -1187,6 +1224,7 @@ async def search_memories_with_focus(
         role_names=role_names,
         entity_names=entity_names,
         content_type=content_type,
+        temporal_status=temporal_status,
     )
     if filters is None:
         return FocusedSearchResult(

--- a/src/memoryhub_core/services/memory.py
+++ b/src/memoryhub_core/services/memory.py
@@ -197,6 +197,12 @@ async def create_memory(
         updated_at=now,
     )
 
+    # Run temporal classifier when caller didn't set relevant_until explicitly.
+    if node.relevant_until is None:
+        from memoryhub_core.services.temporal import classify_temporal
+
+        node.relevant_until = classify_temporal(data.content, now)
+
     session.add(node)
     await session.commit()
     await session.refresh(node)
@@ -475,6 +481,14 @@ async def update_memory(
         db_content = old_node.content
         storage_type = old_node.storage_type
 
+    # Recompute relevant_until when content changes; inherit from old node otherwise.
+    if content_changed:
+        from memoryhub_core.services.temporal import classify_temporal
+
+        new_relevant_until = classify_temporal(new_content, now)
+    else:
+        new_relevant_until = old_node.relevant_until
+
     new_node = MemoryNode(
         id=new_id,
         content=db_content,
@@ -490,6 +504,7 @@ async def update_memory(
         branch_type=old_node.branch_type,
         metadata_=new_metadata,
         domains=new_domains,
+        relevant_until=new_relevant_until,
         embedding=embedding,
         is_current=True,
         version=old_node.version + 1,

--- a/src/memoryhub_core/services/temporal.py
+++ b/src/memoryhub_core/services/temporal.py
@@ -1,0 +1,206 @@
+"""Lightweight temporal classifier for memory content.
+
+Classifies memory content by temporal signal and returns a
+``relevant_until`` timestamp (or None for evergreen/version-bound
+content). Runs synchronously in the write path -- this is a
+regex/heuristic classifier, NOT an LLM call.
+
+Categories:
+- Explicit deadline: "deploy by 2026-07-15" -> specific date
+- Relative deadline: "within 2 weeks" -> computed date
+- Implicit temporal: "currently using" -> now + 90 days
+- Version-bound: "PostgreSQL 15" -> None
+- Evergreen: "prefers dark mode" -> None
+"""
+
+from __future__ import annotations
+
+import calendar
+import re
+from datetime import UTC, datetime, timedelta
+
+# Implicit temporal markers -> now + 90 days
+_IMPLICIT_TEMPORAL_PATTERNS = [
+    re.compile(r"\bcurrently\b", re.IGNORECASE),
+    re.compile(r"\bright now\b", re.IGNORECASE),
+    re.compile(r"\bat the moment\b", re.IGNORECASE),
+    re.compile(r"\bfor now\b", re.IGNORECASE),
+    re.compile(r"\bat present\b", re.IGNORECASE),
+    re.compile(r"\bfor the time being\b", re.IGNORECASE),
+    re.compile(r"\btemporarily\b", re.IGNORECASE),
+]
+
+_IMPLICIT_TEMPORAL_DAYS = 90
+
+# ISO date pattern: 2026-07-15
+_ISO_DATE_RE = re.compile(r"\b(\d{4})-(\d{2})-(\d{2})\b")
+
+# Deadline phrases with ISO dates: "by 2026-07-15", "deadline 2026-07-15",
+# "due 2026-07-15", "before 2026-07-15", "until 2026-07-15"
+_DEADLINE_ISO_RE = re.compile(
+    r"\b(?:by|deadline|due|before|until)\s+(\d{4})-(\d{2})-(\d{2})\b",
+    re.IGNORECASE,
+)
+
+# Month names for natural-language date parsing
+_MONTH_NAMES = {
+    name.lower(): num
+    for num, name in enumerate(calendar.month_name)
+    if num > 0
+}
+_MONTH_ABBREVS = {
+    name.lower(): num
+    for num, name in enumerate(calendar.month_abbr)
+    if num > 0
+}
+_ALL_MONTHS = {**_MONTH_NAMES, **_MONTH_ABBREVS}
+
+# Deadline phrases with natural dates: "by July 15", "deadline July 15, 2026",
+# "due March 1st"
+_MONTH_PATTERN = "|".join(
+    re.escape(m) for m in sorted(_ALL_MONTHS.keys(), key=len, reverse=True)
+)
+_DEADLINE_NATURAL_RE = re.compile(
+    rf"\b(?:by|deadline|due|before|until)\s+"
+    rf"({_MONTH_PATTERN})\s+(\d{{1,2}})(?:st|nd|rd|th)?"
+    rf"(?:,?\s+(\d{{4}}))?",
+    re.IGNORECASE,
+)
+
+# Relative deadline: "within N days/weeks/months", "in N days/weeks/months"
+_RELATIVE_RE = re.compile(
+    r"\b(?:within|in)\s+(\d+)\s+(days?|weeks?|months?)\b",
+    re.IGNORECASE,
+)
+
+# "next week", "next month"
+_NEXT_UNIT_RE = re.compile(
+    r"\bnext\s+(week|month)\b",
+    re.IGNORECASE,
+)
+
+# Version-bound patterns: these indicate version-specific content that is
+# not time-bound. Return None when found (no semantic expiry).
+_VERSION_RE = re.compile(
+    r"\bv\d+(?:\.\d+)*\b|\bversion\s+\d+",
+    re.IGNORECASE,
+)
+
+
+def classify_temporal(
+    content: str,
+    created_at: datetime | None = None,
+) -> datetime | None:
+    """Classify memory content and return a relevant_until timestamp.
+
+    Returns None for evergreen or version-bound content (no semantic expiry).
+    The classifier checks patterns in priority order:
+    1. Deadline phrases with explicit dates
+    2. Standalone ISO dates
+    3. Relative deadlines ("within N weeks")
+    4. "Next week/month"
+    5. Implicit temporal markers ("currently", "for now")
+    6. Version references -> None (version-bound, skip)
+    7. No signal -> None (evergreen)
+    """
+    now = created_at or datetime.now(UTC)
+
+    # 1. Deadline phrases with ISO dates (highest priority -- most explicit)
+    m = _DEADLINE_ISO_RE.search(content)
+    if m:
+        return _parse_iso_match(m.group(1), m.group(2), m.group(3))
+
+    # 2. Deadline phrases with natural dates
+    m = _DEADLINE_NATURAL_RE.search(content)
+    if m:
+        parsed = _parse_natural_date(m.group(1), m.group(2), m.group(3), now)
+        if parsed is not None:
+            return parsed
+
+    # 3. Standalone ISO dates (e.g., "Deploy 2026-07-15")
+    m = _ISO_DATE_RE.search(content)
+    if m:
+        return _parse_iso_match(m.group(1), m.group(2), m.group(3))
+
+    # 4. Relative deadlines
+    m = _RELATIVE_RE.search(content)
+    if m:
+        count = int(m.group(1))
+        unit = m.group(2).lower().rstrip("s")
+        return _apply_relative(now, count, unit)
+
+    # 5. "Next week/month"
+    m = _NEXT_UNIT_RE.search(content)
+    if m:
+        unit = m.group(1).lower()
+        if unit == "week":
+            return now + timedelta(weeks=1)
+        if unit == "month":
+            return now + timedelta(days=30)
+
+    # 6. Implicit temporal markers
+    for pattern in _IMPLICIT_TEMPORAL_PATTERNS:
+        if pattern.search(content):
+            return now + timedelta(days=_IMPLICIT_TEMPORAL_DAYS)
+
+    # 7. No temporal signal found -> evergreen
+    return None
+
+
+def compute_temporal_status(relevant_until: datetime | None) -> str | None:
+    """Compute temporal status from a relevant_until timestamp.
+
+    Returns:
+        None: evergreen or version-bound (no semantic expiry)
+        "expired": relevant_until is in the past
+        "expiring_soon": relevant_until is within 7 days
+        "current": relevant_until is more than 7 days away
+    """
+    if relevant_until is None:
+        return None
+    now = datetime.now(UTC)
+    if relevant_until < now:
+        return "expired"
+    if relevant_until < now + timedelta(days=7):
+        return "expiring_soon"
+    return "current"
+
+
+def _parse_iso_match(year_s: str, month_s: str, day_s: str) -> datetime | None:
+    """Parse year/month/day strings into a UTC datetime, or None on error."""
+    try:
+        return datetime(
+            int(year_s), int(month_s), int(day_s),
+            23, 59, 59, tzinfo=UTC,
+        )
+    except (ValueError, OverflowError):
+        return None
+
+
+def _parse_natural_date(
+    month_s: str,
+    day_s: str,
+    year_s: str | None,
+    now: datetime,
+) -> datetime | None:
+    """Parse a natural-language month + day + optional year."""
+    month_num = _ALL_MONTHS.get(month_s.lower())
+    if month_num is None:
+        return None
+    try:
+        day = int(day_s)
+        year = int(year_s) if year_s else now.year
+        return datetime(year, month_num, day, 23, 59, 59, tzinfo=UTC)
+    except (ValueError, OverflowError):
+        return None
+
+
+def _apply_relative(now: datetime, count: int, unit: str) -> datetime:
+    """Apply a relative offset (days/weeks/months) to now."""
+    if unit == "day":
+        return now + timedelta(days=count)
+    if unit == "week":
+        return now + timedelta(weeks=count)
+    if unit == "month":
+        return now + timedelta(days=count * 30)
+    return now

--- a/tests/test_services/test_temporal.py
+++ b/tests/test_services/test_temporal.py
@@ -1,0 +1,196 @@
+"""Tests for the temporal classifier and compute_temporal_status helper."""
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from memoryhub_core.services.temporal import classify_temporal, compute_temporal_status
+
+
+# -- classify_temporal tests --
+
+
+class TestExplicitDates:
+    """Explicit ISO dates and deadline phrases with dates."""
+
+    def test_standalone_iso_date(self):
+        result = classify_temporal("Deploy by 2026-12-31")
+        assert result is not None
+        assert result.year == 2026
+        assert result.month == 12
+        assert result.day == 31
+
+    def test_deadline_iso_date(self):
+        result = classify_temporal("The deadline is 2027-03-15 for this task")
+        assert result is not None
+        assert result.year == 2027
+        assert result.month == 3
+        assert result.day == 15
+
+    def test_due_iso_date(self):
+        result = classify_temporal("Report due 2026-08-01")
+        assert result is not None
+        assert result.year == 2026
+        assert result.month == 8
+        assert result.day == 1
+
+    def test_before_iso_date(self):
+        result = classify_temporal("Must complete before 2026-09-30")
+        assert result is not None
+        assert result.year == 2026
+        assert result.month == 9
+        assert result.day == 30
+
+    def test_deadline_natural_date(self):
+        now = datetime(2026, 7, 1, tzinfo=UTC)
+        result = classify_temporal("Deploy by July 15", created_at=now)
+        assert result is not None
+        assert result.month == 7
+        assert result.day == 15
+
+    def test_deadline_natural_date_with_year(self):
+        result = classify_temporal("Complete by March 1, 2027")
+        assert result is not None
+        assert result.year == 2027
+        assert result.month == 3
+        assert result.day == 1
+
+    def test_deadline_natural_date_ordinal(self):
+        now = datetime(2026, 7, 1, tzinfo=UTC)
+        result = classify_temporal("Due December 25th", created_at=now)
+        assert result is not None
+        assert result.month == 12
+        assert result.day == 25
+
+
+class TestRelativeDeadlines:
+    """Relative deadline phrases like 'within N weeks'."""
+
+    def test_within_two_weeks(self):
+        now = datetime(2026, 7, 1, tzinfo=UTC)
+        result = classify_temporal("Complete within 2 weeks", created_at=now)
+        assert result is not None
+        assert result == now + timedelta(weeks=2)
+
+    def test_within_three_days(self):
+        now = datetime(2026, 7, 1, tzinfo=UTC)
+        result = classify_temporal("Fix within 3 days", created_at=now)
+        assert result is not None
+        assert result == now + timedelta(days=3)
+
+    def test_in_one_month(self):
+        now = datetime(2026, 7, 1, tzinfo=UTC)
+        result = classify_temporal("Review in 1 month", created_at=now)
+        assert result is not None
+        assert result == now + timedelta(days=30)
+
+    def test_next_week(self):
+        now = datetime(2026, 7, 1, tzinfo=UTC)
+        result = classify_temporal("Ship next week", created_at=now)
+        assert result is not None
+        assert result == now + timedelta(weeks=1)
+
+    def test_next_month(self):
+        now = datetime(2026, 7, 1, tzinfo=UTC)
+        result = classify_temporal("Revisit next month", created_at=now)
+        assert result is not None
+        assert result == now + timedelta(days=30)
+
+
+class TestImplicitTemporal:
+    """Implicit temporal markers like 'currently', 'for now'."""
+
+    @pytest.mark.parametrize(
+        "content",
+        [
+            "Currently using FastAPI for the backend",
+            "We are right now focused on migration",
+            "At the moment, the cluster uses PostgreSQL 15",
+            "For now, we deploy to staging only",
+            "At present the team uses React 18",
+            "For the time being, skip integration tests",
+            "Temporarily disabled the rate limiter",
+        ],
+    )
+    def test_implicit_temporal_markers(self, content):
+        now = datetime(2026, 7, 1, tzinfo=UTC)
+        result = classify_temporal(content, created_at=now)
+        assert result is not None
+        assert result == now + timedelta(days=90)
+
+
+class TestEvergreenContent:
+    """Content with no temporal signal returns None."""
+
+    @pytest.mark.parametrize(
+        "content",
+        [
+            "User prefers dark mode in all editors",
+            "Always use Podman instead of Docker",
+            "The project uses PostgreSQL for persistence",
+            "Authentication is handled via OAuth2/OIDC",
+            "Code reviews require at least one approval",
+        ],
+    )
+    def test_no_temporal_signal(self, content):
+        result = classify_temporal(content)
+        assert result is None
+
+
+class TestEdgeCases:
+    """Edge cases and boundary conditions."""
+
+    def test_empty_string(self):
+        result = classify_temporal("")
+        assert result is None
+
+    def test_invalid_iso_date(self):
+        # Invalid month/day should not crash
+        result = classify_temporal("Deploy by 2026-13-45")
+        assert result is None
+
+    def test_deadline_takes_priority_over_standalone(self):
+        # "by 2026-07-15" should match deadline pattern, not standalone
+        result = classify_temporal("Complete by 2026-07-15 for the release")
+        assert result is not None
+        assert result.year == 2026
+        assert result.month == 7
+        assert result.day == 15
+
+    def test_uses_created_at_for_relative(self):
+        """Relative deadlines should be computed from created_at, not now()."""
+        past = datetime(2020, 1, 1, tzinfo=UTC)
+        result = classify_temporal("Complete within 1 week", created_at=past)
+        assert result is not None
+        assert result == past + timedelta(weeks=1)
+
+
+# -- compute_temporal_status tests --
+
+
+class TestComputeTemporalStatus:
+    """Tests for the compute_temporal_status helper."""
+
+    def test_none_returns_none(self):
+        assert compute_temporal_status(None) is None
+
+    def test_past_returns_expired(self):
+        past = datetime(2025, 1, 1, tzinfo=UTC)
+        assert compute_temporal_status(past) == "expired"
+
+    def test_far_future_returns_current(self):
+        future = datetime(2099, 1, 1, tzinfo=UTC)
+        assert compute_temporal_status(future) == "current"
+
+    def test_within_seven_days_returns_expiring_soon(self):
+        soon = datetime.now(UTC) + timedelta(days=3)
+        assert compute_temporal_status(soon) == "expiring_soon"
+
+    def test_exactly_seven_days_returns_expiring_soon(self):
+        # At the boundary: 6.9 days from now should be expiring_soon
+        boundary = datetime.now(UTC) + timedelta(days=6, hours=23)
+        assert compute_temporal_status(boundary) == "expiring_soon"
+
+    def test_just_past_seven_days_returns_current(self):
+        beyond = datetime.now(UTC) + timedelta(days=8)
+        assert compute_temporal_status(beyond) == "current"


### PR DESCRIPTION
## Summary

Adds semantic expiry tracking for memories via a `relevant_until` timestamp column, a heuristic temporal classifier that automatically tags memories at write time, and search filtering by temporal status.

Distinct from `expires_at` (storage lifecycle) -- `relevant_until` captures content validity. A memory about "currently using FastAPI" gets a 90-day expiry; "deploy by 2026-12-31" gets that date; "prefers dark mode" stays evergreen (NULL).

Closes #282.

## Changes

- **Migration**: `022_add_relevant_until.py` adds `TIMESTAMPTZ NULL` column + partial index
- **ORM + schemas**: `relevant_until` on MemoryNode, MemoryNodeCreate, MemoryNodeRead; computed `temporal_status` on MemoryNodeRead
- **Temporal classifier** (`services/temporal.py`, 206 lines): regex/heuristic patterns for ISO dates, natural-language deadlines, relative phrases ("within 2 weeks"), implicit temporal markers ("currently", "for now"), with 90-day default for implicit signals
- **Write path**: classifier runs when caller doesn't set `relevant_until` explicitly; re-classifies on content updates
- **Read path**: `node_to_read` populates `temporal_status` ("current", "expired", "expiring_soon", or null)
- **Search filter**: `temporal_status` parameter on `search_memories` and `search_memories_with_focus`
- **MCP tools**: `write_memory` accepts `relevant_until` (ISO 8601 string), `search_memory` accepts `temporal_status` filter, unified dispatcher updated

## Test plan

- [x] 34 temporal classifier tests pass (explicit dates, relative deadlines, implicit markers, evergreen, edge cases, compute_temporal_status)
- [x] 4 MCP integration tests pass (option set membership)
- [x] No regressions in existing service tests (102 pass) or dispatcher tests (60 pass)