### PR TITLE
agents: Implement Trace Reviewer with heuristic memory extraction

### DIFF
--- a/memoryhub-agents/deploy/trace-reviewer/deployment.yaml
+++ b/memoryhub-agents/deploy/trace-reviewer/deployment.yaml
@@ -1,0 +1,47 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: trace-reviewer
+  namespace: memoryhub-agents
+  labels:
+    app.kubernetes.io/name: trace-reviewer
+    app.kubernetes.io/part-of: memoryhub
+    app.kubernetes.io/component: agent
+spec:
+  replicas: 1  # HPA on trace_review_queue depth; set to 0 to disable
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: trace-reviewer
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: trace-reviewer
+        app.kubernetes.io/part-of: memoryhub
+        app.kubernetes.io/component: agent
+    spec:
+      serviceAccountName: trace-reviewer
+      containers:
+        - name: agent
+          image: memoryhub-agent:latest
+          command: ["trace-reviewer"]
+          env:
+            - name: AGENT_TYPE
+              value: "trace-reviewer"
+            - name: MH_MCP_URL
+              value: "http://memory-hub-mcp.memory-hub-mcp.svc:8000"
+            - name: MH_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: trace-reviewer-credentials
+                  key: api-key
+            - name: VALKEY_URL
+              value: "redis://valkey.memoryhub-agents.svc:6379"
+            - name: TENANT_ID
+              value: "default"
+          resources:
+            requests:
+              memory: 256Mi
+              cpu: 250m
+            limits:
+              memory: 512Mi
+              cpu: 500m

--- a/memoryhub-agents/pyproject.toml
+++ b/memoryhub-agents/pyproject.toml
@@ -15,5 +15,8 @@ dependencies = [
 [project.optional-dependencies]
 dev = ["pytest>=8.0", "pytest-asyncio>=0.23"]
 
+[project.scripts]
+trace-reviewer = "memoryhub_agents.plugins.run_trace_reviewer:main"
+
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/memoryhub-agents/src/memoryhub_agents/plugins/__init__.py
+++ b/memoryhub-agents/src/memoryhub_agents/plugins/__init__.py
@@ -1,0 +1,1 @@
+"""Agent plugins for MemoryHub curation agents."""

--- a/memoryhub-agents/src/memoryhub_agents/plugins/run_trace_reviewer.py
+++ b/memoryhub-agents/src/memoryhub_agents/plugins/run_trace_reviewer.py
@@ -1,0 +1,24 @@
+"""Entry point for the Trace Reviewer agent."""
+
+import asyncio
+import logging
+
+from memoryhub_agents.config import AgentConfig
+from memoryhub_agents.lifecycle import AgentRunner
+from memoryhub_agents.plugins.trace_reviewer import TraceReviewerPlugin
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(name)s %(levelname)s %(message)s",
+)
+
+
+def main() -> None:
+    config = AgentConfig()
+    plugin = TraceReviewerPlugin()
+    runner = AgentRunner(config, plugin)
+    asyncio.run(runner.run())
+
+
+if __name__ == "__main__":
+    main()

--- a/memoryhub-agents/src/memoryhub_agents/plugins/trace_reviewer.py
+++ b/memoryhub-agents/src/memoryhub_agents/plugins/trace_reviewer.py
@@ -1,0 +1,271 @@
+"""Trace Reviewer Agent plugin.
+
+Reviews conversation content to extract memories that working agents
+missed during sessions. Writes extracted memories with OBO ownership.
+
+Operates in degraded mode when conversation persistence (#168) is
+unavailable: expects thread content in the work item payload.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+
+from memoryhub_agents.config import AgentConfig
+from memoryhub_agents.lifecycle import AgentPlugin
+from memoryhub_agents.mcp_client import MCPSession
+
+logger = logging.getLogger(__name__)
+
+# Phrases that signal memory-worthy content in assistant messages.
+_SIGNAL_PHRASES = (
+    "we decided",
+    "the decision is",
+    "going forward",
+    "lesson learned",
+    "remember that",
+    "important:",
+    "always use",
+    "never use",
+    "prefer",
+    "convention is",
+    "the rule is",
+    "from now on",
+    "note to self",
+    "key takeaway",
+    "turns out that",
+)
+
+
+@dataclass
+class ExtractedMemory:
+    """A memory extracted from a conversation thread."""
+
+    content: str
+    scope: str
+    weight: float
+    domains: list[str] | None = None
+
+
+class TraceReviewerPlugin(AgentPlugin):
+    """Trace Reviewer agent plugin for the shared framework.
+
+    Work item payload (degraded mode)::
+
+        {
+            "thread_id": "uuid",
+            "owner_id": "user who owns the thread",
+            "messages": [
+                {"role": "user", "content": "..."},
+                {"role": "assistant", "content": "..."}
+            ],
+            "project_id": "optional project context"
+        }
+
+    Work item payload (full mode, requires #168)::
+
+        {
+            "thread_id": "uuid",
+            "action": "review"
+        }
+    """
+
+    def __init__(self) -> None:
+        self._stats: dict[str, int] = {
+            "reviewed": 0,
+            "extracted": 0,
+            "skipped": 0,
+            "errors": 0,
+        }
+
+    async def on_start(self, config: AgentConfig, mcp: MCPSession) -> None:
+        logger.info("trace reviewer started for tenant %s", config.tenant_id)
+
+    async def process(self, item: dict, mcp: MCPSession) -> dict:
+        """Process a single trace-review work item.
+
+        Validates the payload, extracts candidate memories via heuristic
+        signal-phrase matching, deduplicates against existing memories,
+        and writes new ones with OBO ownership.
+        """
+        thread_id = item.get("thread_id")
+        if not thread_id:
+            return {"status": "error", "reason": "missing thread_id"}
+
+        owner_id = item.get("owner_id")
+        if not owner_id:
+            return {"status": "error", "reason": "missing owner_id"}
+
+        messages = item.get("messages")
+        if not messages:
+            return {
+                "status": "error",
+                "reason": "missing messages (degraded mode requires messages in payload)",
+            }
+
+        self._stats["reviewed"] += 1
+
+        extracted = _extract_memories(messages)
+        if not extracted:
+            self._stats["skipped"] += 1
+            return {
+                "status": "ok",
+                "thread_id": thread_id,
+                "extracted": 0,
+                "reason": "no extractable memories",
+            }
+
+        written = await self._write_new_memories(extracted, item, mcp)
+        self._stats["extracted"] += written
+        return {
+            "status": "ok",
+            "thread_id": thread_id,
+            "extracted": written,
+            "candidates": len(extracted),
+        }
+
+    async def _write_new_memories(
+        self,
+        candidates: list[ExtractedMemory],
+        item: dict,
+        mcp: MCPSession,
+    ) -> int:
+        """Deduplicate candidates and write genuinely new memories."""
+        owner_id = item["owner_id"]
+        thread_id = item["thread_id"]
+        written = 0
+
+        for memory in candidates:
+            try:
+                search_result = await mcp.call_tool(
+                    "search",
+                    query=memory.content,
+                    options={"max_results": 3, "owner_id": owner_id},
+                )
+                results = []
+                if isinstance(search_result, dict):
+                    results = search_result.get("results", [])
+
+                if _has_near_duplicate(results, memory.content):
+                    continue
+
+                write_opts: dict = {
+                    "weight": memory.weight,
+                    "owner_id": owner_id,
+                    "driver_id": owner_id,
+                }
+                if memory.domains:
+                    write_opts["domains"] = memory.domains
+                if item.get("project_id"):
+                    write_opts["project_id"] = item["project_id"]
+
+                await mcp.call_tool(
+                    "write",
+                    content=memory.content,
+                    scope=memory.scope,
+                    options=write_opts,
+                )
+                written += 1
+
+            except Exception:
+                self._stats["errors"] += 1
+                logger.exception(
+                    "failed to write extracted memory from thread %s", thread_id
+                )
+
+        return written
+
+    async def on_stop(self) -> None:
+        logger.info("trace reviewer stats: %s", self._stats)
+
+    @property
+    def stats(self) -> dict[str, int]:
+        """Current processing statistics."""
+        return dict(self._stats)
+
+
+# ---------------------------------------------------------------------------
+# Extraction helpers (module-level, easily testable)
+# ---------------------------------------------------------------------------
+
+
+def _extract_memories(messages: list[dict]) -> list[ExtractedMemory]:
+    """Extract potential memories from conversation messages.
+
+    Uses heuristic signal-phrase matching on assistant messages.
+    Deliberately conservative -- only extracts when a signal phrase
+    is present and the surrounding sentence is long enough to be
+    meaningful. One extraction per message to avoid noise.
+    """
+    extracted: list[ExtractedMemory] = []
+
+    for msg in messages:
+        if msg.get("role") != "assistant":
+            continue
+        content = msg.get("content", "")
+        if not content or len(content) < 50:
+            continue
+
+        content_lower = content.lower()
+        for phrase in _SIGNAL_PHRASES:
+            if phrase in content_lower:
+                memory_content = _extract_around_phrase(content, phrase)
+                if memory_content and len(memory_content) >= 30:
+                    extracted.append(
+                        ExtractedMemory(
+                            content=memory_content,
+                            scope="user",
+                            weight=0.7,
+                        )
+                    )
+                break  # one extraction per message
+
+    return extracted
+
+
+def _extract_around_phrase(text: str, phrase: str) -> str | None:
+    """Extract the sentence containing a signal phrase.
+
+    Finds the nearest sentence boundaries (periods) around the phrase
+    and returns that slice, capped at 500 characters.
+    """
+    lower = text.lower()
+    idx = lower.find(phrase)
+    if idx < 0:
+        return None
+
+    # Find sentence boundaries
+    start = text.rfind(".", 0, idx)
+    start = start + 1 if start >= 0 else 0
+
+    end = text.find(".", idx + len(phrase))
+    end = end + 1 if end >= 0 else len(text)
+
+    result = text[start:end].strip()
+    if len(result) > 500:
+        result = result[:500]
+    return result
+
+
+def _has_near_duplicate(search_results: list, content: str) -> bool:
+    """Check if any search result is a near-duplicate of the content.
+
+    Uses token-level Jaccard similarity as a cheap heuristic.
+    Production would use embedding similarity from search scores.
+    """
+    for result in search_results:
+        if isinstance(result, dict):
+            existing = result.get("content", "")
+            if existing and _jaccard_similarity(existing, content) > 0.7:
+                return True
+    return False
+
+
+def _jaccard_similarity(a: str, b: str) -> float:
+    """Token-level Jaccard similarity between two strings."""
+    tokens_a = set(a.lower().split())
+    tokens_b = set(b.lower().split())
+    if not tokens_a or not tokens_b:
+        return 0.0
+    return len(tokens_a & tokens_b) / len(tokens_a | tokens_b)

--- a/memoryhub-agents/tests/test_trace_reviewer.py
+++ b/memoryhub-agents/tests/test_trace_reviewer.py
@@ -1,0 +1,409 @@
+"""Tests for the Trace Reviewer agent plugin."""
+
+import pytest
+from unittest.mock import AsyncMock
+
+from memoryhub_agents.plugins.trace_reviewer import (
+    ExtractedMemory,
+    TraceReviewerPlugin,
+    _extract_around_phrase,
+    _extract_memories,
+    _has_near_duplicate,
+    _jaccard_similarity,
+)
+
+
+# ---------------------------------------------------------------------------
+# ExtractedMemory dataclass
+# ---------------------------------------------------------------------------
+
+
+class TestExtractedMemory:
+    def test_construction(self):
+        m = ExtractedMemory(content="test", scope="user", weight=0.7)
+        assert m.content == "test"
+        assert m.scope == "user"
+        assert m.weight == 0.7
+        assert m.domains is None
+
+    def test_with_domains(self):
+        m = ExtractedMemory(
+            content="test", scope="project", weight=0.8, domains=["infra"]
+        )
+        assert m.domains == ["infra"]
+
+
+# ---------------------------------------------------------------------------
+# Jaccard similarity
+# ---------------------------------------------------------------------------
+
+
+class TestJaccardSimilarity:
+    def test_identical(self):
+        assert _jaccard_similarity("hello world", "hello world") == 1.0
+
+    def test_disjoint(self):
+        assert _jaccard_similarity("hello world", "foo bar") == 0.0
+
+    def test_partial_overlap(self):
+        sim = _jaccard_similarity("hello world foo", "hello world bar")
+        assert 0.0 < sim < 1.0
+
+    def test_empty_first(self):
+        assert _jaccard_similarity("", "hello") == 0.0
+
+    def test_empty_second(self):
+        assert _jaccard_similarity("hello", "") == 0.0
+
+    def test_both_empty(self):
+        assert _jaccard_similarity("", "") == 0.0
+
+    def test_case_insensitive(self):
+        assert _jaccard_similarity("Hello World", "hello world") == 1.0
+
+
+# ---------------------------------------------------------------------------
+# Near-duplicate detection
+# ---------------------------------------------------------------------------
+
+
+class TestHasNearDuplicate:
+    def test_no_results(self):
+        assert not _has_near_duplicate([], "some content")
+
+    def test_no_match(self):
+        results = [{"content": "completely different topic about databases"}]
+        assert not _has_near_duplicate(results, "weather forecast for tomorrow")
+
+    def test_match_above_threshold(self):
+        text = "We decided to use FastAPI for the web framework"
+        results = [{"content": text}]
+        assert _has_near_duplicate(results, text)
+
+    def test_non_dict_results_ignored(self):
+        results = ["not a dict", 42, None]
+        assert not _has_near_duplicate(results, "some content")
+
+    def test_missing_content_key(self):
+        results = [{"other_field": "value"}]
+        assert not _has_near_duplicate(results, "some content")
+
+
+# ---------------------------------------------------------------------------
+# Sentence extraction around signal phrases
+# ---------------------------------------------------------------------------
+
+
+class TestExtractAroundPhrase:
+    def test_single_sentence(self):
+        text = "We decided to use PostgreSQL for persistence."
+        result = _extract_around_phrase(text, "we decided")
+        assert result is not None
+        assert "PostgreSQL" in result
+
+    def test_multi_sentence_extracts_correct_one(self):
+        text = "First point. We decided to use FastAPI. Third point."
+        result = _extract_around_phrase(text, "we decided")
+        assert result is not None
+        assert "FastAPI" in result
+        assert "First point" not in result
+
+    def test_phrase_not_found(self):
+        assert _extract_around_phrase("hello world", "nonexistent") is None
+
+    def test_truncation_at_500(self):
+        long_text = "We decided " + "x" * 600 + "."
+        result = _extract_around_phrase(long_text, "we decided")
+        assert result is not None
+        assert len(result) <= 500
+
+    def test_no_trailing_period(self):
+        text = "We decided to go with option A"
+        result = _extract_around_phrase(text, "we decided")
+        assert result is not None
+        assert "option A" in result
+
+
+# ---------------------------------------------------------------------------
+# Memory extraction from messages
+# ---------------------------------------------------------------------------
+
+
+class TestExtractMemories:
+    def test_extracts_decision(self):
+        messages = [
+            {
+                "role": "assistant",
+                "content": (
+                    "After evaluating both options, we decided to use "
+                    "PostgreSQL for persistence because it supports "
+                    "pgvector natively."
+                ),
+            }
+        ]
+        extracted = _extract_memories(messages)
+        assert len(extracted) >= 1
+        assert "PostgreSQL" in extracted[0].content
+        assert extracted[0].scope == "user"
+        assert extracted[0].weight == 0.7
+
+    def test_skips_short_messages(self):
+        messages = [{"role": "assistant", "content": "ok"}]
+        assert _extract_memories(messages) == []
+
+    def test_skips_user_messages(self):
+        messages = [
+            {
+                "role": "user",
+                "content": (
+                    "We decided to use PostgreSQL for the backend "
+                    "database going forward with full support."
+                ),
+            }
+        ]
+        assert _extract_memories(messages) == []
+
+    def test_skips_no_signal_phrases(self):
+        messages = [
+            {
+                "role": "assistant",
+                "content": (
+                    "Here is the code you requested for the HTTP "
+                    "handler. It accepts a JSON body and returns a "
+                    "200 status code on success."
+                ),
+            }
+        ]
+        assert _extract_memories(messages) == []
+
+    def test_one_extraction_per_message(self):
+        messages = [
+            {
+                "role": "assistant",
+                "content": (
+                    "We decided to use FastAPI for the web framework "
+                    "because of async. The lesson learned is that "
+                    "Flask async support is quite limited in practice."
+                ),
+            }
+        ]
+        extracted = _extract_memories(messages)
+        assert len(extracted) == 1
+
+    def test_multiple_messages(self):
+        messages = [
+            {
+                "role": "assistant",
+                "content": (
+                    "We decided to use PostgreSQL for the database "
+                    "because of pgvector support."
+                ),
+            },
+            {
+                "role": "assistant",
+                "content": (
+                    "The key takeaway from this debugging session "
+                    "is that connection pooling matters."
+                ),
+            },
+        ]
+        extracted = _extract_memories(messages)
+        assert len(extracted) == 2
+
+    def test_empty_messages(self):
+        assert _extract_memories([]) == []
+
+    def test_skips_empty_content(self):
+        messages = [{"role": "assistant", "content": ""}]
+        assert _extract_memories(messages) == []
+
+
+# ---------------------------------------------------------------------------
+# TraceReviewerPlugin.process
+# ---------------------------------------------------------------------------
+
+
+class TestTraceReviewerProcess:
+    @pytest.fixture
+    def plugin(self):
+        return TraceReviewerPlugin()
+
+    @pytest.mark.asyncio
+    async def test_missing_thread_id(self, plugin):
+        result = await plugin.process({}, AsyncMock())
+        assert result["status"] == "error"
+        assert "thread_id" in result["reason"]
+
+    @pytest.mark.asyncio
+    async def test_missing_owner_id(self, plugin):
+        result = await plugin.process({"thread_id": "t1"}, AsyncMock())
+        assert result["status"] == "error"
+        assert "owner_id" in result["reason"]
+
+    @pytest.mark.asyncio
+    async def test_missing_messages(self, plugin):
+        item = {"thread_id": "t1", "owner_id": "u1"}
+        result = await plugin.process(item, AsyncMock())
+        assert result["status"] == "error"
+        assert "messages" in result["reason"]
+
+    @pytest.mark.asyncio
+    async def test_no_extractable_content(self, plugin):
+        mcp = AsyncMock()
+        item = {
+            "thread_id": "t1",
+            "owner_id": "u1",
+            "messages": [{"role": "assistant", "content": "ok done"}],
+        }
+        result = await plugin.process(item, mcp)
+        assert result["status"] == "ok"
+        assert result["extracted"] == 0
+        assert plugin.stats["skipped"] == 1
+
+    @pytest.mark.asyncio
+    async def test_extract_and_write(self, plugin):
+        mcp = AsyncMock()
+        mcp.call_tool = AsyncMock(return_value={"results": []})
+
+        item = {
+            "thread_id": "t1",
+            "owner_id": "u1",
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": (
+                        "After testing both approaches, we decided to "
+                        "use FastAPI over Flask because it has native "
+                        "async support and automatic OpenAPI generation."
+                    ),
+                }
+            ],
+        }
+        result = await plugin.process(item, mcp)
+        assert result["status"] == "ok"
+        assert result["extracted"] >= 1
+        assert plugin.stats["extracted"] >= 1
+        # Should have called search (dedup) and write
+        assert mcp.call_tool.call_count >= 2
+
+    @pytest.mark.asyncio
+    async def test_dedup_skips_existing(self, plugin):
+        mcp = AsyncMock()
+        mcp.call_tool = AsyncMock(
+            return_value={
+                "results": [
+                    {
+                        "content": (
+                            "We decided to use FastAPI over Flask because "
+                            "it has native async support and automatic "
+                            "OpenAPI generation."
+                        )
+                    }
+                ]
+            }
+        )
+
+        item = {
+            "thread_id": "t1",
+            "owner_id": "u1",
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": (
+                        "After testing both approaches, we decided to "
+                        "use FastAPI over Flask because it has native "
+                        "async support and automatic OpenAPI generation."
+                    ),
+                }
+            ],
+        }
+        result = await plugin.process(item, mcp)
+        assert result["status"] == "ok"
+        assert result["extracted"] == 0  # skipped as duplicate
+
+    @pytest.mark.asyncio
+    async def test_extract_with_project_id(self, plugin):
+        mcp = AsyncMock()
+        mcp.call_tool = AsyncMock(return_value={"results": []})
+
+        item = {
+            "thread_id": "t1",
+            "owner_id": "u1",
+            "project_id": "proj-1",
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": (
+                        "Going forward, all deployments must use the "
+                        "blue-green strategy to minimize downtime risk."
+                    ),
+                }
+            ],
+        }
+        result = await plugin.process(item, mcp)
+        assert result["status"] == "ok"
+        assert result["extracted"] >= 1
+
+        # Verify project_id was passed to the write call
+        write_calls = [
+            c
+            for c in mcp.call_tool.call_args_list
+            if c.args[0] == "write" or c.kwargs.get("action") == "write"
+        ]
+        assert len(write_calls) >= 1
+
+    @pytest.mark.asyncio
+    async def test_mcp_error_increments_error_stat(self, plugin):
+        mcp = AsyncMock()
+        mcp.call_tool = AsyncMock(side_effect=RuntimeError("connection lost"))
+
+        item = {
+            "thread_id": "t1",
+            "owner_id": "u1",
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": (
+                        "We decided to use PostgreSQL for everything "
+                        "because it handles both relational and vector "
+                        "data with pgvector."
+                    ),
+                }
+            ],
+        }
+        result = await plugin.process(item, mcp)
+        assert result["status"] == "ok"
+        assert result["extracted"] == 0
+        assert plugin.stats["errors"] >= 1
+
+    @pytest.mark.asyncio
+    async def test_stats_accumulate(self, plugin):
+        mcp = AsyncMock()
+        mcp.call_tool = AsyncMock(return_value={"results": []})
+
+        # Process two items: one with extractable content, one without
+        item_with = {
+            "thread_id": "t1",
+            "owner_id": "u1",
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": (
+                        "The key takeaway is that connection pooling "
+                        "significantly improves throughput under load."
+                    ),
+                }
+            ],
+        }
+        item_without = {
+            "thread_id": "t2",
+            "owner_id": "u1",
+            "messages": [{"role": "assistant", "content": "Done, merged the PR."}],
+        }
+
+        await plugin.process(item_with, mcp)
+        await plugin.process(item_without, mcp)
+
+        assert plugin.stats["reviewed"] == 2
+        assert plugin.stats["extracted"] >= 1
+        assert plugin.stats["skipped"] == 1


### PR DESCRIPTION
## Summary

Implements the Trace Reviewer curation agent using the shared `memoryhub-agents` framework. Extracts memories from conversation threads that working agents missed, writing them with OBO ownership. Runs in degraded mode (thread content in payload) until conversation persistence (#168) ships.

Closes #288.

## Changes

- **TraceReviewerPlugin**: Subclasses `AgentPlugin`. Conservative signal-phrase extraction from assistant messages. Dedup via Jaccard similarity against existing memories. OBO writes (owner_id = thread owner, actor_id = trace-reviewer).
- **Deployment manifest**: Event-driven Deployment (not CronJob), HPA-ready.
- **Entry point**: `trace-reviewer` console_scripts command.
- **Signal phrases**: "we decided", "lesson learned", "always use", "convention is", etc.

## Test plan

- [x] 36 new tests pass (extraction, dedup, Jaccard similarity, process flow, error handling)
- [x] 39 existing framework tests pass (75 total)