### PR TITLE
authz: Wire project-scope membership enforcement into claims pipeline

### DIFF
--- a/memory-hub-mcp/deploy/users-configmap.example.yaml
+++ b/memory-hub-mcp/deploy/users-configmap.example.yaml
@@ -28,6 +28,7 @@ data:
           "name": "Wes Jackson",
           "api_key": "REPLACE-ME-GENERATE-WITH-openssl-rand-hex-16",
           "scopes": ["user", "project", "role", "organizational", "enterprise"],
+          "project_memberships": [],
           "_comment": "primary operator"
         },
         {
@@ -35,6 +36,7 @@ data:
           "name": "Test User",
           "api_key": "REPLACE-ME-GENERATE-WITH-openssl-rand-hex-16",
           "scopes": ["user", "project"],
+          "project_memberships": [],
           "_comment": "local development and integration testing"
         },
         {
@@ -42,6 +44,7 @@ data:
           "name": "RDWJ Agent 1",
           "api_key": "REPLACE-ME-GENERATE-WITH-openssl-rand-hex-16",
           "scopes": ["user", "project", "role", "organizational", "enterprise"],
+          "project_memberships": [],
           "_comment": "agent automation slot 1"
         },
         {
@@ -49,6 +52,7 @@ data:
           "name": "RDWJ Agent 2",
           "api_key": "REPLACE-ME-GENERATE-WITH-openssl-rand-hex-16",
           "scopes": ["user", "project", "role", "organizational", "enterprise"],
+          "project_memberships": [],
           "_comment": "agent automation slot 2"
         },
         {
@@ -56,6 +60,7 @@ data:
           "name": "Kagenti CI",
           "api_key": "REPLACE-ME-GENERATE-WITH-openssl-rand-hex-16",
           "scopes": ["user", "project"],
+          "project_memberships": [],
           "_comment": "kagenti-adk E2E test runner (see docs/SYSTEMS.md)"
         }
       ]

--- a/memory-hub-mcp/src/core/authz.py
+++ b/memory-hub-mcp/src/core/authz.py
@@ -88,6 +88,7 @@ def get_claims_from_context() -> dict:
             "identity_type": token.claims.get("identity_type", "user"),
             "tenant_id": token.claims.get("tenant_id", "default"),
             "scopes": list(token.scopes),
+            "project_memberships": token.claims.get("project_memberships", []),
         }
         log.debug("Resolved JWT identity via get_access_token: sub=%s", claims["sub"])
         return claims
@@ -106,6 +107,7 @@ def get_claims_from_context() -> dict:
             "identity_type": jwt_claims.get("identity_type", "user"),
             "tenant_id": jwt_claims.get("tenant_id", "default"),
             "scopes": scopes,
+            "project_memberships": jwt_claims.get("project_memberships", []),
         }
         log.debug("Resolved JWT identity via Authorization header: sub=%s", claims["sub"])
         return claims

--- a/memory-hub-mcp/src/core/authz.py
+++ b/memory-hub-mcp/src/core/authz.py
@@ -242,11 +242,19 @@ def authorize_write(
     return False
 
 
-def build_authorized_scopes(claims: dict) -> dict[str, str | None]:
+def build_authorized_scopes(claims: dict) -> dict[str, str | list[str] | None]:
     """Build scope visibility filter from claims for search queries.
 
-    Returns a dict mapping scope names to required owner_id values.
-    None means no owner filter (open read for that tier).
+    Returns a dict mapping scope names to required owner_id values:
+      - ``str``: exact owner_id match (user tier)
+      - ``list[str]``: set of allowed scope_ids (project tier, when
+        project_memberships are present in claims)
+      - ``None``: no owner filter (open read for that tier)
+
+    For the project tier, when the caller has project read access and
+    project_memberships are present in claims, the value is the list
+    of project IDs the caller belongs to. When memberships are empty,
+    the project tier is omitted entirely (no project memories visible).
 
     NOTE: This function does NOT include the tenant_id filter. Service-layer
     callers must combine the result of this function with `get_tenant_filter`
@@ -254,7 +262,7 @@ def build_authorized_scopes(claims: dict) -> dict[str, str | None]:
     """
     scopes = claims.get("scopes", [])
     caller_id = claims["sub"]
-    result: dict[str, str | None] = {}
+    result: dict[str, str | list[str] | None] = {}
 
     has_blanket_read = "memory:read" in scopes
 
@@ -262,6 +270,14 @@ def build_authorized_scopes(claims: dict) -> dict[str, str | None]:
         if has_blanket_read or f"memory:read:{tier}" in scopes:
             if tier == "user":
                 result[tier] = caller_id
+            elif tier == "project" and PROJECT_ISOLATION_ENABLED:
+                # When project isolation is on, use claims-based membership
+                # to restrict project visibility. Empty membership = no
+                # project memories visible (tier omitted from result).
+                memberships = claims.get("project_memberships", [])
+                if memberships:
+                    result[tier] = list(memberships)
+                # else: omit project tier entirely
             else:
                 result[tier] = None
 

--- a/memory-hub-mcp/src/core/authz.py
+++ b/memory-hub-mcp/src/core/authz.py
@@ -125,6 +125,7 @@ def get_claims_from_context() -> dict:
             "identity_type": user.get("identity_type", "user"),
             "tenant_id": user.get("tenant_id", "default"),
             "scopes": scopes,
+            "project_memberships": user.get("project_memberships", []),
         }
         log.debug("Resolved session identity: sub=%s", claims["sub"])
         return claims

--- a/memory-hub-mcp/src/tools/list_memory.py
+++ b/memory-hub-mcp/src/tools/list_memory.py
@@ -124,13 +124,17 @@ async def list_memory(
         if project_id:
             project_ids = {project_id}
         else:
-            session_p, gen_p = await get_db_session()
-            try:
-                project_ids = await get_projects_for_user(
-                    session_p, claims["sub"],
-                )
-            finally:
-                await release_db_session(gen_p)
+            claims_memberships = claims.get("project_memberships", [])
+            if claims_memberships:
+                project_ids = set(claims_memberships)
+            else:
+                session_p, gen_p = await get_db_session()
+                try:
+                    project_ids = await get_projects_for_user(
+                        session_p, claims["sub"],
+                    )
+                finally:
+                    await release_db_session(gen_p)
 
     role_names: set[str] | None = None
     if ROLE_ISOLATION_ENABLED:

--- a/memory-hub-mcp/src/tools/register_session.py
+++ b/memory-hub-mcp/src/tools/register_session.py
@@ -23,7 +23,7 @@ from fastmcp.exceptions import ToolError
 from pydantic import Field
 
 from memoryhub_core.config import AppSettings
-from memoryhub_core.services.project import list_projects_for_tenant
+from memoryhub_core.services.project import get_projects_for_user, list_projects_for_tenant
 from memoryhub_core.services.push_subscriber import (
     ensure_memoryhub_subscriber_running,
     stop_memoryhub_subscriber,
@@ -168,6 +168,39 @@ async def _fetch_user_projects(
             await release_db_session(gen)
 
 
+async def _resolve_project_memberships(
+    user: dict[str, Any],
+) -> list[str]:
+    """Merge ConfigMap-declared and DB-enrolled project memberships.
+
+    The ConfigMap provides a static bootstrap list; the DB has the
+    authoritative runtime state (including auto-enrollments from
+    write_memory). Returns the sorted union so the session carries
+    the fullest membership snapshot available at registration time.
+
+    Non-fatal: returns ConfigMap memberships alone if the DB is
+    unreachable, so registration is never blocked.
+    """
+    configmap_projects = set(user.get("project_memberships", []))
+
+    gen = None
+    try:
+        session, gen = await get_db_session()
+        db_projects = await get_projects_for_user(session, user["user_id"])
+        merged = configmap_projects | db_projects
+        return sorted(merged)
+    except Exception as exc:
+        logger.debug(
+            "Failed to resolve DB project memberships for %s: %s",
+            user.get("user_id", "?"),
+            exc,
+        )
+        return sorted(configmap_projects)
+    finally:
+        if gen is not None:
+            await release_db_session(gen)
+
+
 @mcp.tool(
     annotations={
         "readOnlyHint": False,
@@ -228,6 +261,14 @@ async def register_session(
         tenant = get_tenant_filter(jwt_claims)
         await _start_push_for_session(session_id, ctx)
         projects = await _fetch_user_projects(user_id, tenant)
+
+        # Resolve project memberships from DB for JWT users.
+        jwt_user_stub = {
+            "user_id": user_id,
+            "project_memberships": jwt_claims.get("project_memberships", []),
+        }
+        project_memberships = await _resolve_project_memberships(jwt_user_stub)
+
         record_event(
             event_type="session.registered",
             actor_id=user_id,
@@ -243,6 +284,7 @@ async def register_session(
             "user_id": user_id,
             "name": jwt_claims.get("name", user_id),
             "scopes": list(token.scopes),
+            "project_memberships": project_memberships,
             "auth_method": "jwt",
             "default_driver_id": default_driver_id,
             "projects": projects,
@@ -280,6 +322,11 @@ async def register_session(
             "Keys follow the format: mh-dev-<hex>."
         )
 
+    # Resolve project memberships: merge ConfigMap bootstrap with DB state.
+    # This must happen before set_session() so the session user dict
+    # carries project_memberships for get_claims_from_context() to extract.
+    user["project_memberships"] = await _resolve_project_memberships(user)
+
     app_settings = AppSettings()
     ttl = app_settings.session_ttl_seconds
     expires_at = set_session(user, ttl_seconds=ttl)
@@ -312,6 +359,7 @@ async def register_session(
         "user_id": user["user_id"],
         "name": user["name"],
         "scopes": user["scopes"],
+        "project_memberships": user["project_memberships"],
         "expires_at": expires_at.isoformat(),
         "session_ttl_seconds": ttl,
         "default_driver_id": default_driver_id,

--- a/memory-hub-mcp/src/tools/search_memory.py
+++ b/memory-hub-mcp/src/tools/search_memory.py
@@ -774,25 +774,32 @@ async def search_memory(
             await release_db_session(gen_for_campaign)
 
     # Resolve project memberships for the caller.
-    # When PROJECT_ISOLATION_ENABLED is False, skip resolution — the
+    # When PROJECT_ISOLATION_ENABLED is False, skip resolution -- the
     # search filter's generic branch handles project scope without
     # scope_id filtering, and authorize_read returns True.
     #
     # When a specific project_id is given, restrict results to THAT
-    # project only.  Without project_id, include all projects the
-    # caller belongs to so project-scoped memories stay discoverable.
+    # project only.  Without project_id, use claims-based memberships
+    # (populated at registration by _resolve_project_memberships) as
+    # the primary source. Fall back to a DB query for sessions that
+    # predate the claims pipeline or when mid-session auto-enrollment
+    # needs the freshest state.
     project_ids: set[str] | None = None
     if PROJECT_ISOLATION_ENABLED:
         if project_id:
             project_ids = {project_id}
         else:
-            session_for_project, gen_for_project = await get_db_session()
-            try:
-                project_ids = await get_projects_for_user(
-                    session_for_project, claims["sub"],
-                )
-            finally:
-                await release_db_session(gen_for_project)
+            claims_memberships = claims.get("project_memberships", [])
+            if claims_memberships:
+                project_ids = set(claims_memberships)
+            else:
+                session_for_project, gen_for_project = await get_db_session()
+                try:
+                    project_ids = await get_projects_for_user(
+                        session_for_project, claims["sub"],
+                    )
+                finally:
+                    await release_db_session(gen_for_project)
 
     # Resolve role assignments for the caller (table + JWT claims).
     role_names: set[str] | None = None

--- a/memory-hub-mcp/tests/test_authz.py
+++ b/memory-hub-mcp/tests/test_authz.py
@@ -222,8 +222,23 @@ def test_build_authorized_scopes_blanket_read():
     assert result["user"] == "alice"
     assert result["organizational"] is None
     assert result["enterprise"] is None
-    assert result["project"] is None
+    # With PROJECT_ISOLATION_ENABLED (default), project tier is omitted when
+    # no project_memberships are in claims. Add memberships to see the tier.
+    assert "project" not in result
     assert result["role"] is None
+
+
+def test_build_authorized_scopes_blanket_read_with_memberships():
+    """Blanket read with project memberships includes project tier."""
+    claims = {
+        "sub": "alice",
+        "scopes": ["memory:read"],
+        "project_memberships": ["proj-1"],
+    }
+    result = build_authorized_scopes(claims)
+    assert result["user"] == "alice"
+    assert result["project"] == ["proj-1"]
+    assert result["organizational"] is None
 
 
 def test_build_authorized_scopes_user_only():

--- a/memory-hub-mcp/tests/test_project_membership.py
+++ b/memory-hub-mcp/tests/test_project_membership.py
@@ -1,0 +1,303 @@
+"""Tests for project membership claims pipeline (issue #64).
+
+Verifies that project_memberships flows through the claims pipeline:
+  ConfigMap/DB -> session user dict -> get_claims_from_context() ->
+  build_authorized_scopes() -> _build_search_filters()
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.core.authz import (
+    authorize_read,
+    authorize_write,
+    build_authorized_scopes,
+    get_claims_from_context,
+)
+
+
+# -- build_authorized_scopes with project memberships -----------------------
+
+
+class TestBuildAuthorizedScopesProjectMembership:
+    """build_authorized_scopes uses claims-based project_memberships."""
+
+    def test_includes_project_ids_from_claims(self):
+        """Project tier carries the membership list when present."""
+        claims = {
+            "sub": "alice",
+            "scopes": ["memory:read"],
+            "project_memberships": ["proj-1", "proj-2"],
+        }
+        result = build_authorized_scopes(claims)
+        assert "project" in result
+        assert sorted(result["project"]) == ["proj-1", "proj-2"]
+
+    def test_empty_membership_omits_project_tier(self):
+        """Empty project_memberships means no project memories visible."""
+        claims = {
+            "sub": "alice",
+            "scopes": ["memory:read"],
+            "project_memberships": [],
+        }
+        result = build_authorized_scopes(claims)
+        assert "project" not in result
+
+    def test_missing_membership_key_omits_project_tier(self):
+        """Missing project_memberships key treated as empty."""
+        claims = {
+            "sub": "alice",
+            "scopes": ["memory:read"],
+        }
+        result = build_authorized_scopes(claims)
+        # With PROJECT_ISOLATION_ENABLED=True (default), no memberships
+        # means no project tier. This test verifies the key-missing case.
+        assert "project" not in result
+
+    def test_project_specific_scope_with_memberships(self):
+        """memory:read:project scope respects membership filtering."""
+        claims = {
+            "sub": "alice",
+            "scopes": ["memory:read:project"],
+            "project_memberships": ["my-proj"],
+        }
+        result = build_authorized_scopes(claims)
+        assert result == {"project": ["my-proj"]}
+
+    def test_project_with_isolation_disabled(self):
+        """When isolation is off, project tier returns None (no filter)."""
+        claims = {
+            "sub": "alice",
+            "scopes": ["memory:read"],
+            "project_memberships": ["proj-1"],
+        }
+        with patch("src.core.authz.PROJECT_ISOLATION_ENABLED", False):
+            result = build_authorized_scopes(claims)
+        assert result["project"] is None
+
+    def test_other_tiers_unaffected(self):
+        """Non-project tiers are unaffected by project_memberships."""
+        claims = {
+            "sub": "alice",
+            "scopes": ["memory:read"],
+            "project_memberships": ["proj-1"],
+        }
+        result = build_authorized_scopes(claims)
+        assert result["user"] == "alice"
+        assert result["organizational"] is None
+        assert result["enterprise"] is None
+
+    def test_blanket_read_includes_project_with_memberships(self):
+        """Blanket memory:read includes project tier when memberships exist."""
+        claims = {
+            "sub": "alice",
+            "scopes": ["memory:read"],
+            "project_memberships": ["proj-a", "proj-b", "proj-c"],
+        }
+        result = build_authorized_scopes(claims)
+        assert "project" in result
+        assert sorted(result["project"]) == ["proj-a", "proj-b", "proj-c"]
+
+    def test_no_read_scope_excludes_project(self):
+        """No read scope means no project tier regardless of memberships."""
+        claims = {
+            "sub": "alice",
+            "scopes": ["memory:write"],
+            "project_memberships": ["proj-1"],
+        }
+        result = build_authorized_scopes(claims)
+        assert "project" not in result
+
+
+# -- get_claims_from_context extracts project_memberships -------------------
+
+
+class TestClaimsIncludeProjectMemberships:
+    """get_claims_from_context populates project_memberships from session."""
+
+    def test_session_fallback_includes_memberships(self):
+        """Session user dict with project_memberships flows into claims."""
+        user = {
+            "user_id": "alice",
+            "name": "Alice",
+            "scopes": ["user", "project"],
+            "project_memberships": ["proj-1", "proj-2"],
+        }
+        with (
+            patch("fastmcp.server.dependencies.get_access_token", return_value=None),
+            patch("src.core.authz._extract_jwt_from_headers", return_value=None),
+            patch("src.core.authz.get_current_user", return_value=user),
+        ):
+            claims = get_claims_from_context()
+
+        assert claims["project_memberships"] == ["proj-1", "proj-2"]
+        assert claims["sub"] == "alice"
+
+    def test_session_fallback_empty_memberships(self):
+        """Session user without project_memberships defaults to empty list."""
+        user = {
+            "user_id": "bob",
+            "name": "Bob",
+            "scopes": ["user"],
+        }
+        with (
+            patch("fastmcp.server.dependencies.get_access_token", return_value=None),
+            patch("src.core.authz._extract_jwt_from_headers", return_value=None),
+            patch("src.core.authz.get_current_user", return_value=user),
+        ):
+            claims = get_claims_from_context()
+
+        assert claims["project_memberships"] == []
+
+    def test_jwt_path_includes_memberships(self):
+        """JWT token with project_memberships flows into claims."""
+        token = MagicMock()
+        token.claims = {
+            "sub": "alice",
+            "project_memberships": ["jwt-proj-1"],
+        }
+        token.client_id = "alice"
+        token.scopes = ["memory:read"]
+
+        with patch("fastmcp.server.dependencies.get_access_token", return_value=token):
+            claims = get_claims_from_context()
+
+        assert claims["project_memberships"] == ["jwt-proj-1"]
+
+    def test_jwt_path_missing_memberships(self):
+        """JWT token without project_memberships defaults to empty list."""
+        token = MagicMock()
+        token.claims = {"sub": "alice"}
+        token.client_id = "alice"
+        token.scopes = ["memory:read"]
+
+        with patch("fastmcp.server.dependencies.get_access_token", return_value=token):
+            claims = get_claims_from_context()
+
+        assert claims["project_memberships"] == []
+
+    def test_header_jwt_includes_memberships(self):
+        """JWT extracted from Authorization header includes memberships."""
+        jwt_claims = {
+            "sub": "alice",
+            "project_memberships": ["header-proj"],
+        }
+        with (
+            patch("fastmcp.server.dependencies.get_access_token", return_value=None),
+            patch(
+                "src.core.authz._extract_jwt_from_headers",
+                return_value=jwt_claims,
+            ),
+        ):
+            claims = get_claims_from_context()
+
+        assert claims["project_memberships"] == ["header-proj"]
+
+
+# -- authorize_read/write with project memberships -------------------------
+
+
+class TestAuthorizeWithMemberships:
+    """authorize_read/write project checks work with membership-aware claims."""
+
+    def test_read_project_member_allowed(self):
+        """Member of the project can read its memories."""
+        memory = SimpleNamespace(
+            scope="project",
+            owner_id="alice",
+            scope_id="proj-1",
+            tenant_id="default",
+        )
+        claims = {
+            "sub": "alice",
+            "scopes": ["memory:read"],
+            "project_memberships": ["proj-1", "proj-2"],
+        }
+        assert authorize_read(claims, memory, project_ids={"proj-1", "proj-2"}) is True
+
+    def test_read_project_non_member_denied(self):
+        """Non-member cannot read project memories."""
+        memory = SimpleNamespace(
+            scope="project",
+            owner_id="alice",
+            scope_id="proj-secret",
+            tenant_id="default",
+        )
+        claims = {
+            "sub": "alice",
+            "scopes": ["memory:read"],
+            "project_memberships": ["proj-1"],
+        }
+        assert authorize_read(claims, memory, project_ids={"proj-1"}) is False
+
+    def test_write_project_member_allowed(self):
+        """Member can write to their project."""
+        claims = {
+            "sub": "alice",
+            "scopes": ["memory:write"],
+            "project_memberships": ["proj-1"],
+        }
+        assert authorize_write(
+            claims, "project", "alice", "default",
+            project_ids={"proj-1"}, scope_id="proj-1",
+        ) is True
+
+    def test_write_project_non_member_denied(self):
+        """Non-member cannot write to a project."""
+        claims = {
+            "sub": "alice",
+            "scopes": ["memory:write"],
+            "project_memberships": ["proj-1"],
+        }
+        assert authorize_write(
+            claims, "project", "alice", "default",
+            project_ids={"proj-1"}, scope_id="proj-other",
+        ) is False
+
+
+# -- End-to-end: claims -> build_authorized_scopes --------------------------
+
+
+class TestClaimsToBuildAuthorizedScopes:
+    """Integration: session claims flow through to build_authorized_scopes."""
+
+    def test_session_with_memberships_produces_scoped_project(self):
+        """Session user with memberships -> claims -> authorized_scopes with project list."""
+        user = {
+            "user_id": "alice",
+            "name": "Alice",
+            "scopes": ["user", "project"],
+            "project_memberships": ["my-proj"],
+        }
+        with (
+            patch("fastmcp.server.dependencies.get_access_token", return_value=None),
+            patch("src.core.authz._extract_jwt_from_headers", return_value=None),
+            patch("src.core.authz.get_current_user", return_value=user),
+        ):
+            claims = get_claims_from_context()
+
+        scopes = build_authorized_scopes(claims)
+        assert "project" in scopes
+        assert scopes["project"] == ["my-proj"]
+
+    def test_session_without_memberships_omits_project(self):
+        """Session user without memberships -> claims -> no project tier."""
+        user = {
+            "user_id": "alice",
+            "name": "Alice",
+            "scopes": ["user", "project"],
+            "project_memberships": [],
+        }
+        with (
+            patch("fastmcp.server.dependencies.get_access_token", return_value=None),
+            patch("src.core.authz._extract_jwt_from_headers", return_value=None),
+            patch("src.core.authz.get_current_user", return_value=user),
+        ):
+            claims = get_claims_from_context()
+
+        scopes = build_authorized_scopes(claims)
+        assert "project" not in scopes
+        # But user tier is present
+        assert scopes["user"] == "alice"

--- a/src/memoryhub_core/services/memory.py
+++ b/src/memoryhub_core/services/memory.py
@@ -738,14 +738,22 @@ def _build_search_filters(
                 # memories are visible to this caller.
                 continue
             if scope_name == "project":
-                if project_ids:
+                # Use explicitly-passed project_ids when available (may
+                # be a narrower filter, e.g. single project_id from the
+                # tool parameter). Fall back to the authorized_scopes
+                # value when it carries a list of project IDs from the
+                # claims pipeline (#64).
+                effective_project_ids = project_ids
+                if not effective_project_ids and isinstance(required_owner, list):
+                    effective_project_ids = set(required_owner)
+                if effective_project_ids:
                     scope_conditions.append(
                         and_(
                             MemoryNode.scope == "project",
-                            MemoryNode.scope_id.in_(project_ids),
+                            MemoryNode.scope_id.in_(effective_project_ids),
                         )
                     )
-                # If project_ids is empty/None, skip — no project
+                # If no project IDs from either source, skip — no project
                 # memories are visible to this caller.
                 continue
             if scope_name == "role":


### PR DESCRIPTION
## Summary

Completes the project-scope membership enforcement by wiring the existing infrastructure (ProjectMembership model, service layer, authorize_read/write checks) into the claims pipeline and search filters.

Previously, project membership checks existed in authz but the claims dict never carried `project_memberships`, so the checks always received empty/None project_ids. Now the full pipeline works: ConfigMap bootstrap -> DB merge at registration -> claims -> build_authorized_scopes -> search filter.

Closes #64.

## Changes

- **ConfigMap**: Added `project_memberships` field to user records (static bootstrap)
- **Claims pipeline**: All three claims resolution paths (JWT, header JWT, session fallback) now extract `project_memberships`
- **register_session**: New `_resolve_project_memberships()` helper merges ConfigMap-declared + DB-enrolled memberships at registration. Included in response so agents know their project access.
- **build_authorized_scopes**: Project tier now carries the membership list instead of None. Empty membership omits the tier (fail-closed).
- **Search/list tools**: Use claims-based memberships as primary source, eliminating per-call DB round-trip. DB fallback preserved for sessions without claims.
- **_build_search_filters**: Falls back to authorized_scopes project list when explicit project_ids not passed.

## Test plan

- [x] 19 new tests pass covering full claims pipeline (build_authorized_scopes with memberships, claims extraction from all 3 paths, authorize read/write with memberships, end-to-end session-to-scopes)
- [x] Existing authz tests pass (1 updated for new build_authorized_scopes behavior)
- [x] No regressions