### PR TITLE
chore: Commit pending docs, research, and planning changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ backups/
 
 medium_article_1.pdf
 
+# Specs in progress
+specs/
+

--- a/docs/admin/content-moderation.md
+++ b/docs/admin/content-moderation.md
@@ -1,6 +1,6 @@
 # Content Moderation
 
-> Status: Draft -- expanding from skeleton
+> Status: Design complete -- open questions resolved 2026-06-30
 
 ## Problem
 
@@ -200,18 +200,20 @@ The content hash serves a specific purpose: after a spill cleanup, an automated 
 - **Memory `status` column**: Not yet defined in [storage-layer.md](../storage-layer.md). The `status` enum described above (`active`, `quarantined`, `soft_deleted`) requires a schema migration that adds a `status` column to `memory_nodes` and updates all read queries to filter by `status = 'active'` for non-admin callers. This is in-scope for the same milestone as `quarantine_memory`.
 - **`Identity` type**: A shared type passed into every core operation, capturing actor id, actor type (`user`, `service`, `worker`), tenant, and scopes. Defined as part of the core library scaffold.
 
-## Open Questions
+## Decisions (resolved 2026-06-30)
 
-- **Should `search_memory_admin` results have a TTL?** If the calling session holds search results in memory, those results are sensitive during a spill response. Should the server enforce an expiration, or is session-scoped lifetime sufficient? The current design relies on the session ending, but a long-running admin session could hold sensitive results indefinitely. This concern applies equally to MCP and BFF callers.
+These were open questions during the design phase. Resolved during backlog refinement.
 
-- **How do we verify completeness of a spill cleanup?** After deleting all matches, how does the admin confirm nothing was missed? Re-running the search should return zero results, but timing matters -- if new memories are being written concurrently, a race condition could introduce new instances. Should `bulk_delete_memories` temporarily block writes matching the search pattern?
+1. **Admin search result TTL.** Session-scoped lifetime is sufficient. No server-side expiration or TTL enforcement. If a long-running admin session becomes a concern, address it operationally (session timeouts) rather than adding application complexity.
 
-- **Should there be a "spill response" meta-operation?** A single core function that orchestrates the full search, review, confirm, delete flow would reduce the chance of operator error during a high-stress incident. The tradeoff is complexity -- a meta-operation is harder to test and harder to reason about than composing individual operations. If added, it lives in the core like everything else and is exposed via every transport.
+2. **Spill cleanup completeness verification.** Re-run the search after deletion; zero results means complete. No write-blocking for v1. The concurrent-write race is real but low-probability during an active spill response, and adding write-blocking introduces its own complexity and blast radius. Accept the race; document the "re-run search" verification step in the operator runbook.
 
-- **Integration with external incident management systems**: Should deletion audit entries be forwarded to an external system (ServiceNow, PagerDuty, etc.) as part of the operation, or is that a downstream consumer of the audit log?
+3. **"Spill response" meta-operation.** No. Compose individual operations (`search_memory_admin` -> review -> `bulk_delete_memories`). A meta-operation adds complexity and is harder to test. Revisit if operator error during spill response becomes a pattern.
 
-- **Embedding inversion risk quantification**: The requirement to delete embeddings is based on published research on inversion attacks. How realistic is this threat for our embedding model (all-MiniLM-L6-v2) and memory content lengths? This affects whether embedding deletion is a hard requirement or a defense-in-depth measure.
+4. **External incident management integration.** Out of scope. Audit log entries are the integration surface. Downstream consumers (ServiceNow, PagerDuty) consume the audit log; the admin operations do not push to external systems.
 
-- **Indexing for content_hash reintroduction detection**: The hash-based reintroduction check requires querying `request_context->>'content_hash'` across the audit log. The indexes defined in [governance.md](../governance.md) do not cover this access pattern. Options: a dedicated `content_hash` column on `audit_log`, a GIN index on `request_context`, or a separate `deletion_hashes` table populated as a side effect of sanitized deletions. The separate-table approach is probably cleanest because it isolates the access pattern from the audit log's append-only role.
+5. **Embedding inversion risk.** Defense in depth. Delete embeddings with the row (they're stored on the row, so this is automatic). No special treatment beyond ensuring the row is physically removed. The threat is real in research but low-probability for short content with our embedding model.
 
-- **Atomic audit-before-delete with the audit_writer role**: governance.md restricts audit log inserts to a dedicated `audit_writer` role with INSERT-only privileges. `hard_delete_memory` requires both an audit insert and a memory delete in the same transaction. This needs either (a) the application to switch roles mid-transaction via `SET LOCAL ROLE`, (b) a single role with both INSERT-on-audit and DELETE-on-memory permissions (weakening the audit_writer isolation), or (c) a stored procedure that runs as `SECURITY DEFINER` and encapsulates the audit-then-delete sequence. Option (c) is probably the right answer but needs validation.
+6. **content_hash reintroduction detection indexing.** Separate `deletion_hashes` table, populated as a side effect of sanitized deletions. This isolates the access pattern from the audit log's append-only role and avoids GIN index overhead on `request_context`.
+
+7. **Atomic audit-before-delete role isolation.** Stored procedure running as `SECURITY DEFINER` (option c). The procedure encapsulates the audit-insert-then-memory-delete sequence, runs with the privileges of the definer role (which has both INSERT on audit_log and DELETE on memory_nodes), and is callable by the application role. This preserves the audit_writer isolation for all non-admin paths while allowing the admin path to do both operations atomically.

--- a/planning/backlog-refinement-2026-06.md
+++ b/planning/backlog-refinement-2026-06.md
@@ -1,0 +1,319 @@
+# Backlog Refinement -- June 2026
+
+**Date:** 2026-06-30
+**Purpose:** Categorize all 50 open issues into loop-ready work vs design/judgment sessions, track progress through each.
+
+---
+
+## How to use this file
+
+Each section below represents a work batch. Within each batch, issues are grouped by the design/judgment session needed to unblock them, followed by the loop-ready execution work. Work through the design sessions in order, then execute the loops.
+
+**Status key:** `[ ]` not started, `[d]` design session done, `[x]` loop executed and complete
+
+---
+
+## 1. Benchmarking Suite
+
+Design doc: `planning/system-benchmarks.md`
+
+#275 (agent performance evaluation) decoupled and deferred to `priority:future` -- it's a research track, not a system benchmark. The four system benchmarks follow `tests/perf/` conventions (no shared base class, just shared metric functions and result file format).
+
+### Design session -- DONE (2026-06-30)
+
+Decisions made:
+- Follow existing `tests/perf/` pattern, not a new framework
+- Extract shared metrics (recall, precision, MRR, NDCG) to `tests/perf/metrics.py`
+- Each benchmark: engine module + test file + standalone script + JSON results
+- #100 folded into #274 (cross-encoder superset)
+- #275 deferred as separate research track
+
+### Manual prep (before loops)
+
+- [ ] Label 50-100 memories with ground-truth entities (for #272)
+- [ ] Design and label 50+ queries with expected results (for #273)
+
+### Loop targets (in execution order)
+
+- [ ] **#272** -- Entity extraction throughput and accuracy
+  - Prereq: labeled entity set exists
+  - Exit predicate: per-stage latency breakdown + accuracy metrics committed to `benchmarks/`
+- [ ] **#274** -- Cross-encoder re-ranking cost/benefit (subsumes #100)
+  - Prereq: none (extends existing benchmark)
+  - Exit predicate: optimal candidate set size identified, recommendation in results JSON
+- [ ] **#271** -- Retrieval latency and relevance at scale (100/1K/10K memories)
+  - Prereq: none (corpus generated programmatically)
+  - Exit predicate: all three scale tiers benchmarked, latency stable across 3 runs
+- [ ] **#273** -- Graph-traversal vs flat vector search
+  - Prereq: labeled query set exists
+  - Exit predicate: comparison report committed, pursue/skip/hybrid recommendation documented
+
+---
+
+## 2. MCP Server Plumbing
+
+### Design session -- DONE (2026-06-30)
+
+Decisions made:
+- #66 and #64 are independent, both loop-ready as-is (detailed acceptance criteria in issues)
+- #71 and #72 deferred to `priority:future` (both self-described as future work, depend on unshipped prerequisites)
+- #64 is not urgent (healthcare demo reference is stale)
+- Schema columns and Pydantic schemas for actor_id/driver_id already exist; #66 is purely MCP tool wiring
+
+### Loop targets (independent, either order)
+
+- [ ] **#66** -- Plumb actor_id and driver_id through tools and register_session
+  - Exit predicate: all tools accept and propagate actor_id/driver_id, tests pass
+- [ ] **#64** -- Implement project-scope membership enforcement
+  - Exit predicate: non-members rejected, members allowed, tests pass
+  - Not urgent; pick up when project isolation becomes a real need
+
+### Deferred (priority:future)
+
+- **#71** -- Intersection authorization (depends on #66 + #70)
+- **#72** -- driver_id redaction on read (depends on #71)
+
+---
+
+## 3. Domain Curation Patterns
+
+Structurally identical work across four domains, but blocked on demo script readiness.
+
+### Design session -- DONE (2026-06-30)
+
+Decisions made:
+- Demo goals are still solid, but scripts may need rework to reflect MemoryHub capabilities added since April
+- fips-agents team capability (in progress) may materially change how demos run -- wait for that to land before building demos
+- Curation patterns use demo scripts as their spec; can't loop until scripts are current
+- #93 (SME validation) stays open as a parallel human gate
+- The curation infrastructure (CuratorRule model, regex pipeline, layered rules) is ready -- no framework work needed
+
+### Prerequisite: demo script review
+
+- [ ] **Demo script freshness audit** -- Review all five demo scripts against current MemoryHub capabilities (entity extraction, curation pipeline, identity model, memory tree, threads). Flag sections that assume features we didn't have in April or miss features we've added since.
+  - Blocked on: fips-agents team capability landing (in progress)
+  - Output: per-script delta list, then update the scripts before building curation patterns
+
+### Loop targets (parallel, independent -- after demo scripts are current)
+
+- [ ] **#89** -- Cybersecurity domain curation patterns (credentials, exec ID redaction)
+  - Exit predicate: patterns defined, test fixtures pass, integrated with curation pipeline
+- [ ] **#90** -- Public-safety domain curation patterns (third-party PII, CI handling)
+  - Exit predicate: same as #89
+- [ ] **#91** -- Agriculture domain curation patterns (yield data, lease boundaries)
+  - Exit predicate: same as #89
+- [ ] **#92** -- Emergency-response domain curation patterns (resident PII, political dynamics)
+  - Exit predicate: same as #89
+
+### Related
+
+- [ ] **#93** -- SME validation outreach for 5 demo scenarios (tracking)
+  - Human-only gate, runs in parallel with implementation
+
+---
+
+## 4. Autonomous Curation Agents Epic (#281)
+
+Large epic with strict sequential phases. Design doc at `planning/autonomous-curation-agents.md`.
+
+### Design session -- DONE (2026-06-30)
+
+Decisions made:
+- #282 and #283 are independent prerequisites, both loop-ready now
+- #284 (OBO auth) is loop-ready but depends on #66 (actor_id/driver_id plumbing) landing first
+- #286 (shared framework) needs its own design session before agent implementations start
+- #292 (pattern surfacing) promoted out of epic -- independent read-path enhancement, no agent dependency
+- #290 and #291 deferred until agents are running and collecting data
+
+### Phase 0: Prerequisites (parallel loops, no design session needed)
+
+- [ ] **#282** -- Add relevant_until column and temporal classification
+  - Exit predicate: migration applied, temporal classifier tags memories at write time, tests pass
+- [ ] **#283** -- Deploy Valkey to memoryhub-agents namespace
+  - Exit predicate: Valkey pod running, queue keys accessible, kustomize manifests committed
+
+### Phase 0.5: OBO Auth (sequential, after section 2 loop)
+
+- [ ] **#284** -- Implement OBO authorization for service agents
+  - Depends on: #66 (actor_id/driver_id plumbing)
+  - Exit predicate: service agents can write with any owner_id in their scope, metadata_.actor_id auto-set, tests pass
+
+### Phase 1: Shared Framework (loop-ready -- design doc resolves open questions)
+
+- [ ] **#286** -- Build shared agent framework
+  - Design doc Section 13 answers all 8 open questions; recommendations confirmed 2026-06-30
+  - Single `memoryhub-agent` package, plugin modules per agent, single container image with AGENT_TYPE env var
+  - Exit predicate: package installable, lifecycle (auth/dequeue/process/report) works end-to-end with a test agent, leader election helper tested
+  - Blocks: all four agent implementations
+
+### Phase 2: Agent Implementations (after framework, loops)
+
+- [ ] **#285** -- Curator Agent (deep dedup, staleness, conflict detection)
+  - Exit predicate: CronJob runs on schedule, processes queue, dedup/staleness results verified
+- [ ] **#287** -- Fact Checker Agent (temporal expiry, verification plugins)
+  - Exit predicate: verifies facts, updates relevant_until, CalendarPlugin works, tests pass
+  - Can parallelize with #285 (most independent pair)
+- [ ] **#288** -- Trace Reviewer Agent (post-session memory extraction)
+  - Exit predicate: extracts memories from completed threads, OBO writes succeed
+  - Note: full mode needs conversation persistence (#168); basic mode works without
+- [ ] **#289** -- Statistician Agent (population-level pattern aggregation)
+  - Exit predicate: produces summary memories with convergence provenance
+
+### Phase 3+: Deferred (after agents are running)
+
+- **#290** -- Integrate Curator with five-stage promotion pipeline
+- **#291** -- Training data collection and per-agent fine-tuning
+
+### Promoted out of epic (standalone loop target)
+
+- [ ] **#292** -- Within-user pattern surfacing via search-time signals
+  - No agent dependency; read-path enhancement to existing search
+  - Exit predicate: search annotates results with pattern_signals when cluster detected, tests pass
+
+---
+
+## 5. Governance
+
+### Design session -- DONE (2026-06-30)
+
+Decisions made:
+- #67 (audit stub) is a clean standalone loop target -- fully specified, no design needed
+- #70 (LlamaStack telemetry) is a research/evaluation task, not blocking anything; keep as-is
+- #276 (access control design) -- concrete children already tracked (#64, #71, #72); recommend defer to `priority:future`
+- #277 already `priority:future`
+
+### Loop target
+
+- [ ] **#67** -- Add audit logging stub interface
+  - Exit predicate: `audit.py` created, all tools call `record_event` after auth decisions, structured JSON log lines verified
+
+### Research (not loop-shaped, not urgent)
+
+- [ ] **#70** -- Evaluate LlamaStack telemetry as audit persistence backend
+  - Replaces the stub from #67 when ready; evaluation criteria listed in issue
+
+### Deferred (priority:future)
+
+- ~~**#276**~~ -- Closed; concrete children tracked as #64, #71, #72
+- **#277** -- Design immutable audit trail schema
+
+---
+
+## 6. Auth
+
+### Design session -- DONE (2026-06-30)
+
+Decisions made:
+- #105 is fully specified (acceptance criteria, data model already tenant-aware). Loop-ready as-is.
+- #236 stays `priority:future`
+
+### Loop target
+
+- [ ] **#105** -- Tenant-scope memoryhub-auth admin API endpoints
+  - Exit predicate: admin API enforces tenant_id filter, BFF forwards tenant, cross-tenant returns 404, tests pass
+
+### Deferred (priority:future)
+
+- **#236** -- Design team agent identity model with delegated user access
+
+---
+
+## 7. UI
+
+### Design session -- DONE (2026-06-30)
+
+Decisions made:
+- No UI work is on the near-term horizon; all four issues deferred
+- #44 (local dev server) is the only loop-ready item but pointless without active UI work
+- #106 (Option B multi-tenant) has open design questions and Option A already works
+- #125 (welcome flow) explicitly not urgent until >10 contributors
+- Revisit this section when a UI development push is planned
+
+### Deferred (all -- revisit when UI work resumes)
+
+- **#109** -- Write UI design doc (writing task, not code)
+- **#106** -- Per-request BFF operator identity (design questions unresolved, Option A works)
+- **#125** -- Automate contributor welcome flow (not urgent at current contributor count)
+- **#44** -- Set up local dev server (loop-ready but no active UI work to justify it)
+
+---
+
+## 8. Remaining Individual Issues
+
+### Design session -- DONE (2026-06-30)
+
+Decisions made:
+- #100 already folded into #274 (section 1)
+- #99 closed (LlamaStack integration no longer active)
+- #87 deferred to `priority:future` (no active consumer for full-content push)
+- #82 kept (blocker #74 is closed; loop-ready as config + validation)
+- #45 kept (incident response, distinct from background curation agents)
+- #69 tied to demo fleet; blocked on same items as section 3 (fips-agents team capability)
+- #104 needs its own design session when session persistence becomes a priority
+
+### Loop targets
+
+- [ ] **#82** -- Integrate MemoryHub with LibreChat as second MCP client
+  - Blocker #74 (OAuth broker) is closed; no MemoryHub code changes needed
+  - Exit predicate: OAuth client registered, librechat.yaml configured, 8-step verification passes
+
+### Loop-ready (design doc resolves forks)
+
+- [ ] **#104** -- Persist session state across pod restarts
+  - Design doc at `planning/session-persistence.md` recommends Fork C (Valkey + no-op register_session under JWT + SDK retry); confirmed 2026-06-30
+  - Phase 1: Valkey persistence for app session map
+  - Phase 2: SDK transparent retry on "Session not found"
+  - Phase 3: Upstream FastMCP investigation (separate, non-blocking)
+  - Exit predicate: pod restart doesn't require SDK clients to re-register; push subscribers re-spawn lazily
+
+### Loop-ready (design doc found and open questions resolved)
+
+- [ ] **#45** -- Admin agent for content moderation and bulk deletion
+  - Design doc at `docs/admin/content-moderation.md` (issue had wrong path); 7 open questions resolved 2026-06-30
+  - Exit predicate: status column migration applied, four admin operations implemented, MCP tools exposed, authorization enforced (memory:admin + sub-scopes), audit trail works in normal + sanitized modes, tests pass
+
+### Blocked on demo work (section 3)
+
+- [ ] **#69** -- Agent generation CLI for demo fleet provisioning
+  - Also depends on #64 (project membership)
+
+### Deferred (priority:future)
+
+- **#87** -- Push notifications full-content delivery (no active consumer)
+- **#239** -- Convergent learning to consolidate duplicate memories
+- **#241** -- Evaluate pluggable storage backend adapter pattern
+- **#254** -- Multi-modal memory with text-stub + artifact retrieval
+- **#270** -- Semantic search over conversation message content
+
+---
+
+## 9. Large Design Documents (no near-term implementation)
+
+### Design session -- DONE (2026-06-30)
+
+Confirmed parked. Both are ambitious multi-subsystem designs with unshipped prerequisites. Not loop targets. Revisit when their dependencies (#168 conversation persistence, #170 graph-enhanced memory) start landing.
+
+- **#169** -- Context compaction services (ACE) -- needs design doc authored; builds on existing curator
+- **#171** -- Knowledge compilation -- builds on #168, #169, #170; "crown jewel" capability, furthest out
+
+---
+
+## Progress Log
+
+Track design sessions and loop executions here as they complete.
+
+| Date | Item | Type | Notes |
+|------|------|------|-------|
+| 2026-06-30 | Benchmarking suite design | Design session | #275 deferred as research; #100 folded into #274; design doc at planning/system-benchmarks.md |
+| 2026-06-30 | MCP server plumbing | Design session | #71, #72 deferred to future; #66, #64 are independent loop targets; #64 not urgent |
+| 2026-06-30 | Domain curation patterns | Design session | Blocked on demo script freshness audit + fips-agents team capability; curation infra is ready |
+| 2026-06-30 | Curation agents epic | Design session | Prerequisites loop-ready; #284 depends on #66; #286 needs own design session; #292 promoted out of epic; #290/#291 deferred |
+| 2026-06-30 | Governance | Design session | #67 is standalone loop target; #70 is research; #276 closed (children cover it); #277 stays future |
+| 2026-06-30 | Auth | Design session | #105 loop-ready as-is; #236 stays future |
+| 2026-06-30 | UI | Design session | All four deferred; no active UI work planned |
+| 2026-06-30 | Remaining issues | Design session | #99 closed; #87 deferred; #82 loop-ready; #104 loop-ready (design doc resolves forks); #45 needs design doc; #69 blocked on demos |
+| 2026-06-30 | Large design docs | Design session | #169, #171 confirmed parked; prerequisites unshipped |
+| 2026-06-30 | #286 shared framework | Promotion | Design doc resolves all 8 open questions; promoted from "needs design" to loop-ready |
+| 2026-06-30 | #104 session persistence | Promotion | Fork C confirmed; promoted from "needs design" to loop-ready |
+| 2026-06-30 | #45 content moderation | Promotion | Design doc found at docs/admin/content-moderation.md (issue had wrong path); 7 open questions resolved; promoted to loop-ready |
+| 2026-06-30 | Refinement complete | Milestone | 50 issues -> 47 open (3 closed), 14 loop-ready, next session doc written |

--- a/planning/system-benchmarks.md
+++ b/planning/system-benchmarks.md
@@ -1,0 +1,215 @@
+# System Benchmarks Framework
+
+**Status:** Design (for #271, #272, #273, #274)
+**Date:** 2026-06-30
+**Builds on:** `tests/perf/two_vector_bench.py` (existing retrieval benchmark)
+
+---
+
+## 1. Scope
+
+Four system benchmarks that measure MemoryHub infrastructure performance. These are *not* agent-level evaluation (that's #275, deferred to its own research track). Each benchmark produces reproducible numbers, commits results to git, and has a deterministic exit predicate suitable for autonomous loop execution.
+
+| Issue | Benchmark | Measures |
+|-------|-----------|----------|
+| #271 | Retrieval at scale | pgvector search latency + relevance across tenant sizes |
+| #274 | Cross-encoder cost/benefit | Re-ranking latency, NDCG/MRR delta, optimal candidate set size |
+| #272 | Entity extraction throughput | 3-stage cascade (spaCy/GLiNER2/LLM) latency + accuracy |
+| #273 | Graph vs flat retrieval | Relevance delta when using entity relationships for retrieval |
+
+## 2. Existing Infrastructure
+
+The two-vector retrieval benchmark (`tests/perf/`) establishes the pattern:
+
+- **Fixtures:** `tests/perf/fixtures/` -- synthetic memories and queries with ground-truth topic labels
+- **Engine:** `tests/perf/two_vector_bench.py` -- pipeline implementations, metric functions, sweep runner
+- **Script:** `scripts/bench-two-vector.py` -- standalone CLI that calls the engine, prints tables, writes JSON
+- **Results:** `benchmarks/*.json` -- timestamped result files committed to git
+- **Test integration:** `pytest -m perf` -- opt-in marker via `tests/perf/conftest.py`
+- **Metrics:** recall@k, precision@k, MRR, with aggregation by (pipeline, condition, weight)
+
+This is a good pattern. The new benchmarks should follow it rather than introducing new tooling.
+
+## 3. Shared Conventions (Not a Framework)
+
+After reviewing the existing benchmark, a shared base class would be premature abstraction. The four benchmarks differ enough in what they measure that a common `BenchmarkRunner` would either be too generic to be useful or would force awkward inheritance. Instead, enforce conventions:
+
+### Directory structure
+
+```
+tests/perf/
+  conftest.py                          # existing -- auto-marks as 'perf'
+  two_vector_bench.py                  # existing
+  test_two_vector_retrieval.py         # existing
+  fixtures/                            # existing
+    queries.py
+    topics/
+  retrieval_scale_bench.py             # #271
+  test_retrieval_scale.py              # #271
+  cross_encoder_bench.py               # #274
+  test_cross_encoder.py                # #274
+  entity_extraction_bench.py           # #272
+  test_entity_extraction.py            # #272
+  graph_retrieval_bench.py             # #273
+  test_graph_retrieval.py              # #273
+  fixtures/
+    scale_corpus/                      # #271 -- generated at seed time
+    labeled_entities/                  # #272 -- manually labeled
+    graph_queries/                     # #273 -- queries with expected results
+
+scripts/
+  bench-two-vector.py                  # existing
+  bench-retrieval-scale.py             # #271
+  bench-cross-encoder.py               # #274
+  bench-entity-extraction.py           # #272
+  bench-graph-retrieval.py             # #273
+
+benchmarks/
+  two-vector-retrieval-*.json          # existing
+  retrieval-scale-*.json               # #271
+  cross-encoder-*.json                 # #274
+  entity-extraction-*.json             # #272
+  graph-retrieval-*.json               # #273
+```
+
+### Result file format
+
+Every benchmark writes a JSON file to `benchmarks/` with this envelope:
+
+```json
+{
+  "benchmark": "retrieval-scale",
+  "timestamp": "2026-07-01T14:30:00Z",
+  "config": {
+    "corpus_sizes": [100, 1000, 10000],
+    "embedding_url": "https://...",
+    "hardware": "auto-detected or manually noted"
+  },
+  "results": { },
+  "timing": {
+    "total_seconds": 120.5,
+    "phase_breakdown": {}
+  }
+}
+```
+
+The `results` shape is benchmark-specific. The envelope is just timestamp + config + timing so results are self-documenting.
+
+### Metric functions
+
+The existing `recall_at_k`, `precision_at_k`, `mrr` functions in `two_vector_bench.py` should be extracted to a shared `tests/perf/metrics.py` module so all benchmarks can reuse them. Add NDCG as well (needed for #274). This is the only shared code.
+
+### pytest integration
+
+Each benchmark gets a test file that runs a minimal subset (smallest corpus, fewest iterations) to verify the benchmark doesn't crash. The full sweep runs via the standalone script. All tests auto-inherit the `perf` marker from `conftest.py`.
+
+## 4. Per-Benchmark Design
+
+### #271: Retrieval at Scale
+
+**What it measures:** pgvector search latency and relevance as tenant memory count grows.
+
+**Corpus generation:** Seed synthetic memories at 100, 1K, and 10K per tenant. Use the existing topic-based fixture pattern but scale it. Memories should have realistic content length and embedding diversity (not just copies of the same 200 memories).
+
+**Metrics:**
+- Search latency: p50, p95, p99 at each scale
+- Relevance: recall@10, precision@10, MRR against topic-labeled ground truth
+- Embedding throughput: memories/second during corpus seeding
+- Connection pool behavior: concurrent search latency under 1/5/10 parallel queries
+
+**Target environment:** Deployed PostgreSQL + pgvector on the mcp-rhoai cluster. Not a local SQLite test -- the point is to measure real infrastructure.
+
+**Exit predicate for loop:** Results JSON exists for all three scale tiers, latency numbers are within 10% across 3 consecutive runs, report committed.
+
+### #274: Cross-Encoder Cost/Benefit
+
+**What it measures:** Whether the cross-encoder re-ranking step is worth its cost.
+
+**Extends:** The existing two-vector benchmark already measures cross-encoder impact (NEW-1/NEW-3 vs baseline). This benchmark varies the *candidate set size* (10, 25, 50, 100) to find the diminishing returns threshold.
+
+**Metrics:**
+- Re-ranking latency per call at each candidate set size
+- NDCG and MRR delta: vector-only vs vector+reranker
+- Resource consumption: CPU/memory per rerank call (from pod metrics)
+- Recommendation: optimal candidate set size for production
+
+**Target environment:** Deployed reranker service on mcp-rhoai.
+
+**Relationship to #100:** #100 asks to re-benchmark the cross-encoder on real production memories. #274 is the superset -- fold #100 into #274 by running against both synthetic and production data.
+
+**Exit predicate for loop:** Results JSON exists, optimal candidate set size identified, recommendation documented in results file.
+
+### #272: Entity Extraction Throughput
+
+**What it measures:** The 3-stage extraction cascade (spaCy -> GLiNER2 -> LLM fallback) performance.
+
+**Labeled evaluation set:** Manually label 50-100 memories with ground-truth entities (person, organization, technology, location). Store in `tests/perf/fixtures/labeled_entities/`. This is the one manual judgment step; the rest is mechanical.
+
+**Metrics:**
+- Per-stage latency: spaCy, GLiNER2, LLM fallback
+- End-to-end extraction time per memory
+- Backfill rate: memories/minute
+- Accuracy: precision/recall per entity type against labeled set
+- Stage promotion rates: what % need Stage 2? Stage 3?
+- Resource consumption: CPU, memory, GPU
+
+**Target environment:** Local (extraction runs in-process with local models, no cluster dependency).
+
+**Exit predicate for loop:** Labeled set exists, benchmark runs clean, per-stage breakdown committed, accuracy numbers stable.
+
+### #273: Graph vs Flat Retrieval
+
+**What it measures:** Whether following entity relationships surfaces better results than vector similarity alone.
+
+**Prerequisites:** Entity extraction must be running (it is -- shipped in the June extraction sprint). The relationship model must have enough data to test traversal. This may need a seeded graph corpus.
+
+**Evaluation approach:**
+1. Build a test corpus of 50+ queries with manually labeled "expected relevant memories"
+2. For each query, compare: (a) flat vector search results, (b) graph-augmented results (follow entity edges from top vector hits to find related memories)
+3. Measure relevance delta, latency cost, and result diversity
+
+**Metrics:**
+- Recall@10, precision@10, MRR for flat vs graph-augmented
+- Latency cost of graph traversal (extra DB queries)
+- Result diversity: Jaccard distance between flat and graph result sets
+- Qualitative: are the extra results actually useful, or just noise?
+
+**Judgment required:** The labeled query set is the hardest part. The queries need to be designed so that graph relationships *could* help (e.g., "what do we know about project X?" where some memories mention project X by name and others are linked via entity relationships but don't mention it in text).
+
+**Exit predicate for loop:** Labeled query set exists, both retrieval paths benchmarked, comparison report committed, clear recommendation (pursue/skip/hybrid) documented.
+
+## 5. Loop Execution Plan
+
+Each benchmark is an autonomous loop target with this structure:
+
+```
+1. Check prerequisites (deployed services, fixtures exist)
+2. Generate/seed test corpus if needed
+3. Run benchmark sweep
+4. Collect metrics into JSON
+5. Verify stability (re-run, compare to prior run)
+6. Commit results to benchmarks/
+7. Exit: results file exists, numbers stable, report committed
+```
+
+### Execution order
+
+1. **#272 (entity extraction)** -- runs locally, no cluster dependency, fast feedback
+2. **#274 (cross-encoder)** -- extends existing benchmark, most infrastructure already in place
+3. **#271 (retrieval at scale)** -- needs corpus generation, more setup
+4. **#273 (graph vs flat)** -- most judgment needed (labeled query set), last
+
+### Manual steps required before loops can run
+
+| Benchmark | Manual step | Effort |
+|-----------|-------------|--------|
+| #272 | Label 50-100 memories with ground-truth entities | 2-3 hours |
+| #273 | Design and label 50+ queries with expected results | 3-4 hours |
+| #271 | None (corpus is generated programmatically) | -- |
+| #274 | None (extends existing benchmark) | -- |
+
+#274 and #271 are fully automatable. #272 and #273 need labeled data first.
+
+## 6. Folding #100
+
+Issue #100 (re-benchmark NEW-1 cross-encoder on real production memories) should be closed as subsumed by #274. Add a comment on #100 pointing to #274 and close it.

--- a/planning/turn-level-hooks.md
+++ b/planning/turn-level-hooks.md
@@ -1,0 +1,256 @@
+# Turn-Level Hooks for MemoryHub
+
+Status: Draft
+Date: 2026-07-08
+
+## Problem
+
+MemoryHub's current hook integration is session-level only: a `SessionStart` shell hook pre-loads memories via the CLI, and mid-session operations require the agent to explicitly call MCP tools. This creates two gaps:
+
+1. **Write-back depends on agent initiative.** The agent must decide "I should save this" and call `write_memory`. Agents frequently forget, especially under context pressure or when the conversation shifts quickly.
+2. **Pivot detection is prompt-instruction-only.** The `.claude/rules/memoryhub-loading.md` file tells the agent to call `search_memory` on topic pivots, but compliance is inconsistent. A hook that fires on every user turn could automate relevance search without relying on agent judgment.
+
+Turn-level hooks would let MemoryHub **automatically extract memories after each model response** and **re-bias context before each user turn is processed**, without the agent needing to do anything.
+
+## Use Cases
+
+**Post-turn write-back.** After the model responds, a hook extracts decisions, preferences, and facts from the conversation delta and persists them. The agent never needs to call `write_memory`.
+
+**Pre-turn re-bias.** Before the model sees a new user message, a hook searches for memories relevant to the message content and injects them as context. This replaces the unreliable "detect pivots via prompt instructions" pattern.
+
+**Contradiction detection.** A post-turn hook could compare newly extracted facts against existing memories and flag contradictions before they propagate.
+
+## Harness Landscape
+
+Research conducted July 2026. Sources verified via adversarial 3-vote protocol.
+
+### Claude Code
+
+The richest hook system of the four verified harnesses.
+
+**Relevant events:**
+- `UserPromptSubmit` -- fires after user submits, before model processes. Payload includes `prompt` (full user message text), `session_id`, `cwd`.
+- `Stop` -- fires after model finishes responding. Payload includes `last_assistant_message`, `stop_reason`.
+- `PreToolUse` / `PostToolUse` -- per-tool-call hooks with `tool_name`, `tool_input`, `tool_response`.
+
+**Context injection:** All events support `additionalContext` in hook stdout (JSON). Injected as a system reminder, invisible in chat UI. 10K character cap.
+
+**Blocking/modification:** Exit code 2 blocks the action. `PreToolUse` supports `updatedInput` to rewrite tool arguments. `PostToolUse` supports `updatedToolOutput`.
+
+**Configuration:** `settings.json` at user or project scope. Shell commands with `matcher`, `timeout`, `type: "command"`.
+
+**MemoryHub fit:** Excellent. `UserPromptSubmit` provides the user's message for relevance search; `additionalContext` injects results. `Stop` provides the model's response for extraction.
+
+Sources: [code.claude.com/docs/en/hooks](https://code.claude.com/docs/en/hooks) (verified 3-0)
+
+### OpenAI Codex CLI
+
+Mirrors Claude Code's event model almost exactly.
+
+**Relevant events:** Same 10 events as Claude Code: `SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PostToolUse`, `PermissionRequest`, `Stop`, `SubagentStart`, `SubagentStop`, `PreCompact`, `PostCompact`.
+
+**Configuration:** `hooks.json` or inline TOML at `~/.codex/` (user) or `<repo>/.codex/` (project). Same `matcher`, `type`, `command`, `timeout` structure. Trust gating required.
+
+**Limitations:** Only `command`-type handlers execute at runtime. `prompt` and `agent` handler types are parsed but not yet invoked. Payload schemas and `additionalContext` support are documented on the Hooks page but independent verification of Codex-specific payloads vs. Claude Code payloads was not fully established -- the two systems may share a schema wholesale.
+
+**MemoryHub fit:** Good, assuming payload parity with Claude Code. Same integration pattern would work.
+
+Sources: [developers.openai.com/codex/hooks](https://developers.openai.com/codex/hooks), [developers.openai.com/codex/config-reference](https://developers.openai.com/codex/config-reference), [developers.openai.com/codex/config-advanced](https://developers.openai.com/codex/config-advanced) (verified 3-0)
+
+### OpenCode
+
+Plugin-based middleware system, TypeScript/JavaScript.
+
+**Relevant events:**
+- `tool.execute.before` -- fires before tool runs. Receives tool name and modifiable args. Block by throwing an error.
+- `message.updated` -- per-message event with `role` and `content` fields. User text is accessible.
+- `experimental.session.compacting` -- fires before context compaction. Supports context injection via `output.context` array or full prompt replacement via `output.prompt`.
+- `session.idle`, `session.created` -- session lifecycle.
+
+**Context injection:** The compaction hook supports `output.context` injection. Per-message context injection paths are less well-documented.
+
+**Blocking/modification:** `tool.execute.before` blocks via thrown error, modifies via `output.args`. A stop hook can re-prompt the agent via `client.session.prompt()`.
+
+**Configuration:** TypeScript plugin modules exporting a hooks object. No shell-command hooks.
+
+**MemoryHub fit:** Moderate. The plugin model means MemoryHub would need a published npm package or a TypeScript wrapper around the CLI. `message.updated` provides user text access but payload schemas aren't fully documented in official docs (community gist is the best source).
+
+Sources: [opencode.ai/docs/plugins/](https://opencode.ai/docs/plugins/) (verified 3-0 for tool/compaction), [community gist](https://gist.github.com/johnlindquist/0adf1032b4e84942f3e1050aba3c5e4a) (2-1 for message payloads)
+
+### Hermes Agent (Nous Research)
+
+Three hook systems: Gateway YAML, Plugin Python, Shell config.
+
+**Relevant events:**
+- `pre_llm_call` (Plugin hook) -- fires once per turn before the LLM call. Receives `user_message` (full string) and `conversation_history` (OpenAI message format).
+- `post_llm_call` (Plugin hook) -- fires after LLM response.
+- Gateway hooks (`HOOK.yaml` in `~/.hermes/hooks/`) and Shell hooks (`hooks:` block in `~/.hermes/config.yaml`) provide additional integration points.
+
+**Context injection:** `pre_llm_call` supports ephemeral context injection via `{"context": "text"}` return value. Context is appended to the user message (not the system prompt) to preserve prompt cache.
+
+**Blocking/modification:** All hook systems are non-blocking by design -- errors are logged but never crash the agent. Whether `pre_llm_call` can block or rewrite the user message (beyond appending context) is undocumented.
+
+**Configuration:** Plugin hooks via `ctx.register_hook()` in Python. Gateway hooks via YAML files. Shell hooks via config YAML.
+
+**MemoryHub fit:** Good for the Python plugin path. `pre_llm_call` provides exactly the right payload (user message + history) for relevance search, and context injection is first-class. The Python plugin model aligns naturally with MemoryHub's Python SDK.
+
+Sources: [hermes-agent.nousresearch.com/docs/user-guide/features/hooks/](https://hermes-agent.nousresearch.com/docs/user-guide/features/hooks/) (verified 3-0)
+
+### OpenClaw
+
+**Does not appear to exist** as a recognized AI coding agent harness. No documentation, repository, or credible sources were found. Dropped from scope.
+
+## Proposed Architecture
+
+### New CLI Subcommands
+
+Two new subcommands on the `memoryhub` CLI, designed to be called from hook scripts:
+
+```
+memoryhub rebias <user-message-file>
+    --project-id <id>
+    --output compact
+    --max 10
+```
+
+Reads the user's new message from a file (or stdin), runs a relevance search against existing memories, and prints results in the compact content-only format. Designed for pre-turn hooks (`UserPromptSubmit`, `pre_llm_call`, `message.updated`).
+
+```
+memoryhub extract <conversation-delta-file>
+    --project-id <id>
+    --session-id <id>
+```
+
+Reads a conversation delta (the latest assistant turn) from a file or stdin, extracts facts/decisions/preferences, and writes them as memories. Designed for post-turn hooks (`Stop`, `post_llm_call`). Calls the MCP server's extraction endpoint.
+
+Both commands:
+- Read credentials from `~/.config/memoryhub/api-key` (same as session-start hook)
+- Exit 0 on all failures (graceful degradation)
+- Respect the same `--output compact` format to avoid metadata leaking into agent context
+
+### Harness Integration Matrix
+
+| Capability | Claude Code | Codex CLI | OpenCode | Hermes |
+|------------|------------|-----------|----------|--------|
+| **Pre-turn re-bias** | `UserPromptSubmit` hook calls `memoryhub rebias`, injects via `additionalContext` | Same pattern | `message.updated` plugin calls rebias, injects via compaction hook | `pre_llm_call` plugin calls `memoryhub rebias`, returns `{"context": ...}` |
+| **Post-turn extract** | `Stop` hook calls `memoryhub extract` with `last_assistant_message` | Same pattern | Plugin on model response event | `post_llm_call` plugin calls `memoryhub extract` |
+| **Integration artifact** | Shell script + settings.json | Shell script + hooks.json | TypeScript plugin (npm package) | Python plugin (pip package) |
+| **User message accessible?** | Yes (`prompt` field) | Yes (assumed parity) | Yes (`content` field, 2-1 confidence) | Yes (`user_message` field) |
+| **Model response accessible?** | Yes (`last_assistant_message`) | Likely (assumed parity) | Unclear (payload underdocumented) | Yes (`post_llm_call` payload) |
+| **Context injection method** | `additionalContext` (10K cap) | `additionalContext` (assumed) | `output.context` array | `{"context": "..."}` return |
+
+### Reference Implementation Priority
+
+1. **Claude Code** -- primary target, best-documented, already has session-start hook. Extend with `UserPromptSubmit` and `Stop` hooks.
+2. **Hermes** -- Python-native, clean plugin model, good payload access.
+3. **Codex CLI** -- near-identical to Claude Code, likely works with same scripts.
+4. **OpenCode** -- requires TypeScript artifact, less mature payload docs.
+
+### Hook Script Design (Claude Code reference)
+
+**Pre-turn re-bias** (`.claude/hooks/rebias-memories.sh`):
+
+```bash
+#!/bin/bash
+set -euo pipefail
+
+API_KEY_FILE="$HOME/.config/memoryhub/api-key"
+[ -f "$API_KEY_FILE" ] || exit 0
+export MEMORYHUB_API_KEY=$(tr -d '\n' < "$API_KEY_FILE")
+
+# User message arrives as JSON on stdin from Claude Code
+USER_MSG=$(cat | python3 -c "import json,sys; print(json.load(sys.stdin).get('prompt',''))" 2>/dev/null) || exit 0
+[ -n "$USER_MSG" ] || exit 0
+
+MEMORYHUB_BIN="${CLAUDE_PROJECT_DIR:-$PWD}/.venv/bin/memoryhub"
+[ -x "$MEMORYHUB_BIN" ] || MEMORYHUB_BIN=$(command -v memoryhub 2>/dev/null) || exit 0
+
+PROJECT_ID=$(basename "${CLAUDE_PROJECT_DIR:-$PWD}")
+
+RESULTS=$("$MEMORYHUB_BIN" rebias "$USER_MSG" \
+  --project-id "$PROJECT_ID" \
+  --output compact \
+  --max 10 2>/dev/null) || exit 0
+
+[ -n "$RESULTS" ] || exit 0
+
+# Inject as additionalContext
+python3 -c "import json; print(json.dumps({'additionalContext': '$RESULTS'}))"
+```
+
+**Post-turn extract** (`.claude/hooks/extract-memories.sh`):
+
+```bash
+#!/bin/bash
+set -euo pipefail
+
+API_KEY_FILE="$HOME/.config/memoryhub/api-key"
+[ -f "$API_KEY_FILE" ] || exit 0
+export MEMORYHUB_API_KEY=$(tr -d '\n' < "$API_KEY_FILE")
+
+# Model response arrives as JSON on stdin
+RESPONSE=$(cat | python3 -c "import json,sys; print(json.load(sys.stdin).get('last_assistant_message',''))" 2>/dev/null) || exit 0
+[ -n "$RESPONSE" ] || exit 0
+
+MEMORYHUB_BIN="${CLAUDE_PROJECT_DIR:-$PWD}/.venv/bin/memoryhub"
+[ -x "$MEMORYHUB_BIN" ] || MEMORYHUB_BIN=$(command -v memoryhub 2>/dev/null) || exit 0
+
+PROJECT_ID=$(basename "${CLAUDE_PROJECT_DIR:-$PWD}")
+
+"$MEMORYHUB_BIN" extract --project-id "$PROJECT_ID" --session-id "$SESSION_ID" <<< "$RESPONSE" 2>/dev/null || exit 0
+```
+
+**settings.json additions:**
+
+```json
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "matcher": "",
+        "hooks": [{
+          "type": "command",
+          "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/rebias-memories.sh",
+          "timeout": 3
+        }]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [{
+          "type": "command",
+          "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/extract-memories.sh",
+          "timeout": 5
+        }]
+      }
+    ]
+  }
+}
+```
+
+## Performance Considerations
+
+**Latency budget.** Pre-turn hooks add latency before the user sees the model start thinking. Target: < 500ms for rebias (relevance search is fast). Post-turn hooks run after the response and don't block the user.
+
+**Token budget.** The `additionalContext` injection has a 10K character cap in Claude Code. The compact format keeps memories small (typically 50-100 chars each). 10 memories at ~80 chars = ~800 chars, well within budget.
+
+**Extraction cost.** The `extract` command calls the server's extraction endpoint, which may use an LLM. This is the most expensive operation. Consider: (a) only extracting on turns longer than N characters, (b) batching extraction every K turns, (c) using a small/fast model for extraction.
+
+**Deduplication.** The extraction endpoint must deduplicate against existing memories to avoid writing the same fact on every turn. This is a server-side concern, not a hook concern.
+
+## Open Questions
+
+1. **Codex payload parity.** Does Codex CLI actually support `additionalContext` injection, or did the research conflate it with Claude Code? Needs hands-on verification.
+2. **OpenCode message payloads.** The `message.updated` event payload is documented only in a community gist. Is this stable enough to target?
+3. **Hermes blocking.** Can `pre_llm_call` block a turn (e.g., if the memory system detects a dangerous contradiction), or is it inject-only?
+4. **Extraction model.** Should extraction run locally (fast, no network) or server-side (better quality, shared extraction logic)?
+5. **Opt-in granularity.** Should users be able to enable rebias but not extraction (or vice versa)?
+6. **Other harnesses.** Aider, Continue, Cursor, and Windsurf were not researched. Should they be in scope?
+
+## Relationship to Existing Work
+
+- **SessionStart hook** (`docs/hooks-integration.md`): Turn-level hooks extend this. The session-start hook handles cold-start; turn-level hooks handle mid-session re-bias and continuous extraction.
+- **MCP tools** (`search_memory`, `write_memory`): Turn-level hooks reduce but don't eliminate the need for explicit MCP calls. Agents may still want to search or write on their own initiative.
+- **`.claude/rules/memoryhub-loading.md`**: The pivot-detection instructions become a fallback for harnesses that don't support turn-level hooks, rather than the primary mechanism.
+- **Token compression** (`planning/token-compression.md`): Turn-level context injection interacts with compaction. PreCompact/PostCompact hooks may be relevant for preserving memory context across compactions.

--- a/research/agent-memory-landscape-2026.md
+++ b/research/agent-memory-landscape-2026.md
@@ -1,6 +1,6 @@
-# Agent Memory Landscape Analysis (May 2026)
+# Agent Memory Landscape Analysis (2026)
 
-This document surveys the emerging agent memory landscape through three external sources and maps their findings to MemoryHub's architecture, identifying validations, gaps, and design guardrails.
+This document surveys the emerging agent memory landscape through external sources and maps their findings to MemoryHub's architecture, identifying validations, gaps, and design guardrails.
 
 ## Sources
 
@@ -18,6 +18,11 @@ This document surveys the emerging agent memory landscape through three external
    Author: Michael Sakhatsky
    Published: April 2026
    Focus: Critique of the assumption chain from "we need institutional knowledge" to "we need Neo4j"; case for rules engines and Datalog over graph databases.
+
+4. **"Self-Improving Memory for Agents" (Perplexity Brain)**
+   Published: June 18, 2026
+   Focus: Production memory system for Perplexity's "Computer" agent; context graph + overnight synthesis + LLM wiki injection.
+   Full analysis: [perplexity-brain-analysis.md](perplexity-brain-analysis.md)
 
 Additionally, **Neo4j Agent Memory** (neo4j-labs/agent-memory, v0.2-0.3) was reviewed as the most direct open-source competitor.
 
@@ -287,3 +292,5 @@ Neo4j Agent Memory is a graph-first system that happens to support agents. Memor
 | #240 | SDK extraction pipeline for agent trace observation | Neo4j Agent Memory comparison, Gartner context graphs |
 
 Additionally, #170 (graph-enhanced memory) was prioritized to near-term, informed by all three sources. Design guardrails from Sakhatsky's critique should be applied when scoping that work.
+
+Perplexity Brain (June 2026) validates ACE (#169) and extraction pipeline (#240) urgency -- Brain's overnight synthesis loop is production proof that automated memory compaction and pattern extraction have measurable impact (+25% correctness, -13% cost on context-dependent tasks). See [perplexity-brain-analysis.md](perplexity-brain-analysis.md) for the full comparison.

--- a/research/okf-open-knowledge-format.md
+++ b/research/okf-open-knowledge-format.md
@@ -1,0 +1,90 @@
+# Google's Open Knowledge Format (OKF): Analysis for MemoryHub
+
+**Date**: June 2026
+**Purpose**: Analyze Google's Open Knowledge Format v0.1 spec and its implications for MemoryHub's MemoryHub/RetrievalHub strategy
+**Status**: Research analysis
+
+---
+
+## 1. What OKF Is
+
+Open Knowledge Format (OKF) v0.1 is a draft specification from Google, released under the GoogleCloudPlatform/knowledge-catalog repository (Apache 2.0). Knowledge Catalog is Google Cloud's rebranded Dataplex, their AI-powered data catalog and metadata management platform. OKF is the interchange format for that product, but designed to be vendor-neutral.
+
+The core data model has three concepts:
+
+- **Knowledge Bundle**: A self-contained, hierarchical collection of knowledge documents. The unit of distribution. A bundle is a directory of markdown files with YAML frontmatter, no schema registry, no required tooling.
+- **Concept**: A single unit of knowledge, represented as one markdown file. Concepts can describe tangible assets (BigQuery tables, REST APIs) or abstract ideas (business metrics, operational playbooks). The concept ID is the file path with `.md` removed.
+- **Links and Citations**: Standard markdown links between concepts express relationships. Links from concepts to external sources are citations. Link semantics are conveyed by surrounding prose, not by link metadata. Consumers treat all links as directed edges of untyped relationships.
+
+The spec is aggressively minimal. The only required field is `type` (a free-form string, not drawn from a central registry). Recommended fields include title, description, resource URI, tags, and timestamp. Any additional YAML keys are allowed as extensions, and consumers must preserve unknown keys.
+
+Two reserved files provide structure: `index.md` (directory listing for progressive disclosure) and `log.md` (change history). Versioning uses major.minor via an `okf_version` field in the root index. Distribution is via git repo (recommended), tarball, or subdirectory of a larger repo.
+
+The conformance model is notable for what it does not enforce: consumers must not reject bundles for missing optional fields, unknown types, unknown extension keys, or broken links. This is a deliberately low bar designed for adoption over correctness.
+
+A companion enrichment agent, built on Google's Agent Development Kit (ADK) with Gemini, does two passes over source data: a BigQuery metadata pass and a web-crawl pass. A separate visualizer generates self-contained HTML with a force-directed graph (Cytoscape.js). Sample bundles exist for GA4, Stack Overflow, and Bitcoin datasets.
+
+---
+
+## 2. Positioning: Where OKF Sits in the Landscape
+
+OKF is clearly a semantic-layer format. It describes what things ARE: tables, APIs, metrics, playbooks, business definitions. It does not capture what happened, why decisions were made, or how understanding evolved. In the taxonomy established in [knowledge-graphs-vs-context-graphs.md](knowledge-graphs-vs-context-graphs.md), OKF is firmly on the knowledge graph side: domain vocabulary, entity descriptions, and structural relationships.
+
+**Relative to Karpathy's llm-wiki.** OKF is the spec-level formalization of the same impulse Karpathy described. His three-layer architecture (raw sources, compiled wiki, index) maps directly: OKF bundles are the compiled wiki layer with a formal schema. The key difference is ambition. Karpathy proposed a personal workflow; OKF proposes an interchange format. The llm-wiki gist is "here's how I organize knowledge for my agent." OKF is "here's how organizations exchange knowledge between systems."
+
+**Relative to Knowledge Catalog/Dataplex.** OKF is the open interchange format for Google's proprietary catalog product. The same relationship as Parquet to BigQuery, or OCI to Docker: a vendor publishes an open spec for their internal format to encourage ecosystem adoption. The enrichment agent (ADK + Gemini) is the proprietary layer that produces OKF bundles from Google Cloud metadata.
+
+**Relative to the llm-wiki implementations.** The [landscape analysis](llm-wiki-landscape.md) surveyed a wave of personal-only implementations. OKF adds exchangeability (a spec that multiple producers and consumers can target) but does not add governance, access control, or multi-user support. The llm-wiki implementations are personal knowledge tools. OKF is a data catalog interchange format. Neither addresses the governed, multi-user memory problem.
+
+---
+
+## 3. Design Decisions Worth Noting
+
+**Minimal required fields.** Only `type` is required, and it is a free-form string. MemoryHub requires scope, content, and authenticated identity on every write, with optional but meaningful fields for weight, domain, parent relationships, and branch type. OKF optimizes for adoption friction; MemoryHub optimizes for governance guarantees. These are not competing choices, they reflect different purposes. A knowledge interchange format should be easy to produce. A governed memory system should be hard to misuse.
+
+**Untyped relationships.** OKF uses standard markdown links with no typed semantics. A link from concept A to concept B is a directed edge, but whether it means "depends on," "is a subtype of," or "contradicts" is left to the prose surrounding the link. MemoryHub's relationship model has explicit types, directionality, and a traversal API. OKF's approach is appropriate for a file-based format where humans read the prose. It is insufficient for runtime graph queries where an agent needs to traverse "all dependencies of X" without reading every document.
+
+**No access control.** Knowledge within a bundle is structurally public. There is no scope hierarchy, no RBAC, no concept of restricted visibility. This is fine for a data catalog interchange format (you share a bundle with people who should see it), but it means OKF bundles cannot carry sensitive organizational knowledge without external access control wrapping them.
+
+**Permissive consumption.** The requirement that consumers tolerate broken links, unknown types, and missing fields is an interesting durability choice. It prioritizes partial information over correctness. MemoryHub's contradiction detection and curation subsystem take the opposite stance: conflicts and inconsistencies should be surfaced and resolved, not silently tolerated.
+
+**Progressive disclosure via index.md.** The index file that lists bundle contents with summaries parallels MemoryHub's search-with-focus-bias: show the agent what exists, let it drill into what it needs. The mechanism differs (static file vs dynamic search), but the information architecture principle is the same.
+
+**Git as versioning.** OKF leans on git for distribution and version history. MemoryHub uses internal versioning with `isCurrent` flags, provenance chains, and branch types. Git versioning is appropriate for a file-based format that changes infrequently. Internal versioning is necessary for a runtime system where memories evolve continuously through agent interaction.
+
+---
+
+## 4. Implications for MemoryHub
+
+**OKF validates the MemoryHub/RetrievalHub strategy.** OKF sits squarely on the semantic/factual side of MemoryHub's deliberate scope boundary. It describes domain assets and their relationships. MemoryHub stores decisions, experiences, procedures, and their provenance. The existence of a vendor-neutral spec for the semantic layer confirms that there is real demand for structured, exchangeable knowledge formats, and that it is a different thing from what MemoryHub does. The [knowledge-graphs-vs-context-graphs analysis](knowledge-graphs-vs-context-graphs.md) drew this line; OKF provides concrete evidence that the industry is drawing it too. (For the MemoryHub/RetrievalHub boundary definition, see [planning/knowledge-layer.md](../planning/knowledge-layer.md) section 7.)
+
+**The RetrievalHub could speak OKF.** OKF's permissive extension model means MemoryHub-specific fields (scope, governance metadata, provenance, curation status) could ride alongside OKF's required fields without breaking conformance. The RetrievalHub could consume OKF bundles as an import format (ingest a data catalog and make it queryable with governance) and produce OKF bundles as an export format (share curated knowledge with systems that do not need MemoryHub's governance). The extension mechanism makes this interoperable without forking the spec.
+
+**OKF's governance gap is the RetrievalHub's value proposition.** OKF has no access control, no curation, no provenance, no contradiction detection. For a file-based interchange format, that is fine. But organizations that need to govern their semantic knowledge (who can see this definition? when did it change? does it conflict with another definition?) need something on top of OKF. The RetrievalHub should carry governance where OKF does not, just as MemoryHub carries governance where flat vector stores do not. The [ontology-contextualization analysis](ontology-contextualization.md) identified terminology governance as a key gap in regulated enterprises; OKF bundles carrying organizational terminology would need exactly the governance layers that analysis proposed.
+
+**The enrichment agent pattern is prior art.** OKF's enrichment agent (observe BigQuery metadata and web content, produce structured knowledge bundles) parallels MemoryHub's extraction pipeline design (#240: observe agent traces, produce candidate memories). The source material differs (data catalog metadata vs agent conversation traces), but the architectural pattern is identical: asynchronous observation of operational data, structured extraction into a governed format, human-in-the-loop validation before promotion. Google built this for their semantic layer. MemoryHub is building it for the procedural layer. The pattern validates itself across both sides of the semantic/episodic boundary.
+
+**Cross-linking is simpler but weaker.** OKF's markdown links are human-readable and tool-agnostic, which is the right tradeoff for an interchange format. But they cannot support the kind of queries agents need at runtime: "find all concepts that depend on this API," "trace the provenance of this metric definition," "what changed since last quarter." MemoryHub's typed relationships and traversal API exist precisely because runtime agents need structured traversal, not prose parsing.
+
+---
+
+## 5. What This Means for RetrievalHub
+
+OKF informs the RetrievalHub design in three concrete ways.
+
+**Import/export format.** OKF could serve as the interchange format for the RetrievalHub, allowing organizations to import knowledge from OKF-producing tools (Google's enrichment agent, future third-party generators) and export governed knowledge back to OKF-consuming systems. The RetrievalHub's value-add over raw OKF is governance, access control, runtime query, and scope isolation.
+
+**Enrichment pipeline precedent.** Google's two-pass enrichment agent (metadata extraction, then web-crawl enrichment) is directly applicable to the RetrievalHub's ingestion pipeline. Observe the organization's data assets, extract structured knowledge, surface it for curation. The RetrievalHub would add what Google's agent does not: governed storage with provenance, contradiction detection when extracted knowledge conflicts with existing definitions, and scope-based visibility so different teams see different slices.
+
+**Governance as the differentiator.** OKF proves that a minimal, governance-free format can gain adoption for knowledge interchange. The RetrievalHub should not compete on format; it should consume OKF and add the governance layer. This mirrors MemoryHub's relationship to flat vector stores on the episodic/procedural side: we do not compete on storage or retrieval mechanics, we compete on governance, provenance, and access control. The two hubs together provide governed memory (episodic/procedural) and governed knowledge (semantic/factual) for the same regulated customers where unstructured alternatives are disqualified.
+
+---
+
+## References
+
+- [GoogleCloudPlatform/knowledge-catalog](https://github.com/GoogleCloudPlatform/knowledge-catalog) (OKF spec, enrichment agent, visualizer)
+- [OKF Specification v0.1](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md)
+- [knowledge-graphs-vs-context-graphs.md](knowledge-graphs-vs-context-graphs.md) (semantic vs procedural layer taxonomy)
+- [llm-wiki-landscape.md](llm-wiki-landscape.md) (Karpathy's llm-wiki and implementation survey)
+- [ontology-contextualization.md](ontology-contextualization.md) (terminology governance exploration)
+- [agent-memory-landscape-2026.md](agent-memory-landscape-2026.md) (context graph positioning, Neo4j comparison)

--- a/research/ontology-contextualization.md
+++ b/research/ontology-contextualization.md
@@ -1,0 +1,136 @@
+# Ontology-Aware Contextualization of Agent Memories
+
+**Date**: June 2026
+**Purpose**: Explore how MemoryHub could support terminology-aware memory retrieval and cross-organizational concept mapping
+**Status**: Research exploration
+
+---
+
+## 1. The Problem: Terminology Diverges Across Organizations
+
+AI agents trained on general knowledge inherit general assumptions about terminology. Those assumptions break in practice because organizations redefine, overload, and invert standard terms to match their internal culture, regulatory context, or operational philosophy. This is not an edge case; it is the norm in regulated enterprises.
+
+Four examples illustrate the pattern at different scales.
+
+### 1.1 SIPOC vs COPIS
+
+Lean and Six Sigma practitioners widely use SIPOC (Supplier, Input, Process, Output, Customer) as a process mapping framework. Some organizations that embrace "customer-first" thinking reverse the order to COPIS, considering the same five elements but starting from the Customer and working backward to the Supplier. The framework is identical; the mental model and the vocabulary are inverted. An agent advising on process improvement needs to know which convention the organization uses, or it will produce deliverables that feel foreign and are quietly ignored.
+
+This is the simplest version of the problem: same concept, different name. There is no ambiguity about meaning, only about labeling. A term registry solves it.
+
+### 1.2 FHIR in Healthcare
+
+HL7 FHIR defines roughly 150 resource types (Patient, Observation, Condition, Coverage, Claim, Encounter, etc.), each with deep nested structures, extensions, and profiles. The full specification runs to thousands of pages. No single context window can hold it, and most interactions only need a small slice.
+
+An agent helping a developer build a patient-facing portal needs Patient, Condition, and MedicationRequest resources in detail. If the conversation pivots to claims processing, the agent needs Coverage, Claim, and ExplanationOfBenefit instead. This is progressive unfolding: load the relevant slice of a large domain model based on current focus, pull in more when focus shifts.
+
+MemoryHub's existing focus tracking and search-with-focus-bias already support this pattern mechanically. The gap is that the agent does not know *which* memories constitute a coherent domain slice. FHIR resources have formal relationships (a Claim references a Coverage, which references a Patient), but those relationships are in the FHIR spec, not in MemoryHub's memory graph.
+
+### 1.3 VA and Community Care Records
+
+When veterans receive care from community providers and later transition back to VA healthcare, their records carry terminology from two different systems. A medication name, diagnosis code, or procedure description may use different coding systems (ICD-10 vs SNOMED CT, NDC vs RxNorm), different granularity, or different clinical conventions. The same clinical reality gets two different textual representations.
+
+This is a cross-organizational terminology mapping problem with patient safety implications. An agent summarizing a veteran's care history needs to know that Community Provider A's "office visit" maps to the VA's "outpatient encounter," but with differences in what gets bundled into that concept (the community provider may include lab draws; the VA may code them separately).
+
+This is harder than SIPOC/COPIS because the terms are not interchangeable labels for the same concept. They are *overlapping* concepts with partial equivalence, and getting the mapping wrong has clinical consequences.
+
+### 1.4 The Ontology Gap
+
+A recurring observation from physicians and clinical informaticists working on AI adoption: many healthcare organizations lack a formal ontology for their domain-specific work. Standard ontologies exist (SNOMED CT, LOINC, ICD-10), but the mapping from an organization's actual clinical workflows and documentation practices to those ontologies is often incomplete, inconsistent, or nonexistent.
+
+This gap is not unique to healthcare. Defense organizations layer mission-specific terminology on top of standard frameworks. Financial services firms develop internal risk taxonomies that diverge from Basel/IFRS standards. Government agencies redefine terms across administrations. The pattern is universal: standard ontologies exist, but organizations customize them in undocumented ways, and that customization is precisely the knowledge an AI agent needs to be useful.
+
+---
+
+## 2. Three-Layer Progression
+
+These layers are independently useful. Each can be implemented without the others, though they compose naturally.
+
+### Layer 1: Term Registry
+
+**Scope**: Near-term. Fits entirely within MemoryHub's existing model.
+
+The simplest version is a convention: project or org-scoped memories tagged with a `terminology` domain that define what specific terms mean in a given context. When the retrieval layer encounters a term that has a registry entry, it includes the definition alongside whatever memories it would normally return.
+
+An example memory:
+
+```
+scope: organizational
+domain: terminology
+content: "In this organization, 'COPIS' refers to the Customer-Output-Process-
+Input-Supplier framework. This is the reverse of the standard SIPOC ordering.
+All process documentation uses COPIS, not SIPOC."
+weight: 0.9
+```
+
+No new infrastructure is required. The retrieval layer already searches by scope and can bias by domain tags. The only addition is a convention that agents follow: when a search result includes a `terminology` memory, treat it as definitional context that should be injected alongside the operational memories.
+
+This is immediately useful for any organization with specialized vocabulary. The cost is near-zero: a few well-written terminology memories per project or org.
+
+Where Layer 1 breaks down: when the same term has different definitions in different scopes, and the agent does not know which scope applies. A term that means one thing at the project level and something different at the organizational level requires disambiguation, not just lookup. That is Layer 2.
+
+### Layer 2: Ambiguity Detection
+
+**Scope**: Medium-term. Ties to graph-enhanced memory (#170).
+
+Layer 2 adds the ability for an agent to recognize that a term could have multiple meanings and to avoid silently picking one. This requires two capabilities:
+
+**Known-ambiguous terms.** A curated set of terms that are flagged as overloaded. When the agent encounters one, it checks which scope-specific definition applies (or asks for clarification if the scope is ambiguous). This is still fundamentally a lookup, but with a branching path.
+
+**Inferred ambiguity.** When terminology memories from different scopes define the same term differently, the system detects the conflict. This is a variant of MemoryHub's existing contradiction detection, applied specifically to terminology. Two definitions for "encounter" at different scopes are not a contradiction in the general sense (both may be correct within their scope), but they are a signal that cross-scope communication about "encounters" requires translation.
+
+**Cross-scope term resolution.** When two organizations share a campaign or federated context in MemoryHub, the system can surface where their terminologies diverge. The output is not just "these terms differ" but a structured mapping: "Org A's 'encounter' maps to Org B's 'visit' with these differences: [...]." This mapping itself becomes a memory, stored at the campaign scope, that agents can retrieve when operating in the cross-org context.
+
+Graph-enhanced memory (#170) is the natural vehicle for Layer 2. Typed relationships between terminology memories (synonyms, partial overlaps, scope-specific definitions, superseded definitions) start to look like a lightweight domain ontology without requiring formal ontology tooling.
+
+### Layer 3: Ontology Mapping Engine
+
+**Scope**: Long-term. Worth building only if medical, defense, or other regulated verticals become a significant part of the user base.
+
+Layer 3 does not build ontologies. It helps map between existing ones. Standard ontologies already exist for many regulated domains: SNOMED CT, ICD-10, LOINC, and HL7 FHIR in healthcare; NIST and MITRE frameworks in cybersecurity; Basel and IFRS in financial services. The gap is not the absence of ontologies but the absence of tooling that maps an organization's actual terminology to the relevant standard ontology and keeps that mapping current.
+
+MemoryHub could serve as the persistence and retrieval layer for those mappings. The mapping itself might be generated by an external tool (a LoRA-tuned model, a clinical terminology service, or manual curation), but the mappings would be stored as memories with full provenance, versioning, and scope governance.
+
+The VA/community care case is the clearest illustration. A mapping memory might state: "Community Provider X's discharge summary term 'cardiac event' corresponds to ICD-10 codes I21-I25 in the VA system, but their usage excludes unstable angina (I20.0), which the VA includes." That mapping has provenance (who created it, when, based on what evidence), versioning (it may change as either system updates its coding practices), and scope (it applies to the specific federated context between these two organizations).
+
+This layer is architecturally ambitious but does not require MemoryHub to become an ontology management system. It requires MemoryHub to be a good persistence layer for ontology *mappings*, with the governance, versioning, and access control that regulated environments demand.
+
+---
+
+## 3. Relationship to Existing Work
+
+**Graph-enhanced memory (#170)** is the natural foundation for Layer 2. The richer entity-relationship model being designed there can represent terminology relationships (synonym-of, narrower-than, maps-to, superseded-by) without special-casing. Terminology relationships are just another type of edge in the memory graph.
+
+**Context compaction (#169)** interacts with terminology in a critical way. If the compactor does not understand that a memory tagged `terminology` is definitional context, it might compact or discard it during summarization. A compacted context that loses the definition of "COPIS" forces the agent to fall back on its general knowledge, which says "SIPOC." The compaction policy needs a way to mark certain memories as compaction-resistant, or at least as high-priority for retention. Terminology memories are one class of memory that deserves this treatment; there are likely others.
+
+**Extraction pipeline (#240)** could feed Layer 1 semi-automatically. When an agent encounters a term being defined in conversation ("When we say 'sprint' here, we mean a two-week planning cycle, not the Scrum ceremony"), the extraction pipeline could propose a terminology memory. The human still validates, but the extraction reduces the manual curation burden.
+
+**Focus tracking** already supports the progressive unfolding pattern that FHIR and similar large domain models require. The gap is connecting focus declarations to domain-specific memory slices. If the agent declares focus on "claims processing," the retrieval layer should know to pull in Coverage, Claim, and ExplanationOfBenefit terminology alongside whatever operational memories match the query.
+
+**The episodic/semantic boundary** matters here. Terminology definitions look like semantic knowledge (facts about what terms mean). But an organization's specific usage of those terms, the drift over time, the exceptions and edge cases, these are experiential knowledge that agents accumulate through interaction. MemoryHub's role is not to be the source of truth for "what does FHIR Patient mean" (that belongs in the semantic/library-RAG layer), but to be the source of truth for "how does *this organization* use FHIR Patient, and how does that differ from the standard."
+
+---
+
+## 4. Open Questions
+
+**Compaction interaction.** How does progressive unfolding interact with context compaction (#169)? If the compactor runs while FHIR Coverage definitions are loaded, does it preserve them? If the agent pivots back to Coverage later, does it re-fetch from MemoryHub or work from the compacted summary? The answer likely depends on compaction policy, but the policy needs to be terminology-aware.
+
+**Retrieval priority.** Should terminology memories receive special retrieval priority (always injected when a matching term appears in the query), or is tagging plus search-bias sufficient? Special priority risks token bloat if the terminology registry grows large. Search-bias risks missing critical definitions when the query does not happen to surface them. There may be a hybrid: always inject for terms in the current focus domain, search-bias for everything else.
+
+**Layer 1 scaling limits.** At what scale does the convention-based approach (Layer 1) break down and require structural support (Layer 2)? Ten terminology memories per project are easy to manage. A hundred are manageable with good tagging. A thousand probably need hierarchy, search facets, and disambiguation logic. The threshold likely depends on how many scopes are in play and how much terminology overlaps between them.
+
+**Temporal drift.** How do you handle terminology that evolves over time within an organization? MemoryHub's versioning tracks *that* a definition changed, but detecting *when* a definition has drifted from actual usage is harder. An agent might continue applying a definition that the organization has informally moved past. The extraction pipeline (#240) could help by detecting usage patterns that diverge from stored definitions, but this is an unsolved problem.
+
+**Federation governance.** In the cross-org scenario (VA/community care, multi-agency defense programs), who owns the terminology mappings? MemoryHub's scope model supports multi-org campaigns, but the governance question is operational, not technical. Both organizations need to trust the mappings, and both need a way to flag when a mapping is wrong. The existing contradiction detection mechanism could serve as the flagging mechanism, but the resolution workflow needs human involvement.
+
+---
+
+## 5. What This Is Not
+
+This exploration is not proposing that MemoryHub become an ontology management system. Tools like Protege, TopBraid, and domain-specific terminology servers (UMLS, BioPortal) exist for that purpose and are far more capable at managing formal ontologies.
+
+It is not proposing OWL, RDF, or SPARQL infrastructure. MemoryHub's memory graph is a property graph, not a semantic web triple store, and that is the right choice for its mission.
+
+It is not proposing LoRA training or model fine-tuning as a MemoryHub feature. Domain-specific model tuning is valuable but belongs in the model serving layer (OpenShift AI, vLLM), not in the memory layer.
+
+The insight is narrower and more practical: a lightweight terminology-aware layer, built on existing memory primitives with minimal new infrastructure, solves a real and recurring problem in regulated enterprises. Organizations that adopt AI agents will immediately run into terminology divergence. Giving them a simple, governed way to teach their agents the local dialect, using memories they already know how to create, removes a barrier to adoption that no amount of model training will fix.

--- a/research/perplexity-brain-analysis.md
+++ b/research/perplexity-brain-analysis.md
@@ -1,0 +1,134 @@
+# Perplexity Brain: Self-Improving Memory for Agents
+
+**Published:** June 18, 2026
+**Source:** [Perplexity Blog](https://www.perplexity.ai/hub/blog/self-improving-memory-for-agents)
+**Status:** Research Preview, Max ($200/month) and Enterprise Max subscribers only
+**Reviewed:** June 21, 2026
+
+## Overview
+
+Perplexity launched "Brain" as a memory layer for their "Computer" agentic product. Brain builds a structured context graph of the agent's work across sessions, then runs an overnight synthesis process that extracts patterns and updates a personal "LLM wiki" that loads into the agent's execution environment before the next session.
+
+The distinguishing framing: memory is about the *agent's work*, not the *user's preferences*. Brain remembers what the agent did, what worked, what failed, and what corrections the user made. Its purpose is agent performance improvement, not user personalization.
+
+## Architecture
+
+### Context Graph
+
+After each task, Computer records operational details in a context graph:
+
+- Which connectors (external integrations) were used
+- Which sources were validated as reliable
+- What the user corrected
+- Which attempts failed
+- Relationships between projects, decisions, files, and sources
+
+This is a structured graph, not a flat memory list. A decision made in one session can connect to a file from a connector and a result from a prior search. Three input channels feed it: sessions, connectors (external data integrations), and files.
+
+### LLM Wiki
+
+The context layer manifests as an "LLM wiki" -- structured pages representing entities and concepts from the user's work context. The wiki is automatically loaded onto the agent sandbox at session start. Pages reflect "ideas, people, projects, and other elements" from the user's world.
+
+No details on wiki page schema, markup format, or storage technology have been published. No public API exists.
+
+### Overnight Synthesis
+
+Brain updates on a batch schedule (overnight), not in real-time. The loop:
+
+1. **Execute** -- Computer performs the task
+2. **Record** -- Context graph captures operational details
+3. **Synthesize** -- Brain reviews the accumulated graph overnight, extracts patterns, updates the LLM wiki
+4. **Load** -- Next session begins with updated wiki context injected automatically
+
+Coverage articles describe this as "functionally a training run on your personal workflow data" and "a micro fine-tuning loop disguised as a memory feature." It is not fine-tuning in the ML sense -- the underlying model does not change. The harness-level context improves.
+
+### Automatic Injection
+
+When a task starts, Brain selects relevant subgraph context and injects it automatically. Users don't need to paste prior context or re-explain their situation. No details on relevance scoring, token budget allocation, or selection algorithm have been published.
+
+### Source Traceability
+
+Every memory entry links back to the session, file, or source it came from. Users can inspect provenance and selectively delete individual memories.
+
+## Performance Claims (First-Party, Unverified)
+
+| Metric | Change | Condition |
+|--------|--------|-----------|
+| Answer correctness | +25% | On previously-seen tasks |
+| Recall | +16% | Same early results |
+| Cost per task | -13% | Tasks requiring historical context |
+
+Gains are concentrated on tasks requiring prior context. Self-contained tasks see minimal benefit. The compound effect grows as the context graph enriches over time. No independent benchmark exists.
+
+## What Is Not Published
+
+- Graph database or storage technology
+- Embedding strategy (vector, symbolic, hybrid)
+- Wiki page schema or format
+- Context window budget for injected memories
+- Relevance scoring / retrieval algorithm
+- Contradiction resolution beyond user corrections
+- Retention policies or data lifecycle
+- Connector authentication and data freshness management
+- Privacy architecture beyond user-facing inspect/delete
+- Whether the system supports multi-user or team scenarios
+
+## Comparison to MemoryHub
+
+### Convergences
+
+Several of Brain's design choices validate MemoryHub's direction:
+
+**Graph over flat list.** Brain explicitly builds a structured context graph, not a flat memory store. MemoryHub's tree-structured memories with relationship edges and branch types serve the same purpose -- preserving decision context and provenance, not just facts.
+
+**Source traceability / provenance.** Brain links every memory back to its originating session or source. MemoryHub's provenance branches (`branch_type="provenance"`) and rationale branches serve the same need. This is the "why" that flat memory systems lose.
+
+**Harness-layer intelligence.** Brain's framing that "intelligence shifts from the model layer to the harness layer" maps directly to MemoryHub's architecture -- the memory system makes any model better without changing the model itself. This is MemoryHub's thesis for regulated environments where model access is constrained.
+
+**Automatic injection over manual retrieval.** Brain loads context automatically at session start. MemoryHub's framework connector (fipsagents `self.memory`) does the same -- zero-tool-token prefix injection. Both recognize that asking the agent to manage its own memory is wasteful for most workloads.
+
+**Correction-driven learning.** Brain tracks user corrections and feeds them into the synthesis loop. MemoryHub's contradiction reporting (`report_contradiction`) and curation layer serve the same function -- memory should improve when the user says "no, that's wrong."
+
+### Divergences
+
+**Batch vs. real-time.** Brain synthesizes overnight. MemoryHub writes and retrieves in real-time within the session. Brain's batch approach trades immediacy for synthesis quality (the overnight process can do more expensive cross-referencing). MemoryHub's real-time approach means today's decisions are available today, not tomorrow.
+
+**Cloud-hosted vs. self-hosted.** Brain is a SaaS feature tied to Perplexity's infrastructure. Users get inspect/delete controls but not data ownership or deployment control. MemoryHub is designed for on-premise deployment in regulated environments where data sovereignty is non-negotiable. This is a fundamental positioning difference.
+
+**Work memory vs. governed memory.** Brain focuses on agent operational knowledge ("what worked, what failed"). MemoryHub's scope hierarchy (user/project/campaign/organizational/enterprise) and editorial governance (curation, RBAC, versioning) address a broader set of memory types with explicit access control. Brain has no visible multi-tenant or scope isolation story.
+
+**Wiki synthesis vs. versioned tree.** Brain synthesizes memories into wiki pages -- a lossy compression step where the original memory is replaced by a synthesized summary. MemoryHub preserves version history via `isCurrent` flags and tree branches. The original memory and its evolution are both queryable. This matters for audit trails in regulated environments.
+
+**No team/organizational layer.** Brain is personal -- each employee's agent improves independently. MemoryHub's scope hierarchy explicitly supports team-level and organizational knowledge sharing. Every's field report (see agent-memory-landscape-2026.md) documented why personal-only agents fail at organizational knowledge.
+
+### MemoryHub Gaps Brain Highlights
+
+**Automated synthesis / compaction.** Brain's overnight synthesis loop is close to what MemoryHub's planned Context Compaction Services (ACE, issue #169) would provide. Brain shipping this as a production feature validates the design direction and increases urgency for ACE.
+
+**Connector integration.** Brain ingests from external sources (files, connectors) beyond just agent sessions. MemoryHub currently only ingests from agent interactions. The extraction pipeline decision (2026-05-18, issue #240) covers agent traces but not external document sources. This could be a gap for enterprise use cases where agents need to learn from shared documents.
+
+**Feedback loop metrics.** Brain publishes (first-party) metrics showing memory impact on task performance. MemoryHub has no equivalent measurement framework. Adding instrumentation to measure memory's impact on downstream task quality would strengthen the value proposition.
+
+## Positioning Implications
+
+Brain validates the core thesis that agent memory is a distinct, valuable layer. But it validates it as a *consumer/prosumer SaaS feature*, not as an *enterprise infrastructure component*.
+
+MemoryHub's differentiators against Brain are the same ones that differentiate it against all cloud-hosted memory: data sovereignty, scope isolation, editorial governance, audit trails, and deployment flexibility. Brain is a strong product for individual knowledge workers who trust Perplexity's cloud. It does not serve regulated enterprises that cannot send agent operational data to a third-party SaaS.
+
+The "self-improving" framing is worth watching. If Perplexity demonstrates that overnight synthesis meaningfully improves agent performance over time, it creates market demand for the capability. MemoryHub's ACE (#169) and extraction pipeline (#240) are the self-hosted answer to that demand.
+
+## Key Quotes
+
+> "Most AI memory systems remember what *you* said. Brain remembers what *it* did."
+
+> "A mediocre model with a great Brain could outperform a superior model with no memory -- because accumulated experience beats raw capability on repeated tasks."
+
+> "Intelligence shifts from the model layer to the harness layer."
+
+## References
+
+- [Perplexity Blog: Self-improving Memory for Agents](https://www.perplexity.ai/hub/blog/self-improving-memory-for-agents)
+- [MarkTechPost: Perplexity Launches Brain](https://www.marktechpost.com/2026/06/18/perplexity-launches-brain/)
+- [Decrypt: Perplexity's AI Agent Now Has a Brain](https://decrypt.co/371584/perplexity-ai-agent-brain)
+- [ExplainX: Perplexity Brain Analysis](https://explainx.ai/blog/perplexity-brain-computer-memory-system-2026)
+- [FourWeekMBA: Perplexity Brain Self-Improving Agent Memory](https://fourweekmba.com/perplexity-brain-self-improving-agent-memory/)


### PR DESCRIPTION
Four commits covering uncommitted work from recent sessions:

- Gitignore `specs/` directory
- Resolve all open questions in content moderation design (2026-06-30 backlog refinement)
- Add Perplexity Brain analysis, OKF, and ontology contextualization research
- Add backlog refinement, system benchmarks, and turn-level hooks planning docs