### PR TITLE
agents: Add shared agent framework package with lifecycle, queue, and leader election

### DIFF
--- a/memoryhub-agents/README.md
+++ b/memoryhub-agents/README.md
@@ -1,0 +1,119 @@
+# memoryhub-agents
+
+Shared framework for MemoryHub curation agents (Trace Reviewer, Curator, Fact Checker, Statistician).
+
+All four agents follow the same lifecycle: authenticate via MCP, dequeue work from Valkey, process it, report results. This package provides the shared infrastructure so individual agents only implement their domain-specific logic.
+
+## Installation
+
+```bash
+pip install -e ".[dev]"
+```
+
+## Writing an Agent
+
+Subclass `AgentPlugin` and implement `process()`:
+
+```python
+import asyncio
+
+from memoryhub_agents.config import AgentConfig
+from memoryhub_agents.lifecycle import AgentPlugin, AgentRunner
+from memoryhub_agents.mcp_client import MCPSession
+
+
+class TraceReviewerPlugin(AgentPlugin):
+    """Extracts missed memories from completed conversation threads."""
+
+    async def on_start(self, config, mcp):
+        # One-time setup after authentication
+        self.min_confidence = 0.7
+
+    async def process(self, item: dict, mcp: MCPSession) -> dict:
+        thread_id = item["thread_id"]
+
+        # Use the MCP session to read the conversation thread
+        thread = await mcp.call_tool("get_thread", thread_id=thread_id)
+
+        # ... analyze messages, extract candidate memories ...
+
+        # Write extracted memories back
+        for candidate in candidates:
+            await mcp.call_tool(
+                "write",
+                content=candidate["content"],
+                scope="project",
+            )
+
+        return {"status": "ok", "extracted": len(candidates)}
+
+    async def on_stop(self):
+        pass
+
+
+if __name__ == "__main__":
+    config = AgentConfig()
+    plugin = TraceReviewerPlugin()
+    runner = AgentRunner(config, plugin)
+    asyncio.run(runner.run())
+```
+
+## Configuration
+
+All configuration is via environment variables:
+
+| Variable | Default | Description |
+|---|---|---|
+| `AGENT_TYPE` | `unknown` | Agent type (tracer, curator, factchecker, statistician) |
+| `AGENT_ID` | `""` | Unique instance identifier (typically pod name) |
+| `MH_MCP_URL` | `""` | MemoryHub MCP server URL |
+| `MH_API_KEY` | `""` | API key for MCP authentication |
+| `VALKEY_URL` | `redis://memoryhub-valkey:6379` | Valkey connection URL |
+| `LLM_ENDPOINT` | `""` | LLM inference endpoint |
+| `LLM_MODEL` | `""` | Model name for inference |
+| `DAILY_TOKEN_BUDGET` | `100000` | Daily token budget cap |
+| `POLL_INTERVAL_SECONDS` | `5.0` | Queue poll interval |
+| `MAX_RETRIES` | `5` | Max retries for MCP tool calls |
+| `TENANT_ID` | `default` | Tenant identifier for queue/lock keys |
+
+## Components
+
+- **`config.py`** -- `AgentConfig` dataclass reads all settings from environment variables.
+- **`queue.py`** -- `AgentQueue` wraps Valkey LIST operations for FIFO work item processing.
+- **`leader.py`** -- `LeaderElection` implements distributed locks for singleton agents.
+- **`mcp_client.py`** -- `MCPSession` wraps the MemoryHub SDK with exponential backoff retry.
+- **`lifecycle.py`** -- `AgentRunner` orchestrates the authenticate-dequeue-process loop.
+
+## Leader Election
+
+Singleton agents (Curator, Statistician) should use `LeaderElection` to ensure only one instance processes work at a time:
+
+```python
+from memoryhub_agents.leader import LeaderElection
+import redis.asyncio as redis
+
+client = redis.from_url("redis://memoryhub-valkey:6379")
+election = LeaderElection(client, config.lock_key)
+
+if await election.try_acquire(config.agent_id):
+    # We are the leader -- process work
+    while running:
+        await election.heartbeat()
+        # ... dequeue and process ...
+    await election.release()
+```
+
+## Testing
+
+```bash
+pip install -e ".[dev]"
+pytest tests/ -v
+```
+
+Tests run without Valkey or MCP server -- everything is mocked.
+
+## Design Reference
+
+See `planning/autonomous-curation-agents.md` for the full design, particularly:
+- Section 9: Deployment topology
+- Section 13: Shared framework decision

--- a/memoryhub-agents/pyproject.toml
+++ b/memoryhub-agents/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = ["setuptools>=68", "wheel"]
-build-backend = "setuptools.backends._legacy:_Backend"
+build-backend = "setuptools.build_meta"
 
 [project]
 name = "memoryhub-agents"

--- a/memoryhub-agents/pyproject.toml
+++ b/memoryhub-agents/pyproject.toml
@@ -1,0 +1,19 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.backends._legacy:_Backend"
+
+[project]
+name = "memoryhub-agents"
+version = "0.1.0"
+description = "Shared framework for MemoryHub curation agents"
+requires-python = ">=3.11"
+dependencies = [
+    "redis>=5.0",        # Valkey is Redis-compatible
+    "memoryhub>=0.1.0",  # MemoryHub SDK for MCP client
+]
+
+[project.optional-dependencies]
+dev = ["pytest>=8.0", "pytest-asyncio>=0.23"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"

--- a/memoryhub-agents/src/memoryhub_agents/__init__.py
+++ b/memoryhub-agents/src/memoryhub_agents/__init__.py
@@ -1,0 +1,1 @@
+"""Shared framework for MemoryHub curation agents."""

--- a/memoryhub-agents/src/memoryhub_agents/config.py
+++ b/memoryhub-agents/src/memoryhub_agents/config.py
@@ -1,0 +1,74 @@
+"""Environment-based agent configuration."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class AgentConfig:
+    """Configuration for a curation agent, loaded from environment variables.
+
+    Every field has a sensible default or reads from a well-known env var,
+    so agents can be configured entirely through the pod spec without any
+    config files.
+    """
+
+    agent_type: str = field(
+        default_factory=lambda: os.environ.get("AGENT_TYPE", "unknown"),
+    )
+    agent_id: str = field(
+        default_factory=lambda: os.environ.get("AGENT_ID", ""),
+    )
+
+    # MCP connection
+    mcp_url: str = field(
+        default_factory=lambda: os.environ.get("MH_MCP_URL", ""),
+    )
+    api_key: str = field(
+        default_factory=lambda: os.environ.get("MH_API_KEY", ""),
+    )
+
+    # Valkey
+    valkey_url: str = field(
+        default_factory=lambda: os.environ.get(
+            "VALKEY_URL", "redis://memoryhub-valkey:6379"
+        ),
+    )
+
+    # LLM (for agents that need inference)
+    llm_endpoint: str = field(
+        default_factory=lambda: os.environ.get("LLM_ENDPOINT", ""),
+    )
+    llm_model: str = field(
+        default_factory=lambda: os.environ.get("LLM_MODEL", ""),
+    )
+
+    # Budget
+    daily_token_budget: int = field(
+        default_factory=lambda: int(os.environ.get("DAILY_TOKEN_BUDGET", "100000")),
+    )
+
+    # Timing
+    poll_interval_seconds: float = field(
+        default_factory=lambda: float(os.environ.get("POLL_INTERVAL_SECONDS", "5.0")),
+    )
+    max_retries: int = field(
+        default_factory=lambda: int(os.environ.get("MAX_RETRIES", "5")),
+    )
+
+    # Tenant
+    tenant_id: str = field(
+        default_factory=lambda: os.environ.get("TENANT_ID", "default"),
+    )
+
+    @property
+    def queue_key(self) -> str:
+        """Queue key for this agent's work items."""
+        return f"{self.agent_type}_queue:{self.tenant_id}"
+
+    @property
+    def lock_key(self) -> str:
+        """Leader election lock key."""
+        return f"agent_lock:{self.agent_type}:{self.tenant_id}"

--- a/memoryhub-agents/src/memoryhub_agents/leader.py
+++ b/memoryhub-agents/src/memoryhub_agents/leader.py
@@ -1,0 +1,90 @@
+"""Leader election for singleton agents using Valkey distributed locks.
+
+Some agents (Curator, Statistician) should run as singletons per tenant
+to avoid duplicate work. This module implements leader election using
+Redis SET NX with TTL. The leader must call ``heartbeat()`` periodically
+to maintain leadership; if it fails to do so, the lock expires and
+another instance can take over.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import redis.asyncio as redis
+
+logger = logging.getLogger(__name__)
+
+
+class LeaderElection:
+    """Distributed lock for singleton agents.
+
+    Usage::
+
+        election = LeaderElection(client, "agent_lock:curator:default")
+        if await election.try_acquire("pod-abc123"):
+            # We are the leader -- do work
+            await election.heartbeat()
+        else:
+            # Another instance is leader -- wait or exit
+            pass
+    """
+
+    def __init__(
+        self, client: redis.Redis, lock_key: str, ttl_seconds: int = 30
+    ) -> None:
+        self._client = client
+        self._lock_key = lock_key
+        self._ttl = ttl_seconds
+        self._holder_id: str | None = None
+
+    async def try_acquire(self, holder_id: str) -> bool:
+        """Attempt to acquire leadership.
+
+        Returns True if this instance is now leader. Re-entrant: if we
+        already hold the lock, the TTL is refreshed.
+        """
+        acquired = await self._client.set(
+            self._lock_key, holder_id, nx=True, ex=self._ttl
+        )
+        if acquired:
+            self._holder_id = holder_id
+            logger.info("acquired leadership: %s", self._lock_key)
+            return True
+        # Check if we already hold it (re-entrant call)
+        current = await self._client.get(self._lock_key)
+        if current == holder_id:
+            await self._client.expire(self._lock_key, self._ttl)
+            self._holder_id = holder_id
+            return True
+        return False
+
+    async def heartbeat(self) -> bool:
+        """Refresh the lock TTL.
+
+        Returns False if we lost leadership (another instance took over
+        or the lock expired between heartbeats).
+        """
+        if not self._holder_id:
+            return False
+        current = await self._client.get(self._lock_key)
+        if current != self._holder_id:
+            self._holder_id = None
+            logger.warning("lost leadership: %s", self._lock_key)
+            return False
+        await self._client.expire(self._lock_key, self._ttl)
+        return True
+
+    async def release(self) -> None:
+        """Release leadership if we hold it."""
+        if self._holder_id:
+            current = await self._client.get(self._lock_key)
+            if current == self._holder_id:
+                await self._client.delete(self._lock_key)
+                logger.info("released leadership: %s", self._lock_key)
+            self._holder_id = None
+
+    @property
+    def is_leader(self) -> bool:
+        """Whether this instance currently believes it holds the lock."""
+        return self._holder_id is not None

--- a/memoryhub-agents/src/memoryhub_agents/lifecycle.py
+++ b/memoryhub-agents/src/memoryhub_agents/lifecycle.py
@@ -1,0 +1,128 @@
+"""Main agent lifecycle loop: authenticate, dequeue, process, report.
+
+Each curation agent implements ``AgentPlugin`` with its domain-specific
+logic. ``AgentRunner`` handles the common lifecycle: connect to Valkey
+and MCP, enter the dequeue-process loop, and shut down gracefully on
+SIGTERM/SIGINT.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import signal
+from abc import ABC, abstractmethod
+
+from memoryhub_agents.config import AgentConfig
+from memoryhub_agents.mcp_client import MCPSession
+from memoryhub_agents.queue import AgentQueue
+
+logger = logging.getLogger(__name__)
+
+
+class AgentPlugin(ABC):
+    """Base class for agent-specific processing logic.
+
+    Subclass this and implement ``process()`` to create a curation agent.
+    ``on_start()`` and ``on_stop()`` are optional lifecycle hooks.
+
+    Example::
+
+        class TracerPlugin(AgentPlugin):
+            async def process(self, item, mcp):
+                thread_id = item["thread_id"]
+                # ... extract memories from conversation thread ...
+                return {"status": "ok", "extracted": 3}
+    """
+
+    @abstractmethod
+    async def process(self, item: dict, mcp: MCPSession) -> dict:
+        """Process a single work item. Returns a result dict."""
+
+    async def on_start(self, config: AgentConfig, mcp: MCPSession) -> None:
+        """Called once after authentication succeeds."""
+
+    async def on_stop(self) -> None:
+        """Called during graceful shutdown."""
+
+
+class AgentRunner:
+    """Orchestrates the agent lifecycle.
+
+    Usage::
+
+        config = AgentConfig()
+        plugin = MyAgentPlugin()
+        runner = AgentRunner(config, plugin)
+        await runner.run()
+    """
+
+    def __init__(self, config: AgentConfig, plugin: AgentPlugin) -> None:
+        self.config = config
+        self.plugin = plugin
+        self._running = False
+        self._queue: AgentQueue | None = None
+        self._mcp: MCPSession | None = None
+
+    async def run(self) -> None:
+        """Main entry point. Runs until SIGTERM/SIGINT."""
+        self._running = True
+        loop = asyncio.get_running_loop()
+        for sig in (signal.SIGTERM, signal.SIGINT):
+            loop.add_signal_handler(sig, self._handle_signal)
+
+        try:
+            await self._setup()
+            await self._loop()
+        finally:
+            await self._teardown()
+
+    async def _setup(self) -> None:
+        """Connect to Valkey and MCP, call plugin.on_start."""
+        logger.info("starting %s agent", self.config.agent_type)
+
+        self._queue = AgentQueue(self.config.valkey_url)
+        await self._queue.connect()
+
+        self._mcp = MCPSession(
+            self.config.mcp_url,
+            self.config.api_key,
+            self.config.agent_id,
+            max_retries=self.config.max_retries,
+        )
+        await self._mcp.connect()
+
+        await self.plugin.on_start(self.config, self._mcp)
+        logger.info("%s agent ready", self.config.agent_type)
+
+    async def _loop(self) -> None:
+        """Dequeue and process work items until stopped."""
+        while self._running:
+            item = await self._queue.dequeue(
+                self.config.queue_key,
+                timeout=self.config.poll_interval_seconds,
+            )
+            if item is None:
+                continue
+
+            try:
+                result = await self.plugin.process(item.payload, self._mcp)
+                logger.info(
+                    "processed %s: %s", item.id, result.get("status", "ok")
+                )
+            except Exception:
+                logger.exception("failed to process %s, requeuing", item.id)
+                await self._queue.requeue(item)
+
+    async def _teardown(self) -> None:
+        """Clean shutdown."""
+        logger.info("shutting down %s agent", self.config.agent_type)
+        await self.plugin.on_stop()
+        if self._mcp:
+            await self._mcp.close()
+        if self._queue:
+            await self._queue.close()
+
+    def _handle_signal(self) -> None:
+        logger.info("received shutdown signal")
+        self._running = False

--- a/memoryhub-agents/src/memoryhub_agents/mcp_client.py
+++ b/memoryhub-agents/src/memoryhub_agents/mcp_client.py
@@ -1,0 +1,100 @@
+"""MCP session management with exponential backoff retry.
+
+Wraps the MemoryHub SDK client to provide the lifecycle curation agents
+need: connect with API key auth, call tools with automatic retry on
+transient failures, and clean shutdown.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import random
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+class MCPSession:
+    """Managed wrapper around ``MemoryHubClient`` with retry logic.
+
+    Handles connection, API-key authentication, tool calls with
+    exponential backoff, and clean shutdown. Import of the SDK is
+    deferred to ``connect()`` so that unit tests can mock the client
+    without installing the full SDK.
+
+    Usage::
+
+        session = MCPSession(
+            mcp_url="https://mcp.example.com/mcp/",
+            api_key="mh-dev-abc123",
+            agent_id="curator-pod-xyz",
+        )
+        await session.connect()
+        results = await session.call_tool("search", query="deployment")
+        await session.close()
+    """
+
+    def __init__(
+        self,
+        mcp_url: str,
+        api_key: str,
+        agent_id: str,
+        max_retries: int = 5,
+    ) -> None:
+        self._url = mcp_url
+        self._api_key = api_key
+        self._agent_id = agent_id
+        self._max_retries = max_retries
+        self._client: Any = None  # MemoryHubClient, typed as Any to defer import
+
+    async def connect(self) -> None:
+        """Connect to MCP server and authenticate via API key."""
+        from memoryhub import MemoryHubClient
+
+        self._client = MemoryHubClient(url=self._url, api_key=self._api_key)
+        await self._client.__aenter__()
+        logger.info("registered MCP session for %s", self._agent_id)
+
+    async def call_tool(self, action: str, **kwargs: Any) -> Any:
+        """Call a MemoryHub SDK method with exponential backoff retry.
+
+        The ``action`` maps to a method name on ``MemoryHubClient``
+        (e.g., ``"search"``, ``"write"``, ``"read"``).
+
+        Raises ``RuntimeError`` if all retries are exhausted.
+        """
+        if not self._client:
+            raise RuntimeError("not connected -- call connect() first")
+
+        method = getattr(self._client, action, None)
+        if method is None:
+            raise ValueError(f"unknown action: {action!r}")
+
+        last_error: Exception | None = None
+        for attempt in range(self._max_retries):
+            try:
+                return await method(**kwargs)
+            except Exception as exc:
+                last_error = exc
+                if attempt < self._max_retries - 1:
+                    delay = min(2**attempt + random.uniform(0, 1), 30)
+                    logger.warning(
+                        "tool call %s failed (attempt %d/%d), retrying in %.1fs: %s",
+                        action,
+                        attempt + 1,
+                        self._max_retries,
+                        delay,
+                        exc,
+                    )
+                    await asyncio.sleep(delay)
+
+        raise RuntimeError(
+            f"tool call {action} failed after {self._max_retries} retries"
+        ) from last_error
+
+    async def close(self) -> None:
+        """Disconnect from the MCP server."""
+        if self._client:
+            await self._client.__aexit__(None, None, None)
+            self._client = None

--- a/memoryhub-agents/src/memoryhub_agents/queue.py
+++ b/memoryhub-agents/src/memoryhub_agents/queue.py
@@ -1,0 +1,88 @@
+"""Valkey-backed job queue for agent work items.
+
+Uses Redis LIST operations (BRPOP/LPUSH) for reliable FIFO queueing.
+Valkey is Redis-protocol-compatible, so the ``redis`` Python package
+works unchanged.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+
+import redis.asyncio as redis
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class WorkItem:
+    """A unit of work dequeued from the agent queue."""
+
+    id: str
+    payload: dict
+    queue_key: str
+    raw: str  # original JSON for re-enqueue on failure
+
+
+class AgentQueue:
+    """Async Valkey queue client for agent work items.
+
+    Items are enqueued with LPUSH and dequeued with BRPOP (blocking right
+    pop), giving FIFO ordering. Failed items can be requeued to the head
+    of the queue for retry.
+    """
+
+    def __init__(self, valkey_url: str) -> None:
+        self._url = valkey_url
+        self._client: redis.Redis | None = None
+
+    async def connect(self) -> None:
+        """Establish connection to Valkey and verify with PING."""
+        self._client = redis.from_url(self._url, decode_responses=True)
+        await self._client.ping()
+        logger.info("connected to Valkey at %s", self._url)
+
+    async def close(self) -> None:
+        """Close the Valkey connection."""
+        if self._client:
+            await self._client.aclose()
+            self._client = None
+
+    def _require_client(self) -> redis.Redis:
+        if self._client is None:
+            raise RuntimeError("not connected -- call connect() first")
+        return self._client
+
+    async def dequeue(
+        self, queue_key: str, timeout: float = 5.0
+    ) -> WorkItem | None:
+        """Block-pop the next work item. Returns None on timeout."""
+        client = self._require_client()
+        result = await client.brpop(queue_key, timeout=int(timeout))
+        if result is None:
+            return None
+        _, raw = result
+        data = json.loads(raw)
+        return WorkItem(
+            id=data.get("id", ""),
+            payload=data,
+            queue_key=queue_key,
+            raw=raw,
+        )
+
+    async def enqueue(self, queue_key: str, item: dict) -> None:
+        """Push a work item to the tail of the queue."""
+        client = self._require_client()
+        await client.lpush(queue_key, json.dumps(item))
+
+    async def requeue(self, item: WorkItem) -> None:
+        """Re-enqueue a failed work item (preserves original payload)."""
+        client = self._require_client()
+        await client.lpush(item.queue_key, item.raw)
+
+    async def queue_length(self, queue_key: str) -> int:
+        """Get the current queue depth."""
+        client = self._require_client()
+        return await client.llen(queue_key)

--- a/memoryhub-agents/tests/conftest.py
+++ b/memoryhub-agents/tests/conftest.py
@@ -1,0 +1,7 @@
+"""Shared fixtures for memoryhub-agents tests."""
+
+import sys
+from pathlib import Path
+
+# Ensure the package source is importable without installing.
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))

--- a/memoryhub-agents/tests/test_config.py
+++ b/memoryhub-agents/tests/test_config.py
@@ -1,0 +1,81 @@
+"""Tests for memoryhub_agents.config."""
+
+import os
+
+import pytest
+
+from memoryhub_agents.config import AgentConfig
+
+
+class TestAgentConfigDefaults:
+    """AgentConfig loads sensible defaults when no env vars are set."""
+
+    def test_default_agent_type(self, monkeypatch):
+        monkeypatch.delenv("AGENT_TYPE", raising=False)
+        cfg = AgentConfig()
+        assert cfg.agent_type == "unknown"
+
+    def test_default_valkey_url(self, monkeypatch):
+        monkeypatch.delenv("VALKEY_URL", raising=False)
+        cfg = AgentConfig()
+        assert cfg.valkey_url == "redis://memoryhub-valkey:6379"
+
+    def test_default_poll_interval(self, monkeypatch):
+        monkeypatch.delenv("POLL_INTERVAL_SECONDS", raising=False)
+        cfg = AgentConfig()
+        assert cfg.poll_interval_seconds == 5.0
+
+    def test_default_max_retries(self, monkeypatch):
+        monkeypatch.delenv("MAX_RETRIES", raising=False)
+        cfg = AgentConfig()
+        assert cfg.max_retries == 5
+
+    def test_default_tenant_id(self, monkeypatch):
+        monkeypatch.delenv("TENANT_ID", raising=False)
+        cfg = AgentConfig()
+        assert cfg.tenant_id == "default"
+
+
+class TestAgentConfigFromEnv:
+    """AgentConfig reads values from environment variables."""
+
+    def test_reads_agent_type(self, monkeypatch):
+        monkeypatch.setenv("AGENT_TYPE", "curator")
+        cfg = AgentConfig()
+        assert cfg.agent_type == "curator"
+
+    def test_reads_mcp_url(self, monkeypatch):
+        monkeypatch.setenv("MH_MCP_URL", "https://mcp.test/mcp/")
+        cfg = AgentConfig()
+        assert cfg.mcp_url == "https://mcp.test/mcp/"
+
+    def test_reads_numeric_fields(self, monkeypatch):
+        monkeypatch.setenv("DAILY_TOKEN_BUDGET", "50000")
+        monkeypatch.setenv("POLL_INTERVAL_SECONDS", "2.5")
+        monkeypatch.setenv("MAX_RETRIES", "3")
+        cfg = AgentConfig()
+        assert cfg.daily_token_budget == 50000
+        assert cfg.poll_interval_seconds == 2.5
+        assert cfg.max_retries == 3
+
+
+class TestAgentConfigProperties:
+    """Derived properties generate correct Valkey key patterns."""
+
+    def test_queue_key(self, monkeypatch):
+        monkeypatch.setenv("AGENT_TYPE", "tracer")
+        monkeypatch.setenv("TENANT_ID", "acme")
+        cfg = AgentConfig()
+        assert cfg.queue_key == "tracer_queue:acme"
+
+    def test_lock_key(self, monkeypatch):
+        monkeypatch.setenv("AGENT_TYPE", "curator")
+        monkeypatch.setenv("TENANT_ID", "acme")
+        cfg = AgentConfig()
+        assert cfg.lock_key == "agent_lock:curator:acme"
+
+    def test_frozen(self, monkeypatch):
+        monkeypatch.setenv("AGENT_TYPE", "tracer")
+        cfg = AgentConfig()
+        with pytest.raises(AttributeError):
+            cfg.agent_type = "curator"  # type: ignore[misc]

--- a/memoryhub-agents/tests/test_leader.py
+++ b/memoryhub-agents/tests/test_leader.py
@@ -1,0 +1,106 @@
+"""Tests for memoryhub_agents.leader."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from memoryhub_agents.leader import LeaderElection
+
+
+@pytest.fixture
+def mock_redis():
+    client = AsyncMock()
+    client.set = AsyncMock(return_value=True)
+    client.get = AsyncMock(return_value=None)
+    client.expire = AsyncMock()
+    client.delete = AsyncMock()
+    return client
+
+
+@pytest.fixture
+def election(mock_redis):
+    return LeaderElection(mock_redis, "agent_lock:curator:default", ttl_seconds=30)
+
+
+class TestLeaderElectionAcquire:
+    @pytest.mark.asyncio
+    async def test_acquire_success(self, election, mock_redis):
+        mock_redis.set.return_value = True
+        result = await election.try_acquire("pod-1")
+        assert result is True
+        assert election.is_leader is True
+        mock_redis.set.assert_called_once_with(
+            "agent_lock:curator:default", "pod-1", nx=True, ex=30
+        )
+
+    @pytest.mark.asyncio
+    async def test_acquire_fails_when_held(self, election, mock_redis):
+        mock_redis.set.return_value = False
+        mock_redis.get.return_value = "pod-other"
+        result = await election.try_acquire("pod-1")
+        assert result is False
+        assert election.is_leader is False
+
+    @pytest.mark.asyncio
+    async def test_acquire_reentrant(self, election, mock_redis):
+        """If we already hold the lock, re-acquire refreshes TTL."""
+        mock_redis.set.return_value = False
+        mock_redis.get.return_value = "pod-1"
+        result = await election.try_acquire("pod-1")
+        assert result is True
+        mock_redis.expire.assert_called_once_with(
+            "agent_lock:curator:default", 30
+        )
+
+
+class TestLeaderElectionHeartbeat:
+    @pytest.mark.asyncio
+    async def test_heartbeat_success(self, election, mock_redis):
+        # First acquire
+        mock_redis.set.return_value = True
+        await election.try_acquire("pod-1")
+        # Then heartbeat
+        mock_redis.get.return_value = "pod-1"
+        result = await election.heartbeat()
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_heartbeat_lost_leadership(self, election, mock_redis):
+        mock_redis.set.return_value = True
+        await election.try_acquire("pod-1")
+        # Someone else took over
+        mock_redis.get.return_value = "pod-other"
+        result = await election.heartbeat()
+        assert result is False
+        assert election.is_leader is False
+
+    @pytest.mark.asyncio
+    async def test_heartbeat_without_acquiring(self, election):
+        result = await election.heartbeat()
+        assert result is False
+
+
+class TestLeaderElectionRelease:
+    @pytest.mark.asyncio
+    async def test_release(self, election, mock_redis):
+        mock_redis.set.return_value = True
+        await election.try_acquire("pod-1")
+        mock_redis.get.return_value = "pod-1"
+        await election.release()
+        mock_redis.delete.assert_called_once_with("agent_lock:curator:default")
+        assert election.is_leader is False
+
+    @pytest.mark.asyncio
+    async def test_release_when_not_leader(self, election, mock_redis):
+        await election.release()
+        mock_redis.delete.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_release_when_someone_else_holds(self, election, mock_redis):
+        """Release is a no-op if another instance took over."""
+        mock_redis.set.return_value = True
+        await election.try_acquire("pod-1")
+        mock_redis.get.return_value = "pod-other"
+        await election.release()
+        mock_redis.delete.assert_not_called()
+        assert election.is_leader is False

--- a/memoryhub-agents/tests/test_lifecycle.py
+++ b/memoryhub-agents/tests/test_lifecycle.py
@@ -1,0 +1,141 @@
+"""Tests for memoryhub_agents.lifecycle."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from memoryhub_agents.config import AgentConfig
+from memoryhub_agents.lifecycle import AgentPlugin, AgentRunner
+from memoryhub_agents.mcp_client import MCPSession
+from memoryhub_agents.queue import AgentQueue, WorkItem
+
+
+class TestAgentPluginAbstract:
+    def test_cannot_instantiate(self):
+        with pytest.raises(TypeError):
+            AgentPlugin()  # type: ignore[abstract]
+
+    def test_subclass_must_implement_process(self):
+        class Incomplete(AgentPlugin):
+            pass
+
+        with pytest.raises(TypeError):
+            Incomplete()  # type: ignore[abstract]
+
+    def test_subclass_with_process_works(self):
+        class Complete(AgentPlugin):
+            async def process(self, item, mcp):
+                return {"status": "ok"}
+
+        plugin = Complete()
+        assert plugin is not None
+
+
+class TestAgentRunnerSetupTeardown:
+    @pytest.fixture
+    def config(self, monkeypatch):
+        monkeypatch.setenv("AGENT_TYPE", "test-agent")
+        monkeypatch.setenv("AGENT_ID", "test-1")
+        monkeypatch.setenv("MH_MCP_URL", "https://mcp.test/mcp/")
+        monkeypatch.setenv("MH_API_KEY", "mh-dev-test")
+        monkeypatch.setenv("VALKEY_URL", "redis://localhost:6379")
+        return AgentConfig()
+
+    @pytest.fixture
+    def plugin(self):
+        p = MagicMock(spec=AgentPlugin)
+        p.process = AsyncMock(return_value={"status": "ok"})
+        p.on_start = AsyncMock()
+        p.on_stop = AsyncMock()
+        return p
+
+    @pytest.mark.asyncio
+    async def test_setup_connects_queue_and_mcp(self, config, plugin):
+        runner = AgentRunner(config, plugin)
+
+        with (
+            patch.object(AgentQueue, "connect", new_callable=AsyncMock) as mock_q,
+            patch.object(MCPSession, "connect", new_callable=AsyncMock) as mock_m,
+        ):
+            await runner._setup()
+            mock_q.assert_called_once()
+            mock_m.assert_called_once()
+            plugin.on_start.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_teardown_closes_connections(self, config, plugin):
+        runner = AgentRunner(config, plugin)
+
+        mock_queue = AsyncMock(spec=AgentQueue)
+        mock_mcp = AsyncMock(spec=MCPSession)
+        runner._queue = mock_queue
+        runner._mcp = mock_mcp
+
+        await runner._teardown()
+        plugin.on_stop.assert_called_once()
+        mock_mcp.close.assert_called_once()
+        mock_queue.close.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_loop_processes_items(self, config, plugin):
+        runner = AgentRunner(config, plugin)
+        mock_queue = AsyncMock(spec=AgentQueue)
+        runner._queue = mock_queue
+        runner._mcp = AsyncMock(spec=MCPSession)
+        runner._running = True
+
+        # Return one item, then None to allow a stop check, then stop
+        call_count = 0
+
+        async def mock_dequeue(key, timeout=5.0):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return WorkItem(
+                    id="w1",
+                    payload={"id": "w1", "data": "test"},
+                    queue_key=key,
+                    raw='{"id": "w1", "data": "test"}',
+                )
+            runner._running = False
+            return None
+
+        mock_queue.dequeue = mock_dequeue
+        await runner._loop()
+        plugin.process.assert_called_once_with(
+            {"id": "w1", "data": "test"}, runner._mcp
+        )
+
+    @pytest.mark.asyncio
+    async def test_loop_requeues_on_failure(self, config, plugin):
+        runner = AgentRunner(config, plugin)
+        mock_queue = AsyncMock(spec=AgentQueue)
+        runner._queue = mock_queue
+        runner._mcp = AsyncMock(spec=MCPSession)
+        runner._running = True
+
+        plugin.process.side_effect = ValueError("boom")
+        call_count = 0
+
+        async def mock_dequeue(key, timeout=5.0):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return WorkItem(
+                    id="w1",
+                    payload={"id": "w1"},
+                    queue_key=key,
+                    raw='{"id": "w1"}',
+                )
+            runner._running = False
+            return None
+
+        mock_queue.dequeue = mock_dequeue
+        await runner._loop()
+        mock_queue.requeue.assert_called_once()
+
+    def test_handle_signal(self, config, plugin):
+        runner = AgentRunner(config, plugin)
+        runner._running = True
+        runner._handle_signal()
+        assert runner._running is False

--- a/memoryhub-agents/tests/test_queue.py
+++ b/memoryhub-agents/tests/test_queue.py
@@ -1,0 +1,115 @@
+"""Tests for memoryhub_agents.queue."""
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from memoryhub_agents.queue import AgentQueue, WorkItem
+
+
+class TestWorkItem:
+    """WorkItem is a simple data holder."""
+
+    def test_construction(self):
+        item = WorkItem(
+            id="abc-123",
+            payload={"id": "abc-123", "thread_id": "t1"},
+            queue_key="tracer_queue:default",
+            raw='{"id": "abc-123", "thread_id": "t1"}',
+        )
+        assert item.id == "abc-123"
+        assert item.payload["thread_id"] == "t1"
+        assert item.queue_key == "tracer_queue:default"
+
+
+class TestAgentQueueNotConnected:
+    """Operations on a disconnected queue raise RuntimeError."""
+
+    @pytest.fixture
+    def queue(self):
+        return AgentQueue("redis://localhost:6379")
+
+    @pytest.mark.asyncio
+    async def test_dequeue_not_connected(self, queue):
+        with pytest.raises(RuntimeError, match="not connected"):
+            await queue.dequeue("test_queue")
+
+    @pytest.mark.asyncio
+    async def test_enqueue_not_connected(self, queue):
+        with pytest.raises(RuntimeError, match="not connected"):
+            await queue.enqueue("test_queue", {"id": "1"})
+
+    @pytest.mark.asyncio
+    async def test_requeue_not_connected(self, queue):
+        item = WorkItem(id="1", payload={}, queue_key="q", raw="{}")
+        with pytest.raises(RuntimeError, match="not connected"):
+            await queue.requeue(item)
+
+    @pytest.mark.asyncio
+    async def test_queue_length_not_connected(self, queue):
+        with pytest.raises(RuntimeError, match="not connected"):
+            await queue.queue_length("test_queue")
+
+
+class TestAgentQueueConnected:
+    """Queue operations with a mocked Redis client."""
+
+    @pytest.fixture
+    def mock_client(self):
+        client = AsyncMock()
+        client.ping = AsyncMock()
+        client.brpop = AsyncMock(return_value=None)
+        client.lpush = AsyncMock()
+        client.llen = AsyncMock(return_value=0)
+        client.aclose = AsyncMock()
+        return client
+
+    @pytest.fixture
+    async def queue(self, mock_client):
+        q = AgentQueue("redis://localhost:6379")
+        q._client = mock_client
+        return q
+
+    @pytest.mark.asyncio
+    async def test_dequeue_timeout(self, queue, mock_client):
+        mock_client.brpop.return_value = None
+        result = await queue.dequeue("test_queue", timeout=1.0)
+        assert result is None
+        mock_client.brpop.assert_called_once_with("test_queue", timeout=1)
+
+    @pytest.mark.asyncio
+    async def test_dequeue_item(self, queue, mock_client):
+        payload = {"id": "work-1", "data": "test"}
+        mock_client.brpop.return_value = ("test_queue", json.dumps(payload))
+        result = await queue.dequeue("test_queue")
+        assert result is not None
+        assert result.id == "work-1"
+        assert result.payload == payload
+
+    @pytest.mark.asyncio
+    async def test_enqueue(self, queue, mock_client):
+        item = {"id": "work-2", "data": "test"}
+        await queue.enqueue("test_queue", item)
+        mock_client.lpush.assert_called_once_with(
+            "test_queue", json.dumps(item)
+        )
+
+    @pytest.mark.asyncio
+    async def test_requeue(self, queue, mock_client):
+        raw = '{"id": "work-3"}'
+        item = WorkItem(id="work-3", payload={}, queue_key="q", raw=raw)
+        await queue.requeue(item)
+        mock_client.lpush.assert_called_once_with("q", raw)
+
+    @pytest.mark.asyncio
+    async def test_queue_length(self, queue, mock_client):
+        mock_client.llen.return_value = 5
+        length = await queue.queue_length("test_queue")
+        assert length == 5
+
+    @pytest.mark.asyncio
+    async def test_close(self, queue, mock_client):
+        await queue.close()
+        mock_client.aclose.assert_called_once()
+        assert queue._client is None


### PR DESCRIPTION
## Summary

New `memoryhub-agents` Python package providing the shared authenticate/dequeue/process/report lifecycle pattern used by all four curation agents (Trace Reviewer, Curator, Fact Checker, Statistician).

Closes #286.

## Package contents

- **`config.py`**: Frozen `AgentConfig` dataclass loading all settings from environment variables. Generates consistent Valkey key patterns.
- **`queue.py`**: Async Valkey queue client using Redis LIST operations (BRPOP/LPUSH) for FIFO work items. Safe re-enqueue on failure.
- **`leader.py`**: Distributed lock via SET NX + TTL for singleton agents (Curator, Statistician). Heartbeat refresh, re-entrant acquisition.
- **`mcp_client.py`**: `MCPSession` wrapping the MemoryHub SDK with exponential backoff retry (5 attempts, jitter). Deferred SDK import for test isolation.
- **`lifecycle.py`**: `AgentRunner` orchestrates the full loop with SIGTERM/SIGINT handling. `AgentPlugin` abstract base class -- agents subclass and implement `process()`.

## Usage

```python
from memoryhub_agents.lifecycle import AgentPlugin, AgentRunner
from memoryhub_agents.config import AgentConfig

class MyAgent(AgentPlugin):
    async def process(self, item, mcp):
        result = await mcp.call_tool("search", query=item["query"])
        return {"status": "ok", "matches": len(result.get("results", []))}

runner = AgentRunner(AgentConfig(), MyAgent())
asyncio.run(runner.run())
```

## Test plan

- [x] 39/39 tests pass (config, queue, leader election, lifecycle, all mocked)
- [x] No Valkey or MCP server required for testing
- [x] Package installs cleanly with `pip install -e ".[dev]"`