### PR TITLE
auth: Add tenant-scope filtering to admin API

### DIFF
--- a/memoryhub-auth/src/routes/admin.py
+++ b/memoryhub-auth/src/routes/admin.py
@@ -5,7 +5,7 @@ import secrets
 from datetime import UTC, datetime
 
 import bcrypt
-from fastapi import APIRouter, Depends, Header, HTTPException
+from fastapi import APIRouter, Depends, Header, HTTPException, Query
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -51,9 +51,13 @@ def _client_to_response(client: OAuthClient) -> ClientResponse:
 
 @router.get("/clients", dependencies=[Depends(require_admin_key)])
 async def list_clients(
+    tenant_id: str | None = Query(default=None, description="Filter by tenant"),
     session: AsyncSession = Depends(get_session),
 ) -> list[ClientResponse]:
-    result = await session.execute(select(OAuthClient))
+    stmt = select(OAuthClient)
+    if tenant_id is not None:
+        stmt = stmt.where(OAuthClient.tenant_id == tenant_id)
+    result = await session.execute(stmt)
     clients = result.scalars().all()
     return [_client_to_response(c) for c in clients]
 
@@ -125,11 +129,13 @@ async def create_client(
 @router.get("/clients/{client_id}", dependencies=[Depends(require_admin_key)])
 async def get_client(
     client_id: str,
+    tenant_id: str | None = Query(default=None, description="Filter by tenant"),
     session: AsyncSession = Depends(get_session),
 ) -> ClientResponse:
-    result = await session.execute(
-        select(OAuthClient).where(OAuthClient.client_id == client_id)
-    )
+    stmt = select(OAuthClient).where(OAuthClient.client_id == client_id)
+    if tenant_id is not None:
+        stmt = stmt.where(OAuthClient.tenant_id == tenant_id)
+    result = await session.execute(stmt)
     client = result.scalar_one_or_none()
     if client is None:
         raise HTTPException(status_code=404, detail=f"Client '{client_id}' not found")
@@ -140,11 +146,13 @@ async def get_client(
 async def update_client(
     client_id: str,
     body: UpdateClientRequest,
+    tenant_id: str | None = Query(default=None, description="Filter by tenant"),
     session: AsyncSession = Depends(get_session),
 ) -> ClientResponse:
-    result = await session.execute(
-        select(OAuthClient).where(OAuthClient.client_id == client_id)
-    )
+    stmt = select(OAuthClient).where(OAuthClient.client_id == client_id)
+    if tenant_id is not None:
+        stmt = stmt.where(OAuthClient.tenant_id == tenant_id)
+    result = await session.execute(stmt)
     client = result.scalar_one_or_none()
     if client is None:
         raise HTTPException(status_code=404, detail=f"Client '{client_id}' not found")
@@ -174,11 +182,13 @@ async def update_client(
 )
 async def rotate_secret(
     client_id: str,
+    tenant_id: str | None = Query(default=None, description="Filter by tenant"),
     session: AsyncSession = Depends(get_session),
 ) -> SecretRotatedResponse:
-    result = await session.execute(
-        select(OAuthClient).where(OAuthClient.client_id == client_id)
-    )
+    stmt = select(OAuthClient).where(OAuthClient.client_id == client_id)
+    if tenant_id is not None:
+        stmt = stmt.where(OAuthClient.tenant_id == tenant_id)
+    result = await session.execute(stmt)
     client = result.scalar_one_or_none()
     if client is None:
         raise HTTPException(status_code=404, detail=f"Client '{client_id}' not found")
@@ -206,11 +216,13 @@ async def rotate_secret(
 )
 async def rotate_api_key(
     client_id: str,
+    tenant_id: str | None = Query(default=None, description="Filter by tenant"),
     session: AsyncSession = Depends(get_session),
 ) -> ApiKeyRotatedResponse:
-    result = await session.execute(
-        select(OAuthClient).where(OAuthClient.client_id == client_id)
-    )
+    stmt = select(OAuthClient).where(OAuthClient.client_id == client_id)
+    if tenant_id is not None:
+        stmt = stmt.where(OAuthClient.tenant_id == tenant_id)
+    result = await session.execute(stmt)
     client = result.scalar_one_or_none()
     if client is None:
         raise HTTPException(status_code=404, detail=f"Client '{client_id}' not found")

--- a/memoryhub-auth/tests/test_admin.py
+++ b/memoryhub-auth/tests/test_admin.py
@@ -270,6 +270,95 @@ class TestRotateApiKey:
 
 
 @pytest.mark.asyncio
+class TestTenantFiltering:
+    """Cross-tenant isolation tests for admin endpoints (#105)."""
+
+    async def _create_in_tenant(self, client, client_id: str, tenant: str) -> dict:
+        """Helper: create a client in a specific tenant, return the response."""
+        body = {
+            "client_id": client_id,
+            "client_name": f"{client_id} name",
+            "tenant_id": tenant,
+        }
+        resp = await client.post("/admin/clients", json=body, headers=ADMIN_HEADERS)
+        assert resp.status_code == 201, resp.text
+        return resp.json()
+
+    async def test_list_clients_filters_by_tenant(self, client):
+        """GET /admin/clients?tenant_id=X returns only that tenant's clients."""
+        await self._create_in_tenant(client, "tenant-a-agent", "tenant-a")
+        await self._create_in_tenant(client, "tenant-b-agent", "tenant-b")
+
+        resp = await client.get(
+            "/admin/clients", params={"tenant_id": "tenant-a"}, headers=ADMIN_HEADERS
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert all(c["tenant_id"] == "tenant-a" for c in data), (
+            f"Expected all clients to be in tenant-a, got: {data}"
+        )
+        ids = [c["client_id"] for c in data]
+        assert "tenant-a-agent" in ids
+        assert "tenant-b-agent" not in ids
+
+    async def test_list_clients_without_tenant_returns_all(self, client):
+        """GET /admin/clients without tenant_id returns all (backward compat)."""
+        await self._create_in_tenant(client, "compat-agent-a", "compat-tenant-a")
+        await self._create_in_tenant(client, "compat-agent-b", "compat-tenant-b")
+
+        resp = await client.get("/admin/clients", headers=ADMIN_HEADERS)
+        assert resp.status_code == 200, resp.text
+        ids = [c["client_id"] for c in resp.json()]
+        assert "compat-agent-a" in ids
+        assert "compat-agent-b" in ids
+
+    async def test_get_client_rejects_cross_tenant(self, client):
+        """GET /admin/clients/{id}?tenant_id=wrong returns 404."""
+        await self._create_in_tenant(client, "ct-get-agent", "tenant-a")
+
+        resp = await client.get(
+            "/admin/clients/ct-get-agent",
+            params={"tenant_id": "tenant-b"},
+            headers=ADMIN_HEADERS,
+        )
+        assert resp.status_code == 404, resp.text
+
+    async def test_patch_client_rejects_cross_tenant(self, client):
+        """PATCH /admin/clients/{id}?tenant_id=wrong returns 404."""
+        await self._create_in_tenant(client, "ct-patch-agent", "tenant-a")
+
+        resp = await client.patch(
+            "/admin/clients/ct-patch-agent",
+            params={"tenant_id": "tenant-b"},
+            json={"client_name": "Should Not Update"},
+            headers=ADMIN_HEADERS,
+        )
+        assert resp.status_code == 404, resp.text
+
+    async def test_rotate_secret_rejects_cross_tenant(self, client):
+        """POST /admin/clients/{id}/rotate-secret?tenant_id=wrong returns 404."""
+        await self._create_in_tenant(client, "ct-rotate-agent", "tenant-a")
+
+        resp = await client.post(
+            "/admin/clients/ct-rotate-agent/rotate-secret",
+            params={"tenant_id": "tenant-b"},
+            headers=ADMIN_HEADERS,
+        )
+        assert resp.status_code == 404, resp.text
+
+    async def test_rotate_api_key_rejects_cross_tenant(self, client):
+        """POST /admin/clients/{id}/rotate-api-key?tenant_id=wrong returns 404."""
+        await self._create_in_tenant(client, "ct-apikey-agent", "tenant-a")
+
+        resp = await client.post(
+            "/admin/clients/ct-apikey-agent/rotate-api-key",
+            params={"tenant_id": "tenant-b"},
+            headers=ADMIN_HEADERS,
+        )
+        assert resp.status_code == 404, resp.text
+
+
+@pytest.mark.asyncio
 class TestRotateSecret:
     async def test_rotate_returns_new_secret(self, client, sample_client):
         resp = await client.post(

--- a/memoryhub-ui/backend/src/routes.py
+++ b/memoryhub-ui/backend/src/routes.py
@@ -580,15 +580,6 @@ async def delete_memory(memory_id: str, db: DbDep, settings: SettingsDep):
 
 # ---------------------------------------------------------------------------
 # Client management (proxy to auth service admin API)
-#
-# Phase 6 (#46) note: the /api/clients/* routes deliberately remain
-# unscoped by tenant because they proxy verbatim to the auth service's
-# /admin/clients API, which is itself not yet tenant-scoped. The auth
-# admin API is a separate design concern (tracked as Phase 6 follow-up)
-# and tenant scoping it there is out of scope for the BFF work. If/when
-# the auth service grows a tenant filter, the BFF's ui_tenant_id should
-# be forwarded in the _admin_request call so operators only see their
-# own tenant's clients.
 # ---------------------------------------------------------------------------
 
 
@@ -647,13 +638,8 @@ async def list_users(db: DbDep, settings: SettingsDep):
     """List all identities with memory counts and last active times.
 
     Merges OAuth client data from auth service with memory stats from DB.
-
-    Phase 6 (#46): the local memory_nodes aggregation is tenant-scoped by
-    ``settings.ui_tenant_id`` so owners only appear with the memory
-    counts from their own tenant. The auth service /admin/clients proxy
-    portion is NOT tenant-scoped yet -- same caveat as /api/clients --
-    so the merged roster may still show clients that have not written
-    anything in this tenant (they'll appear with memory_count=0).
+    Both the local memory_nodes aggregation and the auth service client
+    list are tenant-scoped by ``settings.ui_tenant_id`` (#105).
     """
     tenant_id = settings.ui_tenant_id
 

--- a/memoryhub-ui/backend/src/routes.py
+++ b/memoryhub-ui/backend/src/routes.py
@@ -88,12 +88,18 @@ async def _admin_request(
     method: str,
     path: str,
     json_body: dict | None = None,
+    tenant_id: str | None = None,
 ) -> httpx.Response:
     """Make an authenticated request to the auth service admin API."""
     url = f"{settings.auth_service_url}{path}"
     headers = {"X-Admin-Key": settings.admin_key}
+    params: dict[str, str] = {}
+    if tenant_id is not None:
+        params["tenant_id"] = tenant_id
     async with httpx.AsyncClient(timeout=10.0) as client:
-        response = await client.request(method, url, headers=headers, json=json_body)
+        response = await client.request(
+            method, url, headers=headers, json=json_body, params=params
+        )
     if response.status_code >= 400:
         try:
             detail = response.json().get("detail", response.text)
@@ -588,32 +594,46 @@ async def delete_memory(memory_id: str, db: DbDep, settings: SettingsDep):
 
 @router.get("/api/clients", response_model=list[ClientResponse])
 async def list_clients(settings: SettingsDep):
-    resp = await _admin_request(settings, "GET", "/admin/clients")
+    resp = await _admin_request(
+        settings, "GET", "/admin/clients", tenant_id=settings.ui_tenant_id
+    )
     return resp.json()
 
 
 @router.post("/api/clients", response_model=ClientCreatedResponse, status_code=201)
 async def create_client(body: CreateClientRequest, settings: SettingsDep):
-    resp = await _admin_request(settings, "POST", "/admin/clients", json_body=body.model_dump())
+    resp = await _admin_request(
+        settings, "POST", "/admin/clients",
+        json_body=body.model_dump(), tenant_id=settings.ui_tenant_id,
+    )
     return resp.json()
 
 
 @router.patch("/api/clients/{client_id}", response_model=ClientResponse)
 async def update_client(client_id: str, body: UpdateClientRequest, settings: SettingsDep):
     payload = body.model_dump(exclude_none=True)
-    resp = await _admin_request(settings, "PATCH", f"/admin/clients/{client_id}", json_body=payload)
+    resp = await _admin_request(
+        settings, "PATCH", f"/admin/clients/{client_id}",
+        json_body=payload, tenant_id=settings.ui_tenant_id,
+    )
     return resp.json()
 
 
 @router.post("/api/clients/{client_id}/rotate-secret", response_model=SecretRotatedResponse)
 async def rotate_client_secret(client_id: str, settings: SettingsDep):
-    resp = await _admin_request(settings, "POST", f"/admin/clients/{client_id}/rotate-secret")
+    resp = await _admin_request(
+        settings, "POST", f"/admin/clients/{client_id}/rotate-secret",
+        tenant_id=settings.ui_tenant_id,
+    )
     return resp.json()
 
 
 @router.post("/api/clients/{client_id}/rotate-api-key", response_model=ApiKeyRotatedResponse)
 async def rotate_api_key(client_id: str, settings: SettingsDep):
-    resp = await _admin_request(settings, "POST", f"/admin/clients/{client_id}/rotate-api-key")
+    resp = await _admin_request(
+        settings, "POST", f"/admin/clients/{client_id}/rotate-api-key",
+        tenant_id=settings.ui_tenant_id,
+    )
     return resp.json()
 
 
@@ -660,7 +680,9 @@ async def list_users(db: DbDep, settings: SettingsDep):
     # Try to get client list from auth service
     clients = []
     try:
-        resp = await _admin_request(settings, "GET", "/admin/clients")
+        resp = await _admin_request(
+            settings, "GET", "/admin/clients", tenant_id=settings.ui_tenant_id
+        )
         clients = resp.json()
     except Exception:
         logger.warning("Could not fetch clients from auth service, using DB owner_ids only")

--- a/memoryhub-ui/backend/tests/test_routes.py
+++ b/memoryhub-ui/backend/tests/test_routes.py
@@ -849,6 +849,145 @@ class TestClientEndpoints:
 
 
 # ---------------------------------------------------------------------------
+# Client tenant forwarding (#105)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestClientTenantForwarding:
+    """Verify the BFF forwards ui_tenant_id to the auth admin API (#105)."""
+
+    async def test_list_clients_forwards_tenant_id(self, test_settings):
+        upstream = _mock_httpx_response(200, [_SAMPLE_CLIENT])
+        patcher, mock_http = _patch_admin_httpx(upstream)
+
+        app.dependency_overrides[get_settings] = lambda: test_settings
+        with patcher:
+            try:
+                async with AsyncClient(
+                    transport=ASGITransport(app=app), base_url="http://test"
+                ) as ac:
+                    await ac.get("/api/clients")
+
+                # The mock_http.request call should include params with tenant_id
+                call_kwargs = mock_http.request.call_args
+                assert call_kwargs is not None, "request() was not called"
+                params = call_kwargs.kwargs.get("params", {})
+                assert params.get("tenant_id") == test_settings.ui_tenant_id, (
+                    f"Expected tenant_id={test_settings.ui_tenant_id!r} in params, got {params}"
+                )
+            finally:
+                app.dependency_overrides.clear()
+
+    async def test_create_client_forwards_tenant_id(self, test_settings):
+        created = {**_SAMPLE_CLIENT, "client_secret": "s", "api_key": "mh-dev-abc"}
+        upstream = _mock_httpx_response(201, created)
+        patcher, mock_http = _patch_admin_httpx(upstream)
+
+        app.dependency_overrides[get_settings] = lambda: test_settings
+        with patcher:
+            try:
+                async with AsyncClient(
+                    transport=ASGITransport(app=app), base_url="http://test"
+                ) as ac:
+                    await ac.post(
+                        "/api/clients",
+                        json={
+                            "client_id": "x",
+                            "client_name": "X",
+                            "tenant_id": "t",
+                        },
+                    )
+
+                params = mock_http.request.call_args.kwargs.get("params", {})
+                assert params.get("tenant_id") == test_settings.ui_tenant_id
+            finally:
+                app.dependency_overrides.clear()
+
+    async def test_update_client_forwards_tenant_id(self, test_settings):
+        upstream = _mock_httpx_response(200, _SAMPLE_CLIENT)
+        patcher, mock_http = _patch_admin_httpx(upstream)
+
+        app.dependency_overrides[get_settings] = lambda: test_settings
+        with patcher:
+            try:
+                async with AsyncClient(
+                    transport=ASGITransport(app=app), base_url="http://test"
+                ) as ac:
+                    await ac.patch(
+                        "/api/clients/test-client",
+                        json={"client_name": "Renamed"},
+                    )
+
+                params = mock_http.request.call_args.kwargs.get("params", {})
+                assert params.get("tenant_id") == test_settings.ui_tenant_id
+            finally:
+                app.dependency_overrides.clear()
+
+    async def test_rotate_secret_forwards_tenant_id(self, test_settings):
+        upstream = _mock_httpx_response(
+            200, {"client_id": "x", "client_secret": "s", "api_key": "mh-dev-a"}
+        )
+        patcher, mock_http = _patch_admin_httpx(upstream)
+
+        app.dependency_overrides[get_settings] = lambda: test_settings
+        with patcher:
+            try:
+                async with AsyncClient(
+                    transport=ASGITransport(app=app), base_url="http://test"
+                ) as ac:
+                    await ac.post("/api/clients/test-client/rotate-secret")
+
+                params = mock_http.request.call_args.kwargs.get("params", {})
+                assert params.get("tenant_id") == test_settings.ui_tenant_id
+            finally:
+                app.dependency_overrides.clear()
+
+    async def test_rotate_api_key_forwards_tenant_id(self, test_settings):
+        upstream = _mock_httpx_response(
+            200, {"client_id": "x", "api_key": "mh-dev-a"}
+        )
+        patcher, mock_http = _patch_admin_httpx(upstream)
+
+        app.dependency_overrides[get_settings] = lambda: test_settings
+        with patcher:
+            try:
+                async with AsyncClient(
+                    transport=ASGITransport(app=app), base_url="http://test"
+                ) as ac:
+                    await ac.post("/api/clients/test-client/rotate-api-key")
+
+                params = mock_http.request.call_args.kwargs.get("params", {})
+                assert params.get("tenant_id") == test_settings.ui_tenant_id
+            finally:
+                app.dependency_overrides.clear()
+
+    async def test_users_endpoint_forwards_tenant_id(self, test_settings):
+        """GET /api/users sends tenant_id when fetching the client list."""
+        upstream = _mock_httpx_response(200, [_SAMPLE_CLIENT])
+        patcher, mock_http = _patch_admin_httpx(upstream)
+
+        # The users endpoint also queries the DB for memory stats.
+        stats_result = MagicMock()
+        stats_result.fetchall.return_value = []
+        db_session = _make_db_session([stats_result])
+
+        app.dependency_overrides[get_db] = lambda: db_session
+        app.dependency_overrides[get_settings] = lambda: test_settings
+        with patcher:
+            try:
+                async with AsyncClient(
+                    transport=ASGITransport(app=app), base_url="http://test"
+                ) as ac:
+                    await ac.get("/api/users")
+
+                params = mock_http.request.call_args.kwargs.get("params", {})
+                assert params.get("tenant_id") == test_settings.ui_tenant_id
+            finally:
+                app.dependency_overrides.clear()
+
+
+# ---------------------------------------------------------------------------
 # Curation rules
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Adds tenant isolation to the memoryhub-auth admin API so operators only see their own tenant's OAuth clients. The BFF now forwards `settings.ui_tenant_id` on every admin proxy call.

Closes #105.

## Changes

- **Auth admin endpoints** (`memoryhub-auth/src/routes/admin.py`): optional `tenant_id` query parameter on `list_clients`, `get_client`, `update_client`, `rotate_secret`, `rotate_api_key`. When provided, SQL queries include `WHERE tenant_id = :tenant_id`. Cross-tenant access returns 404. When omitted, behavior is unchanged (backward compatible).
- **BFF forwarding** (`memoryhub-ui/backend/src/routes.py`): `_admin_request()` gains `tenant_id` parameter forwarded as query param. All 6 admin proxy routes pass `settings.ui_tenant_id`.
- **Stale comment cleanup**: removed Phase 6 (#46) "intentionally unscoped" comment block
- **Auth tests**: 6 new tests (TestTenantFiltering) for list filtering, backward-compat global listing, and cross-tenant 404s on GET/PATCH/rotate-secret/rotate-api-key
- **BFF tests**: 6 new tests (TestClientTenantForwarding) verifying tenant_id forwarding on all proxy routes

## Test plan

- [x] Auth: 33/33 pass including 6 new cross-tenant isolation tests
- [x] BFF: 64/66 pass, 6 new forwarding tests pass; 2 pre-existing failures (mock data missing `api_key` field, confirmed on main)