### PR TITLE
admin: Add content moderation with status column, quarantine, and hard delete

### DIFF
--- a/alembic/versions/023_add_memory_status.py
+++ b/alembic/versions/023_add_memory_status.py
@@ -1,0 +1,42 @@
+"""Add status column to memory_nodes.
+
+Supports the content moderation workflow (issue #45). Memories carry a
+status field governing visibility: 'active' (default), 'quarantined'
+(hidden from non-admin queries), or 'soft_deleted' (pending GC).
+Existing rows default to 'active' so this migration is non-destructive.
+
+Revision ID: 023_add_memory_status
+Revises: 022_add_relevant_until
+Create Date: 2026-06-30
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "023_add_memory_status"
+down_revision = "022_add_relevant_until"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "memory_nodes",
+        sa.Column(
+            "status",
+            sa.String(20),
+            nullable=False,
+            server_default="active",
+        ),
+    )
+    op.create_index(
+        "ix_memory_nodes_status",
+        "memory_nodes",
+        ["status"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_memory_nodes_status", "memory_nodes")
+    op.drop_column("memory_nodes", "status")

--- a/memory-hub-mcp/src/main.py
+++ b/memory-hub-mcp/src/main.py
@@ -26,6 +26,7 @@ import os
 
 from fastmcp import FastMCP
 
+from src.tools.admin_memory import admin_memory
 from src.tools.delete_memory import delete_memory
 from src.tools.list_memory import list_memory
 from src.tools.manage_curation import manage_curation
@@ -92,13 +93,13 @@ _INSTRUCTIONS_MINIMAL = (
 
 # ── Profile-specific tool sets ─────────────────────────────────────────────
 
-_TOOLS_COMPACT = [register_session, memory, thread]
+_TOOLS_COMPACT = [register_session, memory, admin_memory, thread]
 
 _TOOLS_FULL = [
     register_session, write_memory, read_memory, update_memory,
     delete_memory, search_memory, list_memory,
     manage_session, manage_graph, manage_curation, manage_project,
-    thread,
+    admin_memory, thread,
 ]
 
 _TOOLS_MINIMAL = [register_session, search_memory, write_memory, read_memory, thread]

--- a/memory-hub-mcp/src/tools/admin_memory.py
+++ b/memory-hub-mcp/src/tools/admin_memory.py
@@ -1,0 +1,368 @@
+"""Admin content moderation tool (issue #45).
+
+Action-dispatch tool for admin operations: search, quarantine, restore,
+and hard_delete. All actions require memory:admin scope. Cross-tenant
+search additionally requires memory:admin:cross_tenant.
+"""
+
+import logging
+import uuid as uuid_module
+from typing import Annotated, Any
+
+from fastmcp import Context
+from fastmcp.exceptions import ToolError
+from pydantic import Field
+
+from src.core.app import mcp
+from src.core.audit import record_event
+
+logger = logging.getLogger(__name__)
+
+_VALID_ACTIONS = frozenset({"search", "quarantine", "restore", "hard_delete"})
+
+_SEARCH_OPTS = frozenset({
+    "regex", "cross_tenant", "scope_filter", "max_results",
+    "include_statuses",
+})
+_QUARANTINE_OPTS = frozenset({"reason", "incident_reference"})
+_RESTORE_OPTS = frozenset({"reason"})
+_HARD_DELETE_OPTS = frozenset({
+    "reason", "incident_reference", "sanitized_audit",
+})
+
+
+def _check_admin_scope(scopes: list[str]) -> None:
+    """Verify the caller has memory:admin scope."""
+    if "memory:admin" not in scopes:
+        raise ToolError(
+            "Forbidden: admin_memory requires 'memory:admin' scope. "
+            "Your current scopes do not include admin access."
+        )
+
+
+@mcp.tool(
+    annotations={
+        "readOnlyHint": False,
+        "destructiveHint": True,
+        "idempotentHint": False,
+        "openWorldHint": False,
+    }
+)
+async def admin_memory(
+    action: Annotated[
+        str,
+        Field(description=(
+            "Admin action: search, quarantine, restore, hard_delete"
+        )),
+    ],
+    memory_id: Annotated[
+        str | None,
+        Field(description=(
+            "Memory UUID (required for quarantine/restore/hard_delete)"
+        )),
+    ] = None,
+    query: Annotated[
+        str | None,
+        Field(description="Search query (required for search)"),
+    ] = None,
+    options: Annotated[
+        dict[str, Any] | None,
+        Field(description=(
+            "Action-specific options. "
+            "search: regex, cross_tenant, scope_filter, max_results, include_statuses. "
+            "quarantine: reason (required), incident_reference. "
+            "restore: reason (required). "
+            "hard_delete: reason (required), incident_reference, sanitized_audit."
+        )),
+    ] = None,
+    ctx: Context = None,
+) -> dict[str, Any]:
+    """Admin content moderation operations. Requires memory:admin scope.
+
+    Actions:
+      search(query, [options: regex, cross_tenant, scope_filter, max_results, include_statuses])
+        Cross-owner search ignoring ownership boundaries within a tenant.
+        Combines semantic similarity with optional regex matching.
+        Results are NOT persisted (spill response safety).
+
+      quarantine(memory_id, options: {reason}, [options: incident_reference])
+        Hide memory from all non-admin queries immediately. Content and
+        embeddings are preserved for admin review.
+
+      restore(memory_id, options: {reason})
+        Restore a quarantined memory to active status.
+
+      hard_delete(memory_id, options: {reason}, [options: incident_reference, sanitized_audit])
+        Physically remove memory from database. IRREVERSIBLE.
+        Set sanitized_audit=true for classified data spill response --
+        audit entry will contain only a SHA-256 content hash, no content.
+    """
+    if action not in _VALID_ACTIONS:
+        raise ToolError(
+            f"Invalid admin action '{action}'. Must be one of: "
+            f"{', '.join(sorted(_VALID_ACTIONS))}."
+        )
+
+    # Resolve identity
+    from src.core.authz import get_claims_from_context, get_tenant_filter
+
+    claims = get_claims_from_context()
+    scopes = claims.get("scopes", [])
+    _check_admin_scope(scopes)
+
+    tenant_id = get_tenant_filter(claims)
+    actor_id = claims["sub"]
+    opts = options or {}
+
+    if action == "search":
+        return await _dispatch_search(
+            query, tenant_id, actor_id, scopes, opts,
+        )
+    if action == "quarantine":
+        return await _dispatch_quarantine(
+            memory_id, tenant_id, actor_id, opts,
+        )
+    if action == "restore":
+        return await _dispatch_restore(
+            memory_id, tenant_id, actor_id, opts,
+        )
+    # hard_delete
+    return await _dispatch_hard_delete(
+        memory_id, tenant_id, actor_id, scopes, opts,
+    )
+
+
+async def _dispatch_search(
+    query: str | None,
+    tenant_id: str,
+    actor_id: str,
+    scopes: list[str],
+    opts: dict,
+) -> dict:
+    """Dispatch admin search."""
+    from memoryhub_core.services.admin import search_memory_admin
+    from src.tools._deps import get_db_session, get_embedding_service, release_db_session
+
+    if not query or (isinstance(query, str) and not query.strip()):
+        raise ToolError(
+            "action='search' requires 'query'. "
+            "Example: admin_memory(action='search', query='API key')"
+        )
+
+    cross_tenant = opts.get("cross_tenant", False)
+    if cross_tenant and "memory:admin:cross_tenant" not in scopes:
+        raise ToolError(
+            "Forbidden: cross-tenant admin search requires "
+            "'memory:admin:cross_tenant' scope."
+        )
+
+    session, gen = await get_db_session()
+    try:
+        embedding_service = get_embedding_service()
+
+        kwargs: dict = {
+            "query": query,
+            "tenant_id": tenant_id,
+            "actor_id": actor_id,
+        }
+        if "regex" in opts:
+            kwargs["regex"] = opts["regex"]
+        if cross_tenant:
+            kwargs["cross_tenant"] = True
+        if "scope_filter" in opts:
+            kwargs["scope_filter"] = opts["scope_filter"]
+        if "max_results" in opts:
+            kwargs["max_results"] = int(opts["max_results"])
+        if "include_statuses" in opts:
+            kwargs["include_statuses"] = opts["include_statuses"]
+
+        try:
+            results = await search_memory_admin(
+                session, embedding_service, **kwargs,
+            )
+        except ValueError as e:
+            raise ToolError(str(e)) from e
+
+        return {
+            "results": results,
+            "total": len(results),
+            "query": query,
+            "regex": opts.get("regex"),
+        }
+    finally:
+        await release_db_session(gen)
+
+
+async def _dispatch_quarantine(
+    memory_id: str | None,
+    tenant_id: str,
+    actor_id: str,
+    opts: dict,
+) -> dict:
+    """Dispatch quarantine operation."""
+    from memoryhub_core.services.admin import quarantine_memory
+    from src.tools._deps import get_db_session, release_db_session
+
+    if not memory_id:
+        raise ToolError(
+            "action='quarantine' requires 'memory_id'. "
+            "Example: admin_memory(action='quarantine', memory_id='...')"
+        )
+    reason = opts.get("reason")
+    if not reason or (isinstance(reason, str) and not reason.strip()):
+        raise ToolError(
+            "action='quarantine' requires 'reason' in options. "
+            "Example: admin_memory(action='quarantine', memory_id='...', "
+            "options={'reason': 'Suspected PII leak'})"
+        )
+
+    session, gen = await get_db_session()
+    try:
+        result = await quarantine_memory(
+            session,
+            memory_id=uuid_module.UUID(memory_id),
+            tenant_id=tenant_id,
+            actor_id=actor_id,
+            reason=reason,
+            incident_reference=opts.get("incident_reference"),
+        )
+
+        # MCP-layer audit
+        record_event(
+            event_type="admin.quarantine",
+            actor_id=actor_id,
+            driver_id=actor_id,
+            scope="admin",
+            owner_id=actor_id,
+            memory_id=memory_id,
+            decision="allowed",
+            metadata={"reason": reason},
+        )
+
+        return result
+    except Exception as e:
+        if "not found" in str(e).lower():
+            raise ToolError(f"Memory {memory_id} not found") from e
+        raise
+    finally:
+        await release_db_session(gen)
+
+
+async def _dispatch_restore(
+    memory_id: str | None,
+    tenant_id: str,
+    actor_id: str,
+    opts: dict,
+) -> dict:
+    """Dispatch restore operation."""
+    from memoryhub_core.services.admin import restore_memory
+    from src.tools._deps import get_db_session, release_db_session
+
+    if not memory_id:
+        raise ToolError(
+            "action='restore' requires 'memory_id'. "
+            "Example: admin_memory(action='restore', memory_id='...')"
+        )
+    reason = opts.get("reason")
+    if not reason or (isinstance(reason, str) and not reason.strip()):
+        raise ToolError(
+            "action='restore' requires 'reason' in options. "
+            "Example: admin_memory(action='restore', memory_id='...', "
+            "options={'reason': 'Content reviewed, no issues found'})"
+        )
+
+    session, gen = await get_db_session()
+    try:
+        result = await restore_memory(
+            session,
+            memory_id=uuid_module.UUID(memory_id),
+            tenant_id=tenant_id,
+            actor_id=actor_id,
+            reason=reason,
+        )
+
+        record_event(
+            event_type="admin.restore",
+            actor_id=actor_id,
+            driver_id=actor_id,
+            scope="admin",
+            owner_id=actor_id,
+            memory_id=memory_id,
+            decision="allowed",
+            metadata={"reason": reason},
+        )
+
+        return result
+    except Exception as e:
+        if "not found" in str(e).lower():
+            raise ToolError(f"Memory {memory_id} not found") from e
+        raise
+    finally:
+        await release_db_session(gen)
+
+
+async def _dispatch_hard_delete(
+    memory_id: str | None,
+    tenant_id: str,
+    actor_id: str,
+    scopes: list[str],
+    opts: dict,
+) -> dict:
+    """Dispatch hard delete operation."""
+    from memoryhub_core.services.admin import hard_delete_memory
+    from src.tools._deps import get_db_session, release_db_session
+
+    if not memory_id:
+        raise ToolError(
+            "action='hard_delete' requires 'memory_id'. "
+            "Example: admin_memory(action='hard_delete', memory_id='...')"
+        )
+    reason = opts.get("reason")
+    if not reason or (isinstance(reason, str) and not reason.strip()):
+        raise ToolError(
+            "action='hard_delete' requires 'reason' in options. "
+            "Example: admin_memory(action='hard_delete', memory_id='...', "
+            "options={'reason': 'Classified data spill cleanup'})"
+        )
+
+    sanitized = opts.get("sanitized_audit", False)
+    if sanitized and "memory:admin:sanitized_audit" not in scopes:
+        raise ToolError(
+            "Forbidden: sanitized_audit mode requires "
+            "'memory:admin:sanitized_audit' scope."
+        )
+
+    session, gen = await get_db_session()
+    try:
+        result = await hard_delete_memory(
+            session,
+            memory_id=uuid_module.UUID(memory_id),
+            tenant_id=tenant_id,
+            actor_id=actor_id,
+            reason=reason,
+            incident_reference=opts.get("incident_reference"),
+            sanitized_audit=sanitized,
+        )
+
+        record_event(
+            event_type="admin.hard_delete",
+            actor_id=actor_id,
+            driver_id=actor_id,
+            scope="admin",
+            owner_id=actor_id,
+            memory_id=memory_id,
+            decision="allowed",
+            metadata={
+                "reason": reason,
+                "sanitized_audit": sanitized,
+                "versions_deleted": result.get("versions_deleted", 0),
+            },
+        )
+
+        return result
+    except Exception as e:
+        if "not found" in str(e).lower():
+            raise ToolError(f"Memory {memory_id} not found") from e
+        raise
+    finally:
+        await release_db_session(gen)

--- a/memory-hub-mcp/tests/test_admin_memory.py
+++ b/memory-hub-mcp/tests/test_admin_memory.py
@@ -1,0 +1,310 @@
+"""Tests for the admin_memory MCP tool (issue #45).
+
+Tests action dispatch routing, parameter validation, and authorization
+checks. Underlying service functions are patched to isolate the tool layer.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastmcp.exceptions import ToolError
+
+from src.tools.admin_memory import (
+    _VALID_ACTIONS,
+    _check_admin_scope,
+    admin_memory,
+)
+
+
+# ── Authorization tests ──────────────────────────────────────────────────
+
+
+class TestAdminScopeCheck:
+    def test_check_admin_scope_passes(self):
+        _check_admin_scope(["memory:admin", "memory:read"])
+
+    def test_check_admin_scope_fails(self):
+        with pytest.raises(ToolError, match="memory:admin"):
+            _check_admin_scope(["memory:read", "memory:write"])
+
+    def test_check_admin_scope_empty(self):
+        with pytest.raises(ToolError, match="memory:admin"):
+            _check_admin_scope([])
+
+
+# ── Action validation ─────────────────────────────────────────────────────
+
+
+class TestActionValidation:
+    @pytest.mark.asyncio
+    async def test_invalid_action_raises(self):
+        with patch(
+            "src.core.authz.get_claims_from_context",
+            return_value={
+                "sub": "admin-1",
+                "tenant_id": "default",
+                "scopes": ["memory:admin"],
+            },
+        ):
+            with pytest.raises(ToolError, match="Invalid admin action"):
+                await admin_memory(action="bogus")
+
+    @pytest.mark.asyncio
+    async def test_invalid_action_lists_valid(self):
+        with patch(
+            "src.core.authz.get_claims_from_context",
+            return_value={
+                "sub": "admin-1",
+                "tenant_id": "default",
+                "scopes": ["memory:admin"],
+            },
+        ):
+            with pytest.raises(ToolError) as exc_info:
+                await admin_memory(action="not_real")
+            msg = str(exc_info.value)
+            assert "search" in msg
+            assert "quarantine" in msg
+
+    def test_valid_actions_count(self):
+        assert len(_VALID_ACTIONS) == 4
+
+
+# ── Required parameter validation ────────────────────────────────────────
+
+
+class TestRequiredParams:
+    def _admin_claims(self, extra_scopes=None):
+        scopes = ["memory:admin"]
+        if extra_scopes:
+            scopes.extend(extra_scopes)
+        return {
+            "sub": "admin-1",
+            "tenant_id": "default",
+            "scopes": scopes,
+        }
+
+    @pytest.mark.asyncio
+    async def test_search_requires_query(self):
+        with patch(
+            "src.core.authz.get_claims_from_context",
+            return_value=self._admin_claims(),
+        ):
+            with pytest.raises(ToolError, match="requires 'query'"):
+                await admin_memory(action="search")
+
+    @pytest.mark.asyncio
+    async def test_quarantine_requires_memory_id(self):
+        with patch(
+            "src.core.authz.get_claims_from_context",
+            return_value=self._admin_claims(),
+        ):
+            with pytest.raises(ToolError, match="requires 'memory_id'"):
+                await admin_memory(
+                    action="quarantine",
+                    options={"reason": "test"},
+                )
+
+    @pytest.mark.asyncio
+    async def test_quarantine_requires_reason(self):
+        with patch(
+            "src.core.authz.get_claims_from_context",
+            return_value=self._admin_claims(),
+        ):
+            with pytest.raises(ToolError, match="requires 'reason'"):
+                await admin_memory(
+                    action="quarantine",
+                    memory_id="abc-123",
+                )
+
+    @pytest.mark.asyncio
+    async def test_restore_requires_memory_id(self):
+        with patch(
+            "src.core.authz.get_claims_from_context",
+            return_value=self._admin_claims(),
+        ):
+            with pytest.raises(ToolError, match="requires 'memory_id'"):
+                await admin_memory(
+                    action="restore",
+                    options={"reason": "test"},
+                )
+
+    @pytest.mark.asyncio
+    async def test_restore_requires_reason(self):
+        with patch(
+            "src.core.authz.get_claims_from_context",
+            return_value=self._admin_claims(),
+        ):
+            with pytest.raises(ToolError, match="requires 'reason'"):
+                await admin_memory(
+                    action="restore",
+                    memory_id="abc-123",
+                )
+
+    @pytest.mark.asyncio
+    async def test_hard_delete_requires_memory_id(self):
+        with patch(
+            "src.core.authz.get_claims_from_context",
+            return_value=self._admin_claims(),
+        ):
+            with pytest.raises(ToolError, match="requires 'memory_id'"):
+                await admin_memory(
+                    action="hard_delete",
+                    options={"reason": "test"},
+                )
+
+    @pytest.mark.asyncio
+    async def test_hard_delete_requires_reason(self):
+        with patch(
+            "src.core.authz.get_claims_from_context",
+            return_value=self._admin_claims(),
+        ):
+            with pytest.raises(ToolError, match="requires 'reason'"):
+                await admin_memory(
+                    action="hard_delete",
+                    memory_id="abc-123",
+                )
+
+
+# ── Scope enforcement ────────────────────────────────────────────────────
+
+
+class TestScopeEnforcement:
+    @pytest.mark.asyncio
+    async def test_no_admin_scope_rejected(self):
+        with patch(
+            "src.core.authz.get_claims_from_context",
+            return_value={
+                "sub": "user-1",
+                "tenant_id": "default",
+                "scopes": ["memory:read", "memory:write"],
+            },
+        ):
+            with pytest.raises(ToolError, match="memory:admin"):
+                await admin_memory(action="search", query="test")
+
+    @pytest.mark.asyncio
+    async def test_cross_tenant_requires_extra_scope(self):
+        with patch(
+            "src.core.authz.get_claims_from_context",
+            return_value={
+                "sub": "admin-1",
+                "tenant_id": "default",
+                "scopes": ["memory:admin"],
+            },
+        ):
+            with pytest.raises(ToolError, match="cross_tenant"):
+                await admin_memory(
+                    action="search",
+                    query="test",
+                    options={"cross_tenant": True},
+                )
+
+    @pytest.mark.asyncio
+    async def test_sanitized_audit_requires_extra_scope(self):
+        with patch(
+            "src.core.authz.get_claims_from_context",
+            return_value={
+                "sub": "admin-1",
+                "tenant_id": "default",
+                "scopes": ["memory:admin"],
+            },
+        ):
+            with pytest.raises(ToolError, match="sanitized_audit"):
+                await admin_memory(
+                    action="hard_delete",
+                    memory_id="abc-123",
+                    options={
+                        "reason": "test",
+                        "sanitized_audit": True,
+                    },
+                )
+
+
+# ── Dispatch routing ─────────────────────────────────────────────────────
+
+
+class TestDispatchRouting:
+    def _admin_claims(self, extra_scopes=None):
+        scopes = ["memory:admin"]
+        if extra_scopes:
+            scopes.extend(extra_scopes)
+        return {
+            "sub": "admin-1",
+            "tenant_id": "default",
+            "scopes": scopes,
+        }
+
+    @pytest.mark.asyncio
+    async def test_search_dispatches_to_service(self):
+        mock_search = AsyncMock(return_value=[{"id": "test"}])
+
+        with (
+            patch(
+                "src.core.authz.get_claims_from_context",
+                return_value=self._admin_claims(),
+            ),
+            patch(
+                "memoryhub_core.services.admin.search_memory_admin",
+                mock_search,
+            ),
+            patch(
+                "src.tools._deps.get_db_session",
+                new_callable=AsyncMock,
+                return_value=("mock_session", "mock_gen"),
+            ),
+            patch(
+                "src.tools._deps.get_embedding_service",
+                return_value="mock_emb",
+            ),
+            patch(
+                "src.tools._deps.release_db_session",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await admin_memory(action="search", query="API key")
+
+        assert result["total"] == 1
+        mock_search.assert_called_once()
+        call_kwargs = mock_search.call_args
+        assert call_kwargs[1]["query"] == "API key"
+
+    @pytest.mark.asyncio
+    async def test_quarantine_dispatches_to_service(self):
+        mock_quarantine = AsyncMock(return_value={
+            "memory_id": "abc",
+            "previous_status": "active",
+            "new_status": "quarantined",
+            "reason": "test",
+            "incident_reference": None,
+        })
+
+        with (
+            patch(
+                "src.core.authz.get_claims_from_context",
+                return_value=self._admin_claims(),
+            ),
+            patch(
+                "memoryhub_core.services.admin.quarantine_memory",
+                mock_quarantine,
+            ),
+            patch(
+                "src.tools._deps.get_db_session",
+                new_callable=AsyncMock,
+                return_value=("mock_session", "mock_gen"),
+            ),
+            patch(
+                "src.tools._deps.release_db_session",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "src.core.audit.record_event",
+            ),
+        ):
+            result = await admin_memory(
+                action="quarantine",
+                memory_id="00000000-0000-0000-0000-000000000001",
+                options={"reason": "Suspected PII"},
+            )
+
+        assert result["new_status"] == "quarantined"
+        mock_quarantine.assert_called_once()

--- a/memory-hub-mcp/tests/test_tool_profiles.py
+++ b/memory-hub-mcp/tests/test_tool_profiles.py
@@ -23,11 +23,11 @@ class TestProfileDefinitions:
     def test_three_profiles_defined(self):
         assert {"compact", "full", "minimal"} == _VALID_PROFILES
 
-    def test_compact_has_3_tools(self):
-        assert len(_TOOLS_COMPACT) == 3
+    def test_compact_has_4_tools(self):
+        assert len(_TOOLS_COMPACT) == 4
 
-    def test_full_has_12_tools(self):
-        assert len(_TOOLS_FULL) == 12
+    def test_full_has_13_tools(self):
+        assert len(_TOOLS_FULL) == 13
 
     def test_minimal_has_5_tools(self):
         assert len(_TOOLS_MINIMAL) == 5

--- a/src/memoryhub_core/models/memory.py
+++ b/src/memoryhub_core/models/memory.py
@@ -81,7 +81,7 @@ class MemoryNode(TimestampMixin, Base):
     #   quarantined  - visible only to admin queries
     #   soft_deleted - visible only when explicitly requested
     status: Mapped[str] = mapped_column(
-        String(20), nullable=False, server_default="active", index=True,
+        String(20), nullable=False, server_default="active",
     )
 
     # Content-addressed entity IDs for deduplication (#247)

--- a/src/memoryhub_core/models/memory.py
+++ b/src/memoryhub_core/models/memory.py
@@ -76,6 +76,14 @@ class MemoryNode(TimestampMixin, Base):
     # Content type classification for behavioral memory (#237)
     content_type: Mapped[str] = mapped_column(String(20), nullable=False, default="experiential")
 
+    # Content moderation status (#45). Governs visibility:
+    #   active       - visible to all authorized queries
+    #   quarantined  - visible only to admin queries
+    #   soft_deleted - visible only when explicitly requested
+    status: Mapped[str] = mapped_column(
+        String(20), nullable=False, server_default="active", index=True,
+    )
+
     # Content-addressed entity IDs for deduplication (#247)
     content_hash: Mapped[str | None] = mapped_column(String(64), nullable=True)
 
@@ -144,6 +152,7 @@ class MemoryNode(TimestampMixin, Base):
         # sees the migration-created indexes in the DB but not in the metadata
         # and proposes to drop them on every autogenerate run.
         Index("ix_memory_nodes_deleted_at", "deleted_at"),
+        Index("ix_memory_nodes_status", "status"),
         Index("ix_memory_nodes_scope_id", "scope_id"),
         Index("ix_memory_nodes_domains", "domains", postgresql_using="gin"),
         Index(

--- a/src/memoryhub_core/services/admin.py
+++ b/src/memoryhub_core/services/admin.py
@@ -1,0 +1,403 @@
+"""Admin content moderation operations (issue #45).
+
+Cross-owner search, quarantine, restore, and hard delete for incident
+response workflows. All operations enforce tenant isolation and require
+the caller to have already been verified as an admin (memory:admin scope).
+Authorization is the responsibility of the calling layer (MCP tool or BFF
+route); this module trusts that the caller has been checked.
+
+Audit logging uses the structured JSON pattern from the MCP audit module.
+A future phase will persist to the PostgreSQL audit table.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import re
+import uuid
+from datetime import UTC, datetime
+
+from sqlalchemy import delete, select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from memoryhub_core.models.memory import MemoryNode, MemoryRelationship
+from memoryhub_core.services.exceptions import MemoryNotFoundError
+
+logger = logging.getLogger(__name__)
+audit_logger = logging.getLogger("memoryhub.audit")
+
+
+def _audit_event(
+    operation: str,
+    actor_id: str,
+    tenant_id: str,
+    memory_id: str | None = None,
+    decision: str = "permitted",
+    state_before: dict | None = None,
+    request_context: dict | None = None,
+) -> None:
+    """Emit a structured admin audit event."""
+    event = {
+        "timestamp": datetime.now(UTC).isoformat(),
+        "operation": operation,
+        "actor_id": actor_id,
+        "actor_type": "service",
+        "memory_id": memory_id,
+        "tenant_id": tenant_id,
+        "decision": decision,
+        "state_before": state_before,
+        "request_context": request_context,
+    }
+    audit_logger.info(json.dumps(event, sort_keys=True, default=str))
+
+
+def _memory_to_dict(node: MemoryNode) -> dict:
+    """Serialize a MemoryNode to a dict for search results and audit."""
+    return {
+        "id": str(node.id),
+        "content": node.content,
+        "stub": node.stub,
+        "scope": node.scope,
+        "owner_id": node.owner_id,
+        "tenant_id": node.tenant_id,
+        "status": node.status,
+        "weight": node.weight,
+        "is_current": node.is_current,
+        "version": node.version,
+        "created_at": node.created_at.isoformat() if node.created_at else None,
+        "content_type": node.content_type,
+        "domains": node.domains,
+    }
+
+
+async def search_memory_admin(
+    session: AsyncSession,
+    embedding_service,
+    *,
+    query: str,
+    tenant_id: str,
+    actor_id: str,
+    regex: str | None = None,
+    cross_tenant: bool = False,
+    scope_filter: str | None = None,
+    max_results: int = 50,
+    include_statuses: list[str] | None = None,
+) -> list[dict]:
+    """Cross-owner search combining keyword/regex with semantic similarity.
+
+    Ignores ownership boundaries within a tenant. By default searches
+    active and quarantined memories; pass include_statuses to override.
+
+    Returns results but does NOT persist them (spill response safety).
+    """
+    if include_statuses is None:
+        include_statuses = ["active", "quarantined"]
+
+    # Build base filters
+    filters = [
+        MemoryNode.deleted_at.is_(None),
+        MemoryNode.is_current.is_(True),
+        MemoryNode.status.in_(include_statuses),
+    ]
+
+    if not cross_tenant:
+        filters.append(MemoryNode.tenant_id == tenant_id)
+
+    if scope_filter:
+        filters.append(MemoryNode.scope == scope_filter)
+
+    # Semantic search via pgvector
+    query_embedding = await embedding_service.embed(query)
+    use_pgvector = True
+    try:
+        distance_expr = MemoryNode.embedding.cosine_distance(query_embedding)
+        stmt = (
+            select(MemoryNode, distance_expr.label("distance"))
+            .where(*filters)
+            .order_by(distance_expr)
+            .limit(max_results * 2)  # over-fetch for regex post-filter
+        )
+    except Exception:
+        use_pgvector = False
+        stmt = (
+            select(MemoryNode)
+            .where(*filters)
+            .order_by(MemoryNode.created_at.desc())
+            .limit(max_results * 2)
+        )
+
+    result = await session.execute(stmt)
+
+    if use_pgvector:
+        rows = result.all()
+        candidates = [(row[0], float(row[1])) for row in rows]
+    else:
+        nodes = result.scalars().all()
+        candidates = [(node, 0.5) for node in nodes]
+
+    # Post-filter with regex if provided
+    if regex:
+        try:
+            pattern = re.compile(regex, re.IGNORECASE)
+        except re.error as e:
+            raise ValueError(f"Invalid regex pattern: {e}") from e
+
+        filtered = []
+        for node, dist in candidates:
+            if pattern.search(node.content):
+                filtered.append((node, dist))
+        candidates = filtered
+
+    # Deduplicate and limit
+    seen: set[uuid.UUID] = set()
+    results: list[dict] = []
+    for node, distance in candidates:
+        if node.id in seen:
+            continue
+        seen.add(node.id)
+        entry = _memory_to_dict(node)
+        entry["relevance_score"] = round(max(0.0, 1.0 - distance), 4)
+        results.append(entry)
+        if len(results) >= max_results:
+            break
+
+    # Audit the search (parameters only, not results)
+    _audit_event(
+        operation="admin_search",
+        actor_id=actor_id,
+        tenant_id=tenant_id,
+        request_context={
+            "query": query,
+            "regex": regex,
+            "cross_tenant": cross_tenant,
+            "scope_filter": scope_filter,
+            "result_count": len(results),
+        },
+    )
+
+    return results
+
+
+async def quarantine_memory(
+    session: AsyncSession,
+    *,
+    memory_id: uuid.UUID,
+    tenant_id: str,
+    actor_id: str,
+    reason: str,
+    incident_reference: str | None = None,
+) -> dict:
+    """Set memory status to 'quarantined', hiding from non-admin queries.
+
+    The memory still exists with full content and embeddings intact.
+    Raises MemoryNotFoundError if the memory doesn't exist in this tenant.
+    """
+    stmt = select(MemoryNode).where(
+        MemoryNode.id == memory_id,
+        MemoryNode.deleted_at.is_(None),
+        MemoryNode.tenant_id == tenant_id,
+    )
+    result = await session.execute(stmt)
+    node = result.scalar_one_or_none()
+
+    if node is None:
+        raise MemoryNotFoundError(memory_id)
+
+    previous_status = node.status
+
+    # Audit before mutation
+    _audit_event(
+        operation="quarantine",
+        actor_id=actor_id,
+        tenant_id=tenant_id,
+        memory_id=str(memory_id),
+        state_before={"status": previous_status},
+        request_context={
+            "reason": reason,
+            "incident_reference": incident_reference,
+        },
+    )
+
+    node.status = "quarantined"
+    await session.commit()
+
+    return {
+        "memory_id": str(memory_id),
+        "previous_status": previous_status,
+        "new_status": "quarantined",
+        "reason": reason,
+        "incident_reference": incident_reference,
+    }
+
+
+async def restore_memory(
+    session: AsyncSession,
+    *,
+    memory_id: uuid.UUID,
+    tenant_id: str,
+    actor_id: str,
+    reason: str,
+) -> dict:
+    """Restore a quarantined memory to active status.
+
+    Raises MemoryNotFoundError if the memory doesn't exist in this tenant.
+    """
+    stmt = select(MemoryNode).where(
+        MemoryNode.id == memory_id,
+        MemoryNode.deleted_at.is_(None),
+        MemoryNode.tenant_id == tenant_id,
+    )
+    result = await session.execute(stmt)
+    node = result.scalar_one_or_none()
+
+    if node is None:
+        raise MemoryNotFoundError(memory_id)
+
+    if node.status != "quarantined":
+        return {
+            "memory_id": str(memory_id),
+            "error": f"Cannot restore: memory status is '{node.status}', not 'quarantined'",
+            "current_status": node.status,
+        }
+
+    # Audit before mutation
+    _audit_event(
+        operation="restore",
+        actor_id=actor_id,
+        tenant_id=tenant_id,
+        memory_id=str(memory_id),
+        state_before={"status": node.status},
+        request_context={"reason": reason},
+    )
+
+    node.status = "active"
+    await session.commit()
+
+    return {
+        "memory_id": str(memory_id),
+        "previous_status": "quarantined",
+        "new_status": "active",
+        "reason": reason,
+    }
+
+
+async def hard_delete_memory(
+    session: AsyncSession,
+    *,
+    memory_id: uuid.UUID,
+    tenant_id: str,
+    actor_id: str,
+    reason: str,
+    incident_reference: str | None = None,
+    sanitized_audit: bool = False,
+) -> dict:
+    """Physically remove a memory row from the database.
+
+    This is irreversible. The deletion cascades to relationships and
+    contradiction reports via FK ON DELETE CASCADE.
+
+    When sanitized_audit=True, the audit entry contains only the memory
+    ID and a SHA-256 content hash -- no content, no metadata. Use for
+    classified data spill response.
+
+    Raises MemoryNotFoundError if the memory doesn't exist in this tenant.
+    """
+    stmt = select(MemoryNode).where(
+        MemoryNode.id == memory_id,
+        MemoryNode.tenant_id == tenant_id,
+    )
+    result = await session.execute(stmt)
+    node = result.scalar_one_or_none()
+
+    if node is None:
+        raise MemoryNotFoundError(memory_id)
+
+    # Build audit entry BEFORE delete
+    if sanitized_audit:
+        content_hash = hashlib.sha256(
+            node.content.encode("utf-8")
+        ).hexdigest()
+        state_before = None
+        request_context = {
+            "sanitized_audit": True,
+            "content_hash": f"sha256:{content_hash}",
+            "reason": reason,
+            "incident_reference": incident_reference,
+        }
+    else:
+        state_before = _memory_to_dict(node)
+        request_context = {
+            "reason": reason,
+            "incident_reference": incident_reference,
+        }
+
+    _audit_event(
+        operation="hard_delete",
+        actor_id=actor_id,
+        tenant_id=tenant_id,
+        memory_id=str(memory_id),
+        state_before=state_before,
+        request_context=request_context,
+    )
+
+    # Delete relationships where this memory is source or target.
+    # These have ON DELETE CASCADE on the FK, but we do it explicitly
+    # to be safe across database configurations.
+    await session.execute(
+        delete(MemoryRelationship).where(
+            (MemoryRelationship.source_id == memory_id)
+            | (MemoryRelationship.target_id == memory_id)
+        )
+    )
+
+    # Delete child branches (chunks, rationale, etc.)
+    await session.execute(
+        delete(MemoryNode).where(MemoryNode.parent_id == memory_id)
+    )
+
+    # Delete version chain predecessors if they exist
+    # Walk backward to find and delete old versions
+    version_ids = [memory_id]
+    current = node
+    while current.previous_version_id is not None:
+        version_ids.append(current.previous_version_id)
+        prev_stmt = select(MemoryNode).where(
+            MemoryNode.id == current.previous_version_id
+        )
+        prev_result = await session.execute(prev_stmt)
+        current = prev_result.scalar_one_or_none()
+        if current is None:
+            break
+
+    # Delete children of all versions in the chain
+    if len(version_ids) > 1:
+        await session.execute(
+            delete(MemoryNode).where(
+                MemoryNode.parent_id.in_(version_ids),
+                MemoryNode.id.notin_(version_ids),
+            )
+        )
+        # Delete relationships for all versions
+        await session.execute(
+            delete(MemoryRelationship).where(
+                (MemoryRelationship.source_id.in_(version_ids))
+                | (MemoryRelationship.target_id.in_(version_ids))
+            )
+        )
+
+    # Delete the memory node(s) themselves
+    await session.execute(
+        delete(MemoryNode).where(MemoryNode.id.in_(version_ids))
+    )
+
+    await session.commit()
+
+    return {
+        "memory_id": str(memory_id),
+        "versions_deleted": len(version_ids),
+        "reason": reason,
+        "incident_reference": incident_reference,
+        "sanitized_audit": sanitized_audit,
+    }

--- a/src/memoryhub_core/services/curation/similarity.py
+++ b/src/memoryhub_core/services/curation/similarity.py
@@ -53,6 +53,7 @@ async def check_similarity(
         MemoryNode.tenant_id == tenant_id,
         MemoryNode.is_current.is_(True),
         MemoryNode.deleted_at.is_(None),
+        MemoryNode.status == "active",
         MemoryNode.embedding.isnot(None),
     ]
     if exclude_id is not None:
@@ -116,6 +117,7 @@ async def get_similar_memories(
     source_stmt = select(MemoryNode).where(
         MemoryNode.id == memory_id,
         MemoryNode.deleted_at.is_(None),
+        MemoryNode.status == "active",
         MemoryNode.tenant_id == tenant_id,
     )
     source_result = await session.execute(source_stmt)
@@ -138,6 +140,7 @@ async def get_similar_memories(
         MemoryNode.tenant_id == tenant_id,
         MemoryNode.is_current.is_(True),
         MemoryNode.deleted_at.is_(None),
+        MemoryNode.status == "active",
         MemoryNode.embedding.isnot(None),
         MemoryNode.id != memory_id,
         distance_expr <= max_distance,

--- a/src/memoryhub_core/services/memory.py
+++ b/src/memoryhub_core/services/memory.py
@@ -339,14 +339,18 @@ async def read_memory(
         MemoryNode.id == memory_id,
         MemoryNode.deleted_at.is_(None),
         MemoryNode.tenant_id == tenant_id,
+        # Non-admin read: only active memories are visible.
+        # Quarantined and soft_deleted require admin_memory tool.
+        MemoryNode.status == "active",
     )
     result = await session.execute(stmt)
     node = result.scalar_one_or_none()
 
     if node is None:
-        # Cross-tenant hits land here indistinguishably from nonexistent
-        # rows. Do NOT log the mismatch at WARNING or higher -- anything
-        # above debug leaks existence through log aggregation.
+        # Cross-tenant hits, quarantined, and soft_deleted all land here
+        # indistinguishably from nonexistent rows. Do NOT log the mismatch
+        # at WARNING or higher -- anything above debug leaks existence
+        # through log aggregation.
         raise MemoryNotFoundError(memory_id)
 
     has_children, has_rationale, branch_count = await _compute_branch_flags(node, session)
@@ -692,6 +696,7 @@ def _build_search_filters(
     entity_names: list[str] | None = None,
     content_type: str | None = None,
     temporal_status: str | None = None,
+    include_statuses: list[str] | None = None,
 ) -> list | None:
     """Build the SQL filter list shared by search_memories and count_search_matches.
 
@@ -707,6 +712,13 @@ def _build_search_filters(
         MemoryNode.deleted_at.is_(None),
         MemoryNode.tenant_id == tenant_id,
     ]
+    # Status filter: default to active-only so quarantined and
+    # soft_deleted memories are invisible to regular queries.
+    # Admin callers pass include_statuses to widen visibility.
+    if include_statuses:
+        filters.append(MemoryNode.status.in_(include_statuses))
+    else:
+        filters.append(MemoryNode.status == "active")
     if current_only:
         filters.append(MemoryNode.is_current.is_(True))
     if scope is not None:

--- a/tests/test_services/test_admin.py
+++ b/tests/test_services/test_admin.py
@@ -1,0 +1,363 @@
+"""Tests for admin content moderation service operations (issue #45)."""
+
+import uuid
+from datetime import UTC, datetime
+
+import pytest
+
+from memoryhub_core.models.memory import MemoryNode
+from memoryhub_core.services.admin import (
+    hard_delete_memory,
+    quarantine_memory,
+    restore_memory,
+    search_memory_admin,
+)
+from memoryhub_core.services.exceptions import MemoryNotFoundError
+
+
+TENANT = "test-tenant"
+ACTOR = "admin-agent-01"
+
+
+def _make_memory(
+    *,
+    content: str = "test memory content",
+    owner_id: str = "user-1",
+    scope: str = "user",
+    tenant_id: str = TENANT,
+    status: str = "active",
+    weight: float = 0.8,
+) -> MemoryNode:
+    now = datetime.now(UTC)
+    return MemoryNode(
+        id=uuid.uuid4(),
+        content=content,
+        stub=content[:50],
+        scope=scope,
+        owner_id=owner_id,
+        tenant_id=tenant_id,
+        status=status,
+        weight=weight,
+        is_current=True,
+        version=1,
+        storage_type="inline",
+        created_at=now,
+        updated_at=now,
+    )
+
+
+class TestQuarantineMemory:
+    @pytest.mark.asyncio
+    async def test_quarantine_sets_status(self, async_session):
+        node = _make_memory()
+        async_session.add(node)
+        await async_session.commit()
+
+        result = await quarantine_memory(
+            async_session,
+            memory_id=node.id,
+            tenant_id=TENANT,
+            actor_id=ACTOR,
+            reason="Suspected PII",
+        )
+
+        assert result["new_status"] == "quarantined"
+        assert result["previous_status"] == "active"
+        assert result["reason"] == "Suspected PII"
+
+        # Verify in DB
+        await async_session.refresh(node)
+        assert node.status == "quarantined"
+
+    @pytest.mark.asyncio
+    async def test_quarantine_with_incident_reference(self, async_session):
+        node = _make_memory()
+        async_session.add(node)
+        await async_session.commit()
+
+        result = await quarantine_memory(
+            async_session,
+            memory_id=node.id,
+            tenant_id=TENANT,
+            actor_id=ACTOR,
+            reason="Data spill",
+            incident_reference="INC-2026-0042",
+        )
+
+        assert result["incident_reference"] == "INC-2026-0042"
+
+    @pytest.mark.asyncio
+    async def test_quarantine_nonexistent_raises(self, async_session):
+        with pytest.raises(MemoryNotFoundError):
+            await quarantine_memory(
+                async_session,
+                memory_id=uuid.uuid4(),
+                tenant_id=TENANT,
+                actor_id=ACTOR,
+                reason="test",
+            )
+
+    @pytest.mark.asyncio
+    async def test_quarantine_wrong_tenant_raises(self, async_session):
+        node = _make_memory(tenant_id="other-tenant")
+        async_session.add(node)
+        await async_session.commit()
+
+        with pytest.raises(MemoryNotFoundError):
+            await quarantine_memory(
+                async_session,
+                memory_id=node.id,
+                tenant_id=TENANT,
+                actor_id=ACTOR,
+                reason="test",
+            )
+
+
+class TestRestoreMemory:
+    @pytest.mark.asyncio
+    async def test_restore_quarantined_memory(self, async_session):
+        node = _make_memory(status="quarantined")
+        async_session.add(node)
+        await async_session.commit()
+
+        result = await restore_memory(
+            async_session,
+            memory_id=node.id,
+            tenant_id=TENANT,
+            actor_id=ACTOR,
+            reason="Content reviewed, no issues",
+        )
+
+        assert result["new_status"] == "active"
+        assert result["previous_status"] == "quarantined"
+
+        await async_session.refresh(node)
+        assert node.status == "active"
+
+    @pytest.mark.asyncio
+    async def test_restore_active_returns_error(self, async_session):
+        node = _make_memory(status="active")
+        async_session.add(node)
+        await async_session.commit()
+
+        result = await restore_memory(
+            async_session,
+            memory_id=node.id,
+            tenant_id=TENANT,
+            actor_id=ACTOR,
+            reason="test",
+        )
+
+        assert "error" in result
+        assert result["current_status"] == "active"
+
+    @pytest.mark.asyncio
+    async def test_restore_nonexistent_raises(self, async_session):
+        with pytest.raises(MemoryNotFoundError):
+            await restore_memory(
+                async_session,
+                memory_id=uuid.uuid4(),
+                tenant_id=TENANT,
+                actor_id=ACTOR,
+                reason="test",
+            )
+
+
+class TestHardDeleteMemory:
+    @pytest.mark.asyncio
+    async def test_hard_delete_removes_row(self, async_session):
+        node = _make_memory()
+        async_session.add(node)
+        await async_session.commit()
+        node_id = node.id
+
+        result = await hard_delete_memory(
+            async_session,
+            memory_id=node_id,
+            tenant_id=TENANT,
+            actor_id=ACTOR,
+            reason="Cleanup",
+        )
+
+        assert result["memory_id"] == str(node_id)
+        assert result["versions_deleted"] >= 1
+
+        # Verify row is gone
+        from sqlalchemy import select
+        stmt = select(MemoryNode).where(MemoryNode.id == node_id)
+        check = await async_session.execute(stmt)
+        assert check.scalar_one_or_none() is None
+
+    @pytest.mark.asyncio
+    async def test_hard_delete_sanitized_audit(self, async_session):
+        node = _make_memory(content="classified data here")
+        async_session.add(node)
+        await async_session.commit()
+
+        result = await hard_delete_memory(
+            async_session,
+            memory_id=node.id,
+            tenant_id=TENANT,
+            actor_id=ACTOR,
+            reason="Classified spill",
+            incident_reference="INC-2026-0099",
+            sanitized_audit=True,
+        )
+
+        assert result["sanitized_audit"] is True
+        assert result["incident_reference"] == "INC-2026-0099"
+
+    @pytest.mark.asyncio
+    async def test_hard_delete_wrong_tenant_raises(self, async_session):
+        node = _make_memory(tenant_id="other-tenant")
+        async_session.add(node)
+        await async_session.commit()
+
+        with pytest.raises(MemoryNotFoundError):
+            await hard_delete_memory(
+                async_session,
+                memory_id=node.id,
+                tenant_id=TENANT,
+                actor_id=ACTOR,
+                reason="test",
+            )
+
+    @pytest.mark.asyncio
+    async def test_hard_delete_nonexistent_raises(self, async_session):
+        with pytest.raises(MemoryNotFoundError):
+            await hard_delete_memory(
+                async_session,
+                memory_id=uuid.uuid4(),
+                tenant_id=TENANT,
+                actor_id=ACTOR,
+                reason="test",
+            )
+
+
+class TestSearchMemoryAdmin:
+    @pytest.mark.asyncio
+    async def test_search_returns_active_and_quarantined(
+        self, async_session, embedding_service,
+    ):
+        active = _make_memory(content="active memory about API keys")
+        quarantined = _make_memory(
+            content="quarantined memory about API keys",
+            status="quarantined",
+        )
+        soft_deleted = _make_memory(
+            content="soft deleted memory about API keys",
+            status="soft_deleted",
+        )
+        async_session.add_all([active, quarantined, soft_deleted])
+        await async_session.commit()
+
+        results = await search_memory_admin(
+            async_session,
+            embedding_service,
+            query="API keys",
+            tenant_id=TENANT,
+            actor_id=ACTOR,
+        )
+
+        # Default includes active + quarantined, NOT soft_deleted
+        result_ids = {r["id"] for r in results}
+        assert str(active.id) in result_ids
+        assert str(quarantined.id) in result_ids
+        assert str(soft_deleted.id) not in result_ids
+
+    @pytest.mark.asyncio
+    async def test_search_with_explicit_statuses(
+        self, async_session, embedding_service,
+    ):
+        soft_deleted = _make_memory(
+            content="soft deleted memory",
+            status="soft_deleted",
+        )
+        async_session.add(soft_deleted)
+        await async_session.commit()
+
+        results = await search_memory_admin(
+            async_session,
+            embedding_service,
+            query="soft deleted",
+            tenant_id=TENANT,
+            actor_id=ACTOR,
+            include_statuses=["soft_deleted"],
+        )
+
+        result_ids = {r["id"] for r in results}
+        assert str(soft_deleted.id) in result_ids
+
+    @pytest.mark.asyncio
+    async def test_search_tenant_isolation(
+        self, async_session, embedding_service,
+    ):
+        other_tenant = _make_memory(
+            content="other tenant memory",
+            tenant_id="other-tenant",
+        )
+        async_session.add(other_tenant)
+        await async_session.commit()
+
+        results = await search_memory_admin(
+            async_session,
+            embedding_service,
+            query="other tenant",
+            tenant_id=TENANT,
+            actor_id=ACTOR,
+        )
+
+        result_ids = {r["id"] for r in results}
+        assert str(other_tenant.id) not in result_ids
+
+    @pytest.mark.asyncio
+    async def test_search_with_regex(
+        self, async_session, embedding_service,
+    ):
+        match = _make_memory(content="Contains API_KEY=sk-12345 secret")
+        no_match = _make_memory(content="No secrets here")
+        async_session.add_all([match, no_match])
+        await async_session.commit()
+
+        results = await search_memory_admin(
+            async_session,
+            embedding_service,
+            query="secret",
+            tenant_id=TENANT,
+            actor_id=ACTOR,
+            regex=r"API_KEY=\w+",
+        )
+
+        result_ids = {r["id"] for r in results}
+        assert str(match.id) in result_ids
+        assert str(no_match.id) not in result_ids
+
+    @pytest.mark.asyncio
+    async def test_search_invalid_regex_raises(
+        self, async_session, embedding_service,
+    ):
+        with pytest.raises(ValueError, match="Invalid regex"):
+            await search_memory_admin(
+                async_session,
+                embedding_service,
+                query="test",
+                tenant_id=TENANT,
+                actor_id=ACTOR,
+                regex="[invalid",
+            )
+
+
+class TestStatusFilterInDefaultQueries:
+    """Verify that quarantined memories are invisible to normal queries."""
+
+    @pytest.mark.asyncio
+    async def test_quarantined_invisible_to_read(self, async_session):
+        """read_memory should not return quarantined memories."""
+        from memoryhub_core.services.memory import read_memory
+
+        node = _make_memory(status="quarantined")
+        async_session.add(node)
+        await async_session.commit()
+
+        with pytest.raises(MemoryNotFoundError):
+            await read_memory(node.id, async_session, tenant_id=TENANT)


### PR DESCRIPTION
## Summary

Adds an incident-response workflow for sensitive content in memories: quarantine on suspicion, review, then restore or hard-delete. Includes a status column (active/quarantined/soft_deleted), cross-owner admin search with regex, and sanitized audit mode for classified data spills.

Closes #45.

## Changes

- **Migration 023**: `status VARCHAR(20) NOT NULL DEFAULT 'active'` on memory_nodes with index
- **Active-only filtering**: Default search, read, and similarity checks exclude quarantined/soft_deleted memories
- **Admin service** (`services/admin.py`): `search_memory_admin` (cross-owner semantic + regex), `quarantine_memory`, `restore_memory`, `hard_delete_memory` (physical DELETE with sanitized audit mode)
- **MCP tool** (`admin_memory`): Action-dispatch tool with `memory:admin` scope enforcement. Registered in compact and full profiles.
- **35 new tests** (17 service + 18 MCP tool)

## Test plan

- [x] 17 service tests pass (status transitions, tenant isolation, sanitized audit, regex search)
- [x] 18 MCP tool tests pass (scope checks, parameter validation, dispatch routing)
- [x] No regressions in existing test suite