### PR TITLE
retrieval: Add within-user pattern surfacing via search-time signals

### DIFF
--- a/memory-hub-mcp/src/tools/search_memory.py
+++ b/memory-hub-mcp/src/tools/search_memory.py
@@ -39,6 +39,7 @@ from memoryhub_core.services.memory import (
     search_memories,
     search_memories_with_focus,
 )
+from memoryhub_core.services.pattern import PatternSignal, detect_patterns
 from memoryhub_core.services.project import get_projects_for_user
 from memoryhub_core.services.role import get_roles_for_user
 from memoryhub_core.services.valkey_client import (
@@ -724,6 +725,10 @@ async def search_memory(
         unique nodes surfaced by graph traversal beyond the vector results.
       - graph_fallback_reason (str, only when graph_depth > 0 and traversal
         was skipped): human-readable reason graph traversal was not performed.
+      - pattern_signals (list, only when a within-user topic cluster is
+        detected): each entry has pattern, matching_memories, time_window_days,
+        representative_id, and summary_hint. Indicates 3+ recent memories
+        cluster around the search topic.
 
     Sizing controls:
       - mode controls full-vs-stub detail per result.
@@ -843,6 +848,7 @@ async def search_memory(
         # the original cosine-only path stays on the hot code path.
         focus_meta: dict[str, Any] | None = None
         graph_bundle = None
+        pattern_signals: list[PatternSignal] = []
         if focus and focus.strip():
             reranker = get_reranker_service()
             bundle = await search_memories_with_focus(
@@ -881,6 +887,7 @@ async def search_memory(
                 "used_reranker": bundle.used_reranker,
                 "fallback_reason": bundle.fallback_reason,
             }
+            pattern_signals = bundle.pattern_signals
         else:
             results = await search_memories(
                 query=query,
@@ -900,6 +907,21 @@ async def search_memory(
                 content_type=content_type,
                 temporal_status=temporal_status,
             )
+
+            # Pattern detection on the non-focus path: embed the query
+            # and check for within-user clusters.  Best-effort; failures
+            # are silently ignored.
+            if owner_id:
+                try:
+                    query_emb = await embedding_service.embed(query)
+                    pattern_signals = await detect_patterns(
+                        query_emb,
+                        session,
+                        owner_id=owner_id,
+                        tenant_id=tenant,
+                    )
+                except Exception:
+                    pass  # best-effort
 
         # Count all matching memories under the same filter set so the agent
         # can tell whether more matches exist beyond this page.
@@ -1147,6 +1169,17 @@ async def search_memory(
             response["graph_neighbors_added"] = graph_bundle.graph_neighbors_added
             if graph_bundle.graph_fallback_reason:
                 response["graph_fallback_reason"] = graph_bundle.graph_fallback_reason
+        if pattern_signals:
+            response["pattern_signals"] = [
+                {
+                    "pattern": sig.pattern,
+                    "matching_memories": sig.matching_memories,
+                    "time_window_days": sig.time_window_days,
+                    "representative_id": sig.representative_id,
+                    "summary_hint": sig.summary_hint,
+                }
+                for sig in pattern_signals
+            ]
         return response
 
     except EmbeddingContentTooLargeError as exc:

--- a/memory-hub-mcp/src/tools/search_memory.py
+++ b/memory-hub-mcp/src/tools/search_memory.py
@@ -16,6 +16,22 @@ from typing import Annotated, Any, Literal
 from fastmcp import Context
 from fastmcp.exceptions import ToolError
 from pydantic import Field
+from src.core.app import mcp
+from src.core.audit import record_event
+from src.core.authz import (
+    PROJECT_ISOLATION_ENABLED,
+    ROLE_ISOLATION_ENABLED,
+    AuthenticationError,
+    build_authorized_scopes,
+    get_claims_from_context,
+    get_tenant_filter,
+)
+from src.tools._deps import (
+    get_db_session,
+    get_embedding_service,
+    get_reranker_service,
+    release_db_session,
+)
 
 from memoryhub_core.models.memory import MemoryNode
 from memoryhub_core.models.schemas import MemoryNodeRead, MemoryNodeStub, MemoryScope
@@ -45,22 +61,6 @@ from memoryhub_core.services.role import get_roles_for_user
 from memoryhub_core.services.valkey_client import (
     ValkeyUnavailableError,
     get_valkey_client,
-)
-from src.core.app import mcp
-from src.core.audit import record_event
-from src.core.authz import (
-    PROJECT_ISOLATION_ENABLED,
-    ROLE_ISOLATION_ENABLED,
-    AuthenticationError,
-    build_authorized_scopes,
-    get_claims_from_context,
-    get_tenant_filter,
-)
-from src.tools._deps import (
-    get_db_session,
-    get_embedding_service,
-    get_reranker_service,
-    release_db_session,
 )
 
 logger = logging.getLogger(__name__)

--- a/memory-hub-mcp/tests/test_pattern_signals.py
+++ b/memory-hub-mcp/tests/test_pattern_signals.py
@@ -1,0 +1,82 @@
+"""Tests for pattern_signals integration in the search_memory tool.
+
+Verifies that the search tool imports the pattern detection module and
+that PatternSignal instances serialize correctly for tool responses.
+"""
+
+import dataclasses
+
+from memoryhub_core.services.pattern import PatternSignal
+
+
+def test_pattern_signal_import_from_search_tool():
+    """The search_memory module can import pattern detection."""
+    from src.tools.search_memory import detect_patterns, PatternSignal as PS
+
+    assert detect_patterns is not None
+    assert PS is PatternSignal
+
+
+def test_pattern_signal_to_response_dict():
+    """PatternSignal serializes to the expected response shape."""
+    sig = PatternSignal(
+        pattern="topic_cluster",
+        matching_memories=4,
+        time_window_days=30,
+        representative_id="deadbeef-1234",
+        summary_hint="4 recent memories cluster around this topic",
+    )
+    entry = {
+        "pattern": sig.pattern,
+        "matching_memories": sig.matching_memories,
+        "time_window_days": sig.time_window_days,
+        "representative_id": sig.representative_id,
+        "summary_hint": sig.summary_hint,
+    }
+    assert entry == dataclasses.asdict(sig)
+    assert isinstance(entry["matching_memories"], int)
+    assert isinstance(entry["time_window_days"], int)
+
+
+def test_empty_pattern_signals_not_in_response():
+    """When pattern_signals is empty, it should not appear in the response dict."""
+    pattern_signals: list[PatternSignal] = []
+    response: dict = {"results": [], "total_matching": 0, "has_more": False}
+
+    # Mirrors the tool's conditional injection
+    if pattern_signals:
+        response["pattern_signals"] = [
+            dataclasses.asdict(sig) for sig in pattern_signals
+        ]
+
+    assert "pattern_signals" not in response
+
+
+def test_nonempty_pattern_signals_in_response():
+    """When pattern_signals has entries, they appear in the response dict."""
+    pattern_signals = [
+        PatternSignal(
+            pattern="topic_cluster",
+            matching_memories=5,
+            time_window_days=14,
+            representative_id="abc-123",
+            summary_hint="5 recent memories cluster around this topic",
+        )
+    ]
+    response: dict = {"results": [], "total_matching": 5, "has_more": False}
+
+    if pattern_signals:
+        response["pattern_signals"] = [
+            {
+                "pattern": sig.pattern,
+                "matching_memories": sig.matching_memories,
+                "time_window_days": sig.time_window_days,
+                "representative_id": sig.representative_id,
+                "summary_hint": sig.summary_hint,
+            }
+            for sig in pattern_signals
+        ]
+
+    assert "pattern_signals" in response
+    assert len(response["pattern_signals"]) == 1
+    assert response["pattern_signals"][0]["matching_memories"] == 5

--- a/memory-hub-mcp/tests/test_pattern_signals.py
+++ b/memory-hub-mcp/tests/test_pattern_signals.py
@@ -11,10 +11,11 @@ from memoryhub_core.services.pattern import PatternSignal
 
 def test_pattern_signal_import_from_search_tool():
     """The search_memory module can import pattern detection."""
-    from src.tools.search_memory import detect_patterns, PatternSignal as PS
+    from src.tools.search_memory import PatternSignal as ToolPatternSignal
+    from src.tools.search_memory import detect_patterns
 
     assert detect_patterns is not None
-    assert PS is PatternSignal
+    assert ToolPatternSignal is PatternSignal
 
 
 def test_pattern_signal_to_response_dict():

--- a/memory-hub-mcp/tests/tools/test_search_memory.py
+++ b/memory-hub-mcp/tests/tools/test_search_memory.py
@@ -192,6 +192,11 @@ class _PatchedSearchCall:
                     "src.tools.search_memory.PROJECT_ISOLATION_ENABLED",
                     False,
                 ),
+                patch(
+                    "src.tools.search_memory.detect_patterns",
+                    new_callable=AsyncMock,
+                    return_value=[],
+                ),
             ):
                 return await search_memory(query="memory", **self.call_kwargs)
         finally:

--- a/src/memoryhub_core/services/memory.py
+++ b/src/memoryhub_core/services/memory.py
@@ -34,6 +34,7 @@ from memoryhub_core.services.exceptions import (
     MemoryNotCurrentError,
     MemoryNotFoundError,
 )
+from memoryhub_core.services.pattern import PatternSignal, detect_patterns
 from memoryhub_core.services.rerank import RERANK_MAX_BATCH, RerankerService
 from memoryhub_core.storage.chunker import semantic_chunk
 from memoryhub_core.storage.s3 import S3StorageAdapter
@@ -1097,6 +1098,7 @@ class FocusedSearchResult:
     fallback_reason: str | None = None
     graph_neighbors_added: int = 0
     graph_fallback_reason: str | None = None
+    pattern_signals: list[PatternSignal] = field(default_factory=list)
 
 
 def _cosine_distance(a: list[float], b: list[float]) -> float:
@@ -1510,6 +1512,21 @@ async def search_memories_with_focus(
                 )
             )
 
+    # Pattern detection: check for within-user topic clusters.
+    # Only runs when owner_id is available (can't cluster without
+    # knowing whose memories to check).
+    pattern_signals: list[PatternSignal] = []
+    if owner_id and use_pgvector:
+        try:
+            pattern_signals = await detect_patterns(
+                query_embedding,
+                session,
+                owner_id=owner_id,
+                tenant_id=tenant_id,
+            )
+        except Exception:
+            pass  # pattern detection is best-effort
+
     return FocusedSearchResult(
         results=formatted,
         pivot_suggested=pivot_suggested,
@@ -1520,6 +1537,7 @@ async def search_memories_with_focus(
         fallback_reason=fallback_reason,
         graph_neighbors_added=graph_neighbors_added,
         graph_fallback_reason=graph_fallback_reason,
+        pattern_signals=pattern_signals,
     )
 
 

--- a/src/memoryhub_core/services/memory.py
+++ b/src/memoryhub_core/services/memory.py
@@ -1517,7 +1517,7 @@ async def search_memories_with_focus(
     # knowing whose memories to check).
     pattern_signals: list[PatternSignal] = []
     if owner_id and use_pgvector:
-        try:
+        try:  # noqa: SIM105 -- suppress() can't capture the awaited result
             pattern_signals = await detect_patterns(
                 query_embedding,
                 session,

--- a/src/memoryhub_core/services/pattern.py
+++ b/src/memoryhub_core/services/pattern.py
@@ -12,7 +12,7 @@ import logging
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 
-from sqlalchemy import select, func
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from memoryhub_core.models.memory import MemoryNode

--- a/src/memoryhub_core/services/pattern.py
+++ b/src/memoryhub_core/services/pattern.py
@@ -1,0 +1,116 @@
+"""Within-user pattern detection for search-time signals.
+
+Detects clusters of similar recent memories within a single user's
+memory stream. When a search query overlaps with a cluster of recent
+memories (3+ with high cosine similarity in a configurable time window),
+the search response is annotated with pattern_signals.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+
+from sqlalchemy import select, func
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from memoryhub_core.models.memory import MemoryNode
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class PatternSignal:
+    """A detected pattern in the user's recent memories."""
+
+    pattern: str  # e.g. "topic_cluster"
+    matching_memories: int
+    time_window_days: int
+    representative_id: str  # UUID of the most recent matching memory
+    summary_hint: str  # Human-readable description
+
+
+async def detect_patterns(
+    query_embedding: list[float],
+    session: AsyncSession,
+    *,
+    owner_id: str,
+    tenant_id: str,
+    similarity_threshold: float = 0.80,
+    min_cluster_size: int = 3,
+    time_window_days: int = 30,
+    max_candidates: int = 50,
+) -> list[PatternSignal]:
+    """Detect within-user patterns by querying recent memories similar to the search query.
+
+    Runs a single pgvector cosine-distance query against the caller's recent
+    memories (last ``time_window_days`` days). If the number of matches above
+    ``similarity_threshold`` meets or exceeds ``min_cluster_size``, a
+    ``PatternSignal`` is returned with a count, time window, and the most
+    recent matching memory's ID.
+
+    This is a best-effort read-path enhancement. If pgvector is unavailable
+    or the query fails for any reason, an empty list is returned -- matching
+    the existing fallback patterns in search.
+    """
+    try:
+        cutoff = datetime.now(UTC) - timedelta(days=time_window_days)
+        distance_threshold = 1.0 - similarity_threshold
+
+        distance_expr = MemoryNode.embedding.cosine_distance(query_embedding)
+        stmt = (
+            select(
+                func.count().label("match_count"),
+                func.max(MemoryNode.created_at).label("latest_at"),
+            )
+            .where(
+                MemoryNode.owner_id == owner_id,
+                MemoryNode.tenant_id == tenant_id,
+                MemoryNode.is_current.is_(True),
+                MemoryNode.created_at >= cutoff,
+                MemoryNode.deleted_at.is_(None),
+                MemoryNode.embedding.isnot(None),
+                distance_expr <= distance_threshold,
+            )
+        )
+        result = await session.execute(stmt)
+        row = result.one()
+
+        if row.match_count < min_cluster_size:
+            return []
+
+        # Fetch the representative memory ID (most recent match).
+        rep_stmt = (
+            select(MemoryNode.id)
+            .where(
+                MemoryNode.owner_id == owner_id,
+                MemoryNode.tenant_id == tenant_id,
+                MemoryNode.is_current.is_(True),
+                MemoryNode.created_at >= cutoff,
+                MemoryNode.deleted_at.is_(None),
+                MemoryNode.embedding.isnot(None),
+                distance_expr <= distance_threshold,
+            )
+            .order_by(MemoryNode.created_at.desc())
+            .limit(1)
+        )
+        rep_result = await session.execute(rep_stmt)
+        representative_id = str(rep_result.scalar_one())
+
+        return [
+            PatternSignal(
+                pattern="topic_cluster",
+                matching_memories=row.match_count,
+                time_window_days=time_window_days,
+                representative_id=representative_id,
+                summary_hint=(
+                    f"{row.match_count} recent memories (last {time_window_days}d) "
+                    f"cluster around this topic"
+                ),
+            )
+        ]
+
+    except Exception:
+        logger.debug("pattern detection skipped (pgvector unavailable or query error)", exc_info=True)
+        return []

--- a/tests/test_services/test_pattern.py
+++ b/tests/test_services/test_pattern.py
@@ -1,0 +1,88 @@
+"""Tests for within-user pattern detection service.
+
+Pattern detection requires pgvector (cosine_distance operator), so the
+core query path is tested via integration tests against real PostgreSQL.
+These unit tests verify the PatternSignal dataclass, the function
+signature, and the graceful fallback when pgvector is unavailable.
+"""
+
+import dataclasses
+import uuid
+
+import pytest
+
+from memoryhub_core.services.pattern import PatternSignal, detect_patterns
+
+
+class TestPatternSignal:
+    """PatternSignal dataclass structure and field requirements."""
+
+    def test_fields(self):
+        fields = {f.name for f in dataclasses.fields(PatternSignal)}
+        assert fields == {
+            "pattern",
+            "matching_memories",
+            "time_window_days",
+            "representative_id",
+            "summary_hint",
+        }
+
+    def test_construction(self):
+        sig = PatternSignal(
+            pattern="topic_cluster",
+            matching_memories=5,
+            time_window_days=7,
+            representative_id="abc-123",
+            summary_hint="5 recent memories match this topic cluster",
+        )
+        assert sig.pattern == "topic_cluster"
+        assert sig.matching_memories == 5
+        assert sig.time_window_days == 7
+        assert sig.representative_id == "abc-123"
+        assert sig.summary_hint == "5 recent memories match this topic cluster"
+
+    def test_serialization_round_trip(self):
+        """PatternSignal can be converted to dict for JSON serialization."""
+        sig = PatternSignal(
+            pattern="topic_cluster",
+            matching_memories=3,
+            time_window_days=30,
+            representative_id=str(uuid.uuid4()),
+            summary_hint="3 recent memories cluster around this topic",
+        )
+        d = dataclasses.asdict(sig)
+        assert d["pattern"] == "topic_cluster"
+        assert d["matching_memories"] == 3
+        assert isinstance(d, dict)
+
+
+class TestDetectPatternsFallback:
+    """detect_patterns returns empty list when pgvector is unavailable."""
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_on_sqlite(self, async_session):
+        """SQLite sessions lack pgvector; detect_patterns should return []."""
+        fake_embedding = [0.1] * 384
+        result = await detect_patterns(
+            fake_embedding,
+            async_session,
+            owner_id="test-user",
+            tenant_id="default",
+        )
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_custom_thresholds_accepted(self, async_session):
+        """All keyword arguments are accepted without error."""
+        fake_embedding = [0.1] * 384
+        result = await detect_patterns(
+            fake_embedding,
+            async_session,
+            owner_id="test-user",
+            tenant_id="default",
+            similarity_threshold=0.90,
+            min_cluster_size=5,
+            time_window_days=7,
+            max_candidates=100,
+        )
+        assert result == []


### PR DESCRIPTION
## Summary

Detects patterns within a user's recent memory stream and annotates search responses with `pattern_signals` when 3+ memories cluster around the same topic as the query (cosine similarity > 0.80 in the last 30 days).

Read-path-only enhancement. No new agents, no new RBAC, no new infrastructure.

Closes #292.

## Changes

- **Pattern detection service** (`services/pattern.py`): `PatternSignal` dataclass + `detect_patterns()` async function. Uses pgvector cosine_distance to find clusters in user's recent memories. Graceful fallback when pgvector unavailable.
- **Service wiring**: `FocusedSearchResult` gains `pattern_signals` field. Detection runs after RRF blend in `search_memories_with_focus`, gated on owner_id and pgvector availability.
- **MCP tool**: Pattern signals surfaced in search response on both focus and non-focus paths. Only emitted when non-empty.

## Example response

```json
{
  "results": [...],
  "pattern_signals": [{
    "pattern": "topic_cluster",
    "matching_memories": 5,
    "time_window_days": 30,
    "representative_id": "uuid",
    "summary_hint": "5 recent memories match this topic cluster"
  }]
}
```

## Test plan

- [x] 5 service tests pass (dataclass structure, SQLite graceful fallback, custom thresholds)
- [x] 4 MCP tests pass (import verification, serialization, response inclusion/exclusion)
- [x] No regressions in existing search tests