### PR TITLE
agents: Implement Fact Checker with calendar verification and temporal expiry

### DIFF
--- a/memoryhub-agents/deploy/fact-checker/cronjob.yaml
+++ b/memoryhub-agents/deploy/fact-checker/cronjob.yaml
@@ -1,0 +1,46 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: fact-checker
+  namespace: memory-hub-mcp
+  labels:
+    app.kubernetes.io/name: fact-checker
+    app.kubernetes.io/part-of: memoryhub
+    app.kubernetes.io/component: agent
+spec:
+  schedule: "0 1 * * *"  # Daily at 01:00 UTC
+  concurrencyPolicy: Allow  # Multiple replicas OK
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: fact-checker
+              image: memoryhub-agent:latest
+              env:
+                - name: AGENT_TYPE
+                  value: fact-checker
+                - name: MH_MCP_URL
+                  valueFrom:
+                    configMapKeyRef:
+                      name: memoryhub-agent-config
+                      key: mcp_url
+                - name: MH_API_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: fact-checker-credentials
+                      key: api_key
+                - name: VALKEY_URL
+                  value: redis://memoryhub-valkey:6379
+                - name: TENANT_ID
+                  value: default
+              resources:
+                requests:
+                  memory: 256Mi
+                  cpu: 250m
+                limits:
+                  memory: 512Mi
+                  cpu: 500m

--- a/memoryhub-agents/pyproject.toml
+++ b/memoryhub-agents/pyproject.toml
@@ -12,6 +12,9 @@ dependencies = [
     "memoryhub>=0.1.0",  # MemoryHub SDK for MCP client
 ]
 
+[project.scripts]
+fact-checker = "memoryhub_agents.plugins.run_fact_checker:main"
+
 [project.optional-dependencies]
 dev = ["pytest>=8.0", "pytest-asyncio>=0.23"]
 

--- a/memoryhub-agents/src/memoryhub_agents/plugins/fact_checker.py
+++ b/memoryhub-agents/src/memoryhub_agents/plugins/fact_checker.py
@@ -1,0 +1,214 @@
+"""Fact Checker Agent plugin.
+
+Processes temporal expiry and runs verification plugins against
+memories with factual claims.
+"""
+
+from __future__ import annotations
+
+import logging
+from abc import ABC, abstractmethod
+from datetime import UTC, datetime, timedelta
+
+from memoryhub_agents.config import AgentConfig
+from memoryhub_agents.lifecycle import AgentPlugin
+from memoryhub_agents.mcp_client import MCPSession
+
+logger = logging.getLogger(__name__)
+
+
+class VerificationResult:
+    """Result of a verification check."""
+
+    def __init__(self, verified: bool, reason: str, plugin_name: str):
+        self.verified = verified
+        self.reason = reason
+        self.plugin_name = plugin_name
+
+
+class VerificationPlugin(ABC):
+    """Base class for domain-specific verification backends."""
+
+    @abstractmethod
+    def can_verify(self, memory: dict) -> bool:
+        """Return True if this plugin can verify the given memory."""
+
+    @abstractmethod
+    async def verify(self, memory: dict) -> VerificationResult:
+        """Verify a memory's claims. Returns a VerificationResult."""
+
+
+class CalendarPlugin(VerificationPlugin):
+    """Verifies temporal claims by checking against current date.
+
+    Handles memories with relevant_until timestamps:
+    - Past relevant_until -> mark as expired
+    - Within 7 days of relevant_until -> mark as expiring_soon
+    """
+
+    def can_verify(self, memory: dict) -> bool:
+        return memory.get("relevant_until") is not None
+
+    async def verify(self, memory: dict) -> VerificationResult:
+        relevant_until_str = memory.get("relevant_until")
+        if not relevant_until_str:
+            return VerificationResult(True, "no temporal claim", "calendar")
+
+        try:
+            if isinstance(relevant_until_str, str):
+                relevant_until = datetime.fromisoformat(relevant_until_str)
+            else:
+                relevant_until = relevant_until_str
+
+            # Ensure timezone-aware comparison
+            if relevant_until.tzinfo is None:
+                relevant_until = relevant_until.replace(tzinfo=UTC)
+
+            now = datetime.now(UTC)
+            if relevant_until < now:
+                return VerificationResult(
+                    False,
+                    f"expired on {relevant_until.isoformat()}",
+                    "calendar",
+                )
+            if relevant_until < now + timedelta(days=7):
+                return VerificationResult(
+                    True,
+                    f"expiring soon ({relevant_until.isoformat()})",
+                    "calendar",
+                )
+            return VerificationResult(True, "current", "calendar")
+        except (ValueError, TypeError) as exc:
+            return VerificationResult(True, f"unparseable date: {exc}", "calendar")
+
+
+class FactCheckerPlugin(AgentPlugin):
+    """Fact Checker agent plugin for the shared framework."""
+
+    def __init__(
+        self, verification_plugins: list[VerificationPlugin] | None = None
+    ):
+        self._plugins = verification_plugins or [CalendarPlugin()]
+        self._stats = {
+            "checked": 0,
+            "expired": 0,
+            "expiring_soon": 0,
+            "verified": 0,
+        }
+
+    async def on_start(self, config: AgentConfig, mcp: MCPSession) -> None:
+        logger.info(
+            "fact checker started with %d verification plugins: %s",
+            len(self._plugins),
+            [type(p).__name__ for p in self._plugins],
+        )
+
+    async def process(self, item: dict, mcp: MCPSession) -> dict:
+        """Process a single memory for verification.
+
+        Work item payload::
+
+            {
+                "memory_id": "uuid",
+                "action": "verify"  # or "scan_expiry"
+            }
+        """
+        action = item.get("action", "verify")
+
+        if action == "scan_expiry":
+            return await self._scan_expiry(mcp)
+
+        memory_id = item.get("memory_id")
+        if not memory_id:
+            return {"status": "error", "reason": "missing memory_id"}
+
+        return await self._verify_memory(memory_id, mcp)
+
+    async def _verify_memory(self, memory_id: str, mcp: MCPSession) -> dict:
+        """Run all applicable verification plugins against a memory."""
+        try:
+            memory = await mcp.call_tool("read", memory_id=memory_id)
+        except Exception as exc:
+            return {"status": "error", "reason": f"failed to read memory: {exc}"}
+
+        if isinstance(memory, dict) and "memory" in memory:
+            memory_data = memory["memory"]
+        else:
+            memory_data = memory
+
+        self._stats["checked"] += 1
+        results = []
+
+        for plugin in self._plugins:
+            if plugin.can_verify(memory_data):
+                result = await plugin.verify(memory_data)
+                results.append(
+                    {
+                        "plugin": result.plugin_name,
+                        "verified": result.verified,
+                        "reason": result.reason,
+                    }
+                )
+
+                if not result.verified:
+                    self._stats["expired"] += 1
+                    try:
+                        await mcp.call_tool(
+                            "report",
+                            memory_id=memory_id,
+                            options={
+                                "observed_behavior": (
+                                    f"Fact check failed: {result.reason}"
+                                )
+                            },
+                        )
+                    except Exception:
+                        logger.exception(
+                            "failed to report contradiction for %s", memory_id
+                        )
+                elif "expiring soon" in result.reason:
+                    self._stats["expiring_soon"] += 1
+                else:
+                    self._stats["verified"] += 1
+
+        return {"status": "ok", "memory_id": memory_id, "results": results}
+
+    async def _scan_expiry(self, mcp: MCPSession) -> dict:
+        """Scan for memories approaching or past expiry."""
+        expired = []
+        expiring_soon = []
+
+        try:
+            result = await mcp.call_tool(
+                "search",
+                query="*",
+                options={"temporal_status": "expired", "max_results": 50},
+            )
+            if isinstance(result, dict):
+                expired = result.get("results", [])
+        except Exception:
+            logger.exception("failed to search for expired memories")
+
+        try:
+            result = await mcp.call_tool(
+                "search",
+                query="*",
+                options={"temporal_status": "expiring_soon", "max_results": 50},
+            )
+            if isinstance(result, dict):
+                expiring_soon = result.get("results", [])
+        except Exception:
+            logger.exception("failed to search for expiring memories")
+
+        return {
+            "status": "ok",
+            "expired_count": len(expired),
+            "expiring_soon_count": len(expiring_soon),
+        }
+
+    async def on_stop(self) -> None:
+        logger.info("fact checker stats: %s", self._stats)
+
+    @property
+    def stats(self) -> dict:
+        return dict(self._stats)

--- a/memoryhub-agents/src/memoryhub_agents/plugins/run_fact_checker.py
+++ b/memoryhub-agents/src/memoryhub_agents/plugins/run_fact_checker.py
@@ -1,0 +1,24 @@
+"""Entry point for the Fact Checker agent."""
+
+import asyncio
+import logging
+
+from memoryhub_agents.config import AgentConfig
+from memoryhub_agents.lifecycle import AgentRunner
+from memoryhub_agents.plugins.fact_checker import FactCheckerPlugin
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(name)s %(levelname)s %(message)s",
+)
+
+
+def main():
+    config = AgentConfig()
+    plugin = FactCheckerPlugin()
+    runner = AgentRunner(config, plugin)
+    asyncio.run(runner.run())
+
+
+if __name__ == "__main__":
+    main()

--- a/memoryhub-agents/tests/test_fact_checker.py
+++ b/memoryhub-agents/tests/test_fact_checker.py
@@ -1,0 +1,299 @@
+"""Tests for memoryhub_agents.plugins.fact_checker."""
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock
+
+import pytest
+
+from memoryhub_agents.plugins.fact_checker import (
+    CalendarPlugin,
+    FactCheckerPlugin,
+    VerificationResult,
+)
+
+
+class TestVerificationResult:
+    def test_construction(self):
+        r = VerificationResult(True, "ok", "calendar")
+        assert r.verified is True
+        assert r.reason == "ok"
+        assert r.plugin_name == "calendar"
+
+    def test_construction_failed(self):
+        r = VerificationResult(False, "expired", "calendar")
+        assert r.verified is False
+
+
+class TestCalendarPlugin:
+    def setup_method(self):
+        self.plugin = CalendarPlugin()
+
+    def test_can_verify_with_relevant_until(self):
+        assert self.plugin.can_verify(
+            {"relevant_until": "2026-12-31T00:00:00+00:00"}
+        )
+
+    def test_can_verify_without_relevant_until(self):
+        assert not self.plugin.can_verify({"content": "evergreen fact"})
+
+    def test_can_verify_with_none_value(self):
+        assert not self.plugin.can_verify({"relevant_until": None})
+
+    @pytest.mark.asyncio
+    async def test_verify_expired_memory(self):
+        past = (datetime.now(UTC) - timedelta(days=30)).isoformat()
+        result = await self.plugin.verify({"relevant_until": past})
+        assert not result.verified
+        assert "expired" in result.reason
+        assert result.plugin_name == "calendar"
+
+    @pytest.mark.asyncio
+    async def test_verify_expiring_soon_memory(self):
+        soon = (datetime.now(UTC) + timedelta(days=3)).isoformat()
+        result = await self.plugin.verify({"relevant_until": soon})
+        assert result.verified
+        assert "expiring soon" in result.reason
+
+    @pytest.mark.asyncio
+    async def test_verify_current_memory(self):
+        future = (datetime.now(UTC) + timedelta(days=90)).isoformat()
+        result = await self.plugin.verify({"relevant_until": future})
+        assert result.verified
+        assert result.reason == "current"
+
+    @pytest.mark.asyncio
+    async def test_verify_unparseable_date(self):
+        result = await self.plugin.verify(
+            {"relevant_until": "not-a-date"}
+        )
+        assert result.verified  # conservative: don't flag unparseable as expired
+        assert "unparseable" in result.reason
+
+    @pytest.mark.asyncio
+    async def test_verify_empty_string(self):
+        result = await self.plugin.verify({"relevant_until": ""})
+        assert result.verified
+        assert result.reason == "no temporal claim"
+
+    @pytest.mark.asyncio
+    async def test_verify_datetime_object(self):
+        """Handles pre-parsed datetime objects, not just strings."""
+        future_dt = datetime.now(UTC) + timedelta(days=60)
+        result = await self.plugin.verify({"relevant_until": future_dt})
+        assert result.verified
+        assert result.reason == "current"
+
+    @pytest.mark.asyncio
+    async def test_verify_naive_datetime_string(self):
+        """Handles naive datetime strings by assuming UTC."""
+        future = (datetime.now(UTC) + timedelta(days=60)).strftime(
+            "%Y-%m-%dT%H:%M:%S"
+        )
+        result = await self.plugin.verify({"relevant_until": future})
+        assert result.verified
+        assert result.reason == "current"
+
+
+class TestFactCheckerPlugin:
+    @pytest.mark.asyncio
+    async def test_process_missing_memory_id(self):
+        plugin = FactCheckerPlugin()
+        result = await plugin.process({"action": "verify"}, AsyncMock())
+        assert result["status"] == "error"
+        assert "missing memory_id" in result["reason"]
+
+    @pytest.mark.asyncio
+    async def test_process_verify_current(self):
+        mcp = AsyncMock()
+        future = (datetime.now(UTC) + timedelta(days=90)).isoformat()
+        mcp.call_tool = AsyncMock(
+            return_value={
+                "memory": {
+                    "id": "abc",
+                    "content": "test",
+                    "relevant_until": future,
+                }
+            }
+        )
+        plugin = FactCheckerPlugin()
+        result = await plugin.process(
+            {"action": "verify", "memory_id": "abc"}, mcp
+        )
+        assert result["status"] == "ok"
+        assert result["memory_id"] == "abc"
+        assert len(result["results"]) == 1
+        assert result["results"][0]["verified"] is True
+        assert plugin.stats["checked"] == 1
+        assert plugin.stats["verified"] == 1
+
+    @pytest.mark.asyncio
+    async def test_process_verify_expired(self):
+        mcp = AsyncMock()
+        past = (datetime.now(UTC) - timedelta(days=10)).isoformat()
+        mcp.call_tool = AsyncMock(
+            return_value={
+                "memory": {
+                    "id": "abc",
+                    "content": "old fact",
+                    "relevant_until": past,
+                }
+            }
+        )
+        plugin = FactCheckerPlugin()
+        result = await plugin.process(
+            {"action": "verify", "memory_id": "abc"}, mcp
+        )
+        assert result["status"] == "ok"
+        assert result["results"][0]["verified"] is False
+        assert plugin.stats["expired"] == 1
+        # Should have called report for the contradiction
+        report_calls = [
+            c for c in mcp.call_tool.call_args_list if c.args[0] == "report"
+        ]
+        assert len(report_calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_process_verify_expiring_soon(self):
+        mcp = AsyncMock()
+        soon = (datetime.now(UTC) + timedelta(days=3)).isoformat()
+        mcp.call_tool = AsyncMock(
+            return_value={
+                "memory": {
+                    "id": "abc",
+                    "content": "soon fact",
+                    "relevant_until": soon,
+                }
+            }
+        )
+        plugin = FactCheckerPlugin()
+        result = await plugin.process(
+            {"action": "verify", "memory_id": "abc"}, mcp
+        )
+        assert result["status"] == "ok"
+        assert result["results"][0]["verified"] is True
+        assert plugin.stats["expiring_soon"] == 1
+
+    @pytest.mark.asyncio
+    async def test_process_verify_no_temporal_claim(self):
+        """Memories without relevant_until are not checked by CalendarPlugin."""
+        mcp = AsyncMock()
+        mcp.call_tool = AsyncMock(
+            return_value={
+                "memory": {"id": "abc", "content": "evergreen fact"}
+            }
+        )
+        plugin = FactCheckerPlugin()
+        result = await plugin.process(
+            {"action": "verify", "memory_id": "abc"}, mcp
+        )
+        assert result["status"] == "ok"
+        assert len(result["results"]) == 0  # CalendarPlugin skips it
+        assert plugin.stats["checked"] == 1
+
+    @pytest.mark.asyncio
+    async def test_process_verify_read_failure(self):
+        mcp = AsyncMock()
+        mcp.call_tool = AsyncMock(side_effect=RuntimeError("connection lost"))
+        plugin = FactCheckerPlugin()
+        result = await plugin.process(
+            {"action": "verify", "memory_id": "abc"}, mcp
+        )
+        assert result["status"] == "error"
+        assert "failed to read memory" in result["reason"]
+
+    @pytest.mark.asyncio
+    async def test_process_scan_expiry(self):
+        mcp = AsyncMock()
+        mcp.call_tool = AsyncMock(return_value={"results": []})
+        plugin = FactCheckerPlugin()
+        result = await plugin.process({"action": "scan_expiry"}, mcp)
+        assert result["status"] == "ok"
+        assert result["expired_count"] == 0
+        assert result["expiring_soon_count"] == 0
+
+    @pytest.mark.asyncio
+    async def test_process_scan_expiry_with_results(self):
+        mcp = AsyncMock()
+        call_count = 0
+
+        async def mock_call_tool(action, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:  # expired search
+                return {"results": [{"id": "m1"}, {"id": "m2"}]}
+            return {"results": [{"id": "m3"}]}  # expiring_soon search
+
+        mcp.call_tool = mock_call_tool
+        plugin = FactCheckerPlugin()
+        result = await plugin.process({"action": "scan_expiry"}, mcp)
+        assert result["expired_count"] == 2
+        assert result["expiring_soon_count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_process_default_action_is_verify(self):
+        """When no action is specified, defaults to verify."""
+        mcp = AsyncMock()
+        mcp.call_tool = AsyncMock(side_effect=RuntimeError("read failed"))
+        plugin = FactCheckerPlugin()
+        result = await plugin.process({"memory_id": "abc"}, mcp)
+        # Confirms it took the verify path (error from read attempt)
+        assert result["status"] == "error"
+        assert "failed to read memory" in result["reason"]
+
+    @pytest.mark.asyncio
+    async def test_stats_tracking(self):
+        plugin = FactCheckerPlugin()
+        assert plugin.stats == {
+            "checked": 0,
+            "expired": 0,
+            "expiring_soon": 0,
+            "verified": 0,
+        }
+
+    @pytest.mark.asyncio
+    async def test_on_start_logs(self, caplog):
+        plugin = FactCheckerPlugin()
+        config = AsyncMock()
+        mcp = AsyncMock()
+        with caplog.at_level("INFO"):
+            await plugin.on_start(config, mcp)
+        assert "fact checker started" in caplog.text
+        assert "CalendarPlugin" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_on_stop_logs(self, caplog):
+        plugin = FactCheckerPlugin()
+        with caplog.at_level("INFO"):
+            await plugin.on_stop()
+        assert "fact checker stats" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_report_failure_does_not_crash(self):
+        """If reporting a contradiction fails, the plugin logs and continues."""
+        mcp = AsyncMock()
+        past = (datetime.now(UTC) - timedelta(days=10)).isoformat()
+
+        call_count = 0
+
+        async def mock_call_tool(action, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if action == "read":
+                return {
+                    "memory": {
+                        "id": "abc",
+                        "relevant_until": past,
+                    }
+                }
+            if action == "report":
+                raise RuntimeError("MCP down")
+            return None
+
+        mcp.call_tool = mock_call_tool
+        plugin = FactCheckerPlugin()
+        result = await plugin.process(
+            {"action": "verify", "memory_id": "abc"}, mcp
+        )
+        # Should still return ok despite report failure
+        assert result["status"] == "ok"
+        assert result["results"][0]["verified"] is False


### PR DESCRIPTION
## Summary

Implements the Fact Checker curation agent using the shared `memoryhub-agents` framework. Scans for expired/expiring memories, verifies temporal claims via a pluggable verification architecture, and reports contradictions for verified-false claims.

Closes #287.

## Changes

- **FactCheckerPlugin**: Subclasses `AgentPlugin`. Two actions: `verify` (single memory) and `scan_expiry` (batch scan). Runs all applicable verification plugins per memory.
- **CalendarPlugin**: First shipped verification plugin. Checks `relevant_until` timestamps against current date. Reports contradictions for expired memories.
- **VerificationPlugin ABC**: Extensible architecture for domain-specific checkers (`can_verify()` + `verify()`).
- **CronJob manifest**: Daily at 01:00 UTC, `concurrencyPolicy: Allow` (idempotent operations).
- **Entry point**: `fact-checker` console_scripts command.

## Test plan

- [x] 25 new tests pass (CalendarPlugin verification, FactCheckerPlugin process/scan, stats tracking)
- [x] 39 existing framework tests pass (64 total)