### PR TITLE
docs: Rename [^tribal-knowledge] footnote anchors

### DIFF
--- a/demos/scenarios/agriculture/demo-script-world-agritech.md
+++ b/demos/scenarios/agriculture/demo-script-world-agritech.md
@@ -71,7 +71,7 @@ same prescription-generation play — has room to land.
    of the existing precision-ag stack, doesn't compete with any
    of them.[^decision-support-boundary]
 3. The cross-season organizational knowledge moment as the most
-   distinctive demonstration of value.[^cross-season][^tribal-knowledge]
+   distinctive demonstration of value.[^cross-season][^organizational-knowledge]
 4. The applicator approval gate as the demonstration that
    MemoryHub is professional ag-tech, not a vendor demo with
    autonomous spraying.[^humans-in-loop]
@@ -391,7 +391,7 @@ MemoryHub.[^identity-triple][^project-scope]
 
 Recorded clip showing the routine scouting flight, the initial
 tar spot detection, and the cross-season organizational knowledge moment
-that tells the team where to look.[^cross-season][^tribal-knowledge]
+that tells the team where to look.[^cross-season][^organizational-knowledge]
 
 ### Talking points
 
@@ -405,7 +405,7 @@ that tells the team where to look.[^cross-season][^tribal-knowledge]
 > early-stage tar spot. Small. Maybe ten acres. But clear
 > enough that the agent flags it for follow-up."
 
-**The killer moment 1 — multi-generational organizational knowledge (1:00)**: Slow down. Make it land.[^cross-season][^tribal-knowledge]
+**The killer moment 1 — multi-generational organizational knowledge (1:00)**: Slow down. Make it land.[^cross-season][^organizational-knowledge]
 
 > "Now watch what the Agronomy agent does next. It's reading
 > shared memory for context on this detection. And here's what
@@ -442,7 +442,7 @@ that tells the team where to look.[^cross-season][^tribal-knowledge]
 > is the leading edge. *That* is the context that makes
 > agronomic decisions go well."[^value-prop]
 
-**The morning briefing organizational knowledge (30 seconds)**:[^tribal-knowledge]
+**The morning briefing organizational knowledge (30 seconds)**:[^organizational-knowledge]
 
 > "While that's happening, watch what the Farm Manager agent
 > does. It's preparing Tom's morning briefing, and it's
@@ -463,9 +463,9 @@ that tells the team where to look.[^cross-season][^tribal-knowledge]
 
 - **Cross-season pattern recognition**[^cross-season] (the
   killer moment)
-- **Multi-generational organizational knowledge**[^tribal-knowledge]
+- **Multi-generational organizational knowledge**[^organizational-knowledge]
   (Tom's 2024 takeaway captured by Kelsey)
-- **Per-operator preference memory**[^tribal-knowledge] (Tom's
+- **Per-operator preference memory**[^organizational-knowledge] (Tom's
   morning briefing order)
 - **Project-scope reads**[^project-scope]
 - **Value prop landing**[^value-prop]: the headline phrase gets
@@ -607,7 +607,7 @@ Key beats:
 - **Multi-source convergence on diagnosis**[^cross-season]
 - **Contradiction detection**[^contradiction]: drone NDVI
   interpretation vs. soil sensor moisture data
-- **Multi-generational organizational knowledge**[^tribal-knowledge]
+- **Multi-generational organizational knowledge**[^organizational-knowledge]
   (Tom's operating philosophy from 2022)
 - **Driver_id distinction across humans on the same
   role**[^driver-id][^role-vs-person]: Tom, Kelsey, and Linda
@@ -905,7 +905,7 @@ most.
 > One. A memory from Kelsey's notes about her father's
 > twenty-five years of experience with one specific field
 > microclimate, available to the team at the moment of
-> detection.[^cross-season][^tribal-knowledge]
+> detection.[^cross-season][^organizational-knowledge]
 >
 > Two. Multi-source convergence — drone imagery, thermal,
 > soil sensors, weather — synthesized into a single
@@ -956,8 +956,8 @@ a single table:
 |---|---|---|---|---|
 | 0:00-1:30 | Opening hook & framing | (None — setup) | Phrase, boundary, data ownership, agents-support-humans | `[^value-prop]` `[^decision-support-boundary]` `[^data-ownership]` `[^humans-in-loop]` |
 | 1:30-3:00 | Operation & team intro | Identity model (10 agents register) | Project membership, fleet provisioning | `[^identity-triple]` `[^project-scope]` `[^cli-provisioning]` |
-| 3:00-5:00 | Detection & cross-season recall | Cross-season organizational knowledge (KILLER MOMENT 1) | Multi-generational knowledge transfer, per-operator preferences | `[^cross-season]` `[^tribal-knowledge]` `[^value-prop]` |
-| 5:00-8:00 | Diagnosis confirmation & convergence | Multi-source convergence + intervention philosophy | Driver_id distinction across humans on same role, contradiction, yield-data quarantine | `[^cross-season]` `[^contradiction]` `[^tribal-knowledge]` `[^role-vs-person]` `[^driver-id]` `[^data-curation]` `[^data-ownership]` |
+| 3:00-5:00 | Detection & cross-season recall | Cross-season organizational knowledge (KILLER MOMENT 1) | Multi-generational knowledge transfer, per-operator preferences | `[^cross-season]` `[^organizational-knowledge]` `[^value-prop]` |
+| 5:00-8:00 | Diagnosis confirmation & convergence | Multi-source convergence + intervention philosophy | Driver_id distinction across humans on same role, contradiction, yield-data quarantine | `[^cross-season]` `[^contradiction]` `[^organizational-knowledge]` `[^role-vs-person]` `[^driver-id]` `[^data-curation]` `[^data-ownership]` |
 | 8:00-10:00 | Applicator approval & application | Applicator approval gate (KILLER MOMENT 2) | Self-correcting weather, compliance recordkeeping | `[^humans-in-loop]` `[^contradiction]` `[^audit]` `[^operational-memory]` |
 | 10:00-11:30 | Audit trail & data ownership | Driver_id audit query + data ownership story | Role-vs-person | `[^audit]` `[^driver-id]` `[^role-vs-person]` `[^identity-triple]` `[^data-ownership]` |
 | 11:30-12:00 | Post-application learning | Explicit cross-season learning capture | Narrative context | `[^cross-season]` `[^narrative-context]` |
@@ -980,7 +980,7 @@ specific cuts in priority order:
    one of two `[^contradiction]` demonstrations.
 3. **Third cut**: drop the per-operator preference memory in
    Segment 3 (Tom's morning briefing order). Save 30 seconds.
-   **Lost milestones**: one of three `[^tribal-knowledge]`
+   **Lost milestones**: one of three `[^organizational-knowledge]`
    demonstrations.
 4. **Fourth cut**: drop one of the two audit queries in Segment 6
    (keep the role-based one, drop the human-based one, mention
@@ -1323,7 +1323,7 @@ GitHub issue (if any) tracking the implementation.
     Segment 7; narrative reasoning surfaced throughout the
     diagnosis and decision phases.
 
-[^tribal-knowledge]: **Multi-generational organizational knowledge
+[^organizational-knowledge]: **Multi-generational organizational knowledge
     memory category**: unique to agriculture among the
     demos because of the multi-generational dimension.
     Senior farmers' understanding of how specific fields

--- a/demos/scenarios/clinical/demo-script-himss.md
+++ b/demos/scenarios/clinical/demo-script-himss.md
@@ -400,7 +400,7 @@ walkthrough of the inpatient rehab phase. Key beats:
 - The Charge Nurse role passing across shifts (different drivers,
   same actor)[^role-vs-person][^driver-id]
 - A organizational knowledge memory being read (Dr. Patel's SSRI
-  preference)[^tribal-knowledge]
+  preference)[^organizational-knowledge]
 - A patient-narrative memory being written (the call light
   observation)[^narrative-context]
 - The PT-vs-OT cane contradiction[^contradiction]
@@ -447,7 +447,7 @@ role-vs-person distinction land.[^role-vs-person][^driver-id][^audit]
 > 'he won't use the call light' note — without any handoff loss.
 > The shift changed; the institutional memory didn't."
 
-**The organizational knowledge moment (45 seconds)**:[^tribal-knowledge][^cds-boundary]
+**The organizational knowledge moment (45 seconds)**:[^organizational-knowledge][^cds-boundary]
 
 > "Now in week 2, something happens that's clinically common.
 > Marcus develops post-stroke depression. Not unusual — the
@@ -513,7 +513,7 @@ detection moment.[^contradiction]
   (the human on shift) changes per session.
 - **Project-scope reads**[^project-scope]: agents reading from the
   team's shared memory.
-- **Organizational knowledge memory**[^tribal-knowledge] (the SSRI
+- **Organizational knowledge memory**[^organizational-knowledge] (the SSRI
   preference).
 - **Patient narrative context**[^narrative-context] (call light
   observation, mentioned in passing).
@@ -806,7 +806,7 @@ mattered most.
 >
 > Two. A care team's organizational knowledge — the SSRI preference —
 > persisting across the unit independent of who was on
-> call.[^tribal-knowledge]
+> call.[^organizational-knowledge]
 >
 > Three. A contradiction surfaced and resolved, not by computer
 > logic, but by the team reading both interpretations and
@@ -849,7 +849,7 @@ a single table:
 | 0:00-1:30 | Opening hook & framing | (None — setup) | Phrase, CDS boundary, AI-supports-humans | `[^value-prop]` `[^cds-boundary]` `[^humans-in-loop]` |
 | 1:30-3:00 | Patient & team intro | Identity model (10 agents register) | Project membership, fleet provisioning | `[^identity-triple]` `[^project-scope]` `[^cli-provisioning]` |
 | 3:00-5:00 | Acute → VA admission | Cross-system memory handoff | PHI quarantine + audit + provenance | `[^cross-system]` `[^narrative-context]` `[^provenance]` `[^phi-curation]` `[^audit]` |
-| 5:00-8:00 | Inpatient + shift change | Driver_id distinction across shifts | Organizational knowledge memory + contradiction detection | `[^role-vs-person]` `[^driver-id]` `[^tribal-knowledge]` `[^contradiction]` |
+| 5:00-8:00 | Inpatient + shift change | Driver_id distinction across shifts | Organizational knowledge memory + contradiction detection | `[^role-vs-person]` `[^driver-id]` `[^organizational-knowledge]` `[^contradiction]` |
 | 8:00-10:00 | Discharge & outpatient | Cross-care-setting narrative continuity (THE KILLER MOMENT) | Agent-operational memory | `[^cross-encounter]` `[^operational-memory]` `[^value-prop]` |
 | 10:00-11:30 | Audit trail | Driver_id audit query | Role-vs-person + compliance use case | `[^audit]` `[^driver-id]` `[^role-vs-person]` `[^identity-triple]` |
 | 11:30-12:00 | Phase 6 & plateau | Memory versioning | Cross-time continuity | `[^versioning]` `[^contradiction]` `[^cross-encounter]` |
@@ -1165,7 +1165,7 @@ GitHub issue (if any) tracking the implementation.
     audit in Segment 3; audit queries are the centerpiece of
     Segment 6.
 
-[^tribal-knowledge]: **Care team organizational knowledge memory
+[^organizational-knowledge]: **Care team organizational knowledge memory
     category**: the practices a unit has developed that aren't
     formal protocol but are how the team actually works. The
     SSRI-over-SNRI preference memory in this scenario is the

--- a/demos/scenarios/cybersecurity/demo-script-rsa.md
+++ b/demos/scenarios/cybersecurity/demo-script-rsa.md
@@ -383,7 +383,7 @@ landing. Slow down. Make it land.[^cross-incident]
 > decision. *That* is what we mean by the context that makes
 > security decisions go well."[^value-prop]
 
-**The organizational knowledge moment (30 seconds)**:[^tribal-knowledge]
+**The organizational knowledge moment (30 seconds)**:[^organizational-knowledge]
 
 > "While the Tier 1 agent is making the escalation decision,
 > watch what else it surfaces — a piece of team practice that
@@ -405,7 +405,7 @@ landing. Slow down. Make it land.[^cross-incident]
   killer moment)
 - **Project-scope reads**[^project-scope] (Tier 1 reading the
   team's shared memory)
-- **Analyst organizational knowledge**[^tribal-knowledge] (the off-hours
+- **Analyst organizational knowledge**[^organizational-knowledge] (the off-hours
   service account heuristic)
 - **Value prop landing**[^value-prop]: the headline phrase gets
   its first strong demonstration here
@@ -937,7 +937,7 @@ a single table:
 |---|---|---|---|---|
 | 0:00-1:30 | Opening hook & framing | (None — setup) | Phrase, detection boundary, no-auto-containment | `[^value-prop]` `[^detection-boundary]` `[^humans-in-loop]` |
 | 1:30-3:00 | Incident & team intro | Identity model (10 agents register) | Project membership, fleet provisioning | `[^identity-triple]` `[^project-scope]` `[^cli-provisioning]` |
-| 3:00-5:00 | Detection & "we've seen this before" | Cross-incident pattern recognition (KILLER MOMENT 1) | Organizational knowledge | `[^cross-incident]` `[^tribal-knowledge]` `[^value-prop]` |
+| 3:00-5:00 | Detection & "we've seen this before" | Cross-incident pattern recognition (KILLER MOMENT 1) | Organizational knowledge | `[^cross-incident]` `[^organizational-knowledge]` `[^value-prop]` |
 | 5:00-8:00 | Investigation & on-call rotation | Driver_id distinction + role-vs-person | Contradiction detection, agent-operational memory, sensitive-data quarantine | `[^role-vs-person]` `[^driver-id]` `[^contradiction]` `[^operational-memory]` `[^data-curation]` |
 | 8:00-10:00 | Containment with operational lessons | Cross-incident operational lesson (KILLER MOMENT 2) | Per-customer context, credential curation | `[^cross-incident]` `[^narrative-context]` `[^data-curation]` |
 | 10:00-11:30 | Audit trail | Driver_id audit query | Role-vs-person + chain of evidence | `[^audit]` `[^driver-id]` `[^role-vs-person]` `[^identity-triple]` |
@@ -1319,7 +1319,7 @@ GitHub issue (if any) tracking the implementation.
     in Segments 4 and 5; audit queries are the centerpiece of
     Segment 6.
 
-[^tribal-knowledge]: **Analyst organizational knowledge memory
+[^organizational-knowledge]: **Analyst organizational knowledge memory
     category**: the practices a SOC team has developed that
     aren't formal SIEM rules or SOAR playbooks but are how the
     team actually works. The "service account alerts after 8pm

--- a/demos/scenarios/emergency-response/demo-script-iaem.md
+++ b/demos/scenarios/emergency-response/demo-script-iaem.md
@@ -496,7 +496,7 @@ the central value-prop moment.[^op-period]
 > captured the working memory of the incident. Both
 > matter."[^value-prop]
 
-**Per-IC preference applied (15 seconds)**:[^tribal-knowledge]
+**Per-IC preference applied (15 seconds)**:[^organizational-knowledge]
 
 > "And while Cynthia is absorbing the handoff, watch what
 > the IC agent does. It's preparing her morning briefing in
@@ -516,7 +516,7 @@ the central value-prop moment.[^op-period]
   transfer**[^op-period] (the killer moment for the EM
   audience)
 - **Project-scope reads**[^project-scope]
-- **Per-IC preference memory**[^tribal-knowledge]
+- **Per-IC preference memory**[^organizational-knowledge]
 - **Value prop landing**[^value-prop]: the headline phrase
   gets its first strong demonstration here
 
@@ -623,7 +623,7 @@ operational tempo:
 > structural way to surface the discrepancy without it
 > being a confrontation."
 
-**Multi-agency organizational knowledge (30 seconds)**:[^tribal-knowledge]
+**Multi-agency organizational knowledge (30 seconds)**:[^organizational-knowledge]
 
 > "And one more piece of this segment. The Liaison Officer
 > is preparing for the afternoon multi-agency coordination
@@ -661,7 +661,7 @@ operational tempo:
   recall**[^cross-incident] (the killer moment 2)
 - **Contradiction detection**[^contradiction]: model
   output vs. field observation
-- **Multi-agency organizational knowledge**[^tribal-knowledge]
+- **Multi-agency organizational knowledge**[^organizational-knowledge]
   (the R5 strike team briefing pattern)
 - **Sensitive-data quarantine**[^data-curation] catching
   resident PII
@@ -1018,8 +1018,8 @@ scan as a single table:
 |---|---|---|---|---|
 | 0:00-1:30 | Opening hook & framing | (None — setup) | Phrase, boundary, no autonomous decisions | `[^value-prop]` `[^decision-support-boundary]` `[^humans-in-loop]` |
 | 1:30-3:00 | Incident & team intro | Identity model (10 ICS-position agents register) | Project membership | `[^identity-triple]` `[^project-scope]` `[^cli-provisioning]` |
-| 3:00-5:00 | Day 2 morning op period start | Operational period handoff state transfer (KILLER MOMENT 1) | Per-IC preference memory | `[^op-period]` `[^tribal-knowledge]` `[^value-prop]` |
-| 5:00-8:00 | Cross-incident recall & pre-positioning | Cross-incident fuel behavior recall (KILLER MOMENT 2) | Model-vs-field contradiction, multi-agency organizational knowledge, resident PII quarantine | `[^cross-incident]` `[^contradiction]` `[^tribal-knowledge]` `[^data-curation]` |
+| 3:00-5:00 | Day 2 morning op period start | Operational period handoff state transfer (KILLER MOMENT 1) | Per-IC preference memory | `[^op-period]` `[^organizational-knowledge]` `[^value-prop]` |
+| 5:00-8:00 | Cross-incident recall & pre-positioning | Cross-incident fuel behavior recall (KILLER MOMENT 2) | Model-vs-field contradiction, multi-agency organizational knowledge, resident PII quarantine | `[^cross-incident]` `[^contradiction]` `[^organizational-knowledge]` `[^data-curation]` |
 | 8:00-10:00 | Wind shift event | Coordinated response with operational period handoff state paying off | Self-correcting Weather agent, humans-in-loop reinforcement | `[^op-period]` `[^cross-incident]` `[^contradiction]` `[^humans-in-loop]` |
 | 10:00-11:30 | Audit trail | Driver_id audit query | Role-vs-person + chain of accountability | `[^audit]` `[^driver-id]` `[^role-vs-person]` `[^identity-triple]` |
 | 11:30-12:00 | Op period handoff & post-event | Operational period handoff at end of period | Cross-incident learning capture | `[^op-period]` `[^cross-incident]` |
@@ -1045,7 +1045,7 @@ specific cuts in priority order:
 3. **Third cut**: shorten the multi-agency organizational knowledge
    moment (R5 strike team briefing pattern) in Segment 4 to
    a single sentence. Save 20 seconds. **Lost milestones**:
-   half of `[^tribal-knowledge]`'s demonstration.
+   half of `[^organizational-knowledge]`'s demonstration.
 4. **Fourth cut**: drop one of the two audit queries in
    Segment 6 (keep the role-based one, drop the
    human-based one, mention the second briefly in
@@ -1409,7 +1409,7 @@ the GitHub issue (if any) tracking the implementation.
     Segments 3-7 implicitly demonstrates the
     enforcement.
 
-[^tribal-knowledge]: **Practitioner organizational knowledge
+[^organizational-knowledge]: **Practitioner organizational knowledge
     memory category**: practices a team or agency has
     developed that aren't formal SOP but are how the team
     actually works. In the emergency response scenario,

--- a/demos/scenarios/public-safety/demo-script-iacp.md
+++ b/demos/scenarios/public-safety/demo-script-iacp.md
@@ -435,7 +435,7 @@ team's geographic analysis.[^cross-incident]
 > mean by the context that makes tactical decisions go
 > well."[^value-prop]
 
-**The organizational knowledge moment (30 seconds)**:[^tribal-knowledge]
+**The organizational knowledge moment (30 seconds)**:[^organizational-knowledge]
 
 > "While the Pattern Analyst is doing its work, watch what
 > happens at the Tip Line Triage agent. Tips are starting to
@@ -460,7 +460,7 @@ team's geographic analysis.[^cross-incident]
   killer moment 1)
 - **Project-scope reads**[^project-scope] (Pattern Analyst
   reading the team's shared memory)
-- **Organizational knowledge memory**[^tribal-knowledge] (the IC
+- **Organizational knowledge memory**[^organizational-knowledge] (the IC
   preference filter)
 - **Value prop landing**[^value-prop]: the headline phrase gets
   its first strong demonstration here
@@ -1010,7 +1010,7 @@ a single table:
 |---|---|---|---|---|
 | 0:00-1:30 | Opening hook & framing | (None — setup) | Phrase, decision-support boundary, no third rails | `[^value-prop]` `[^decision-support-boundary]` `[^humans-in-loop]` |
 | 1:30-3:00 | Search & team intro | Identity model (10 agents register) | Project membership, fleet provisioning | `[^identity-triple]` `[^project-scope]` `[^cli-provisioning]` |
-| 3:00-5:00 | Initial canvass & "we've seen this before" | Cross-incident pattern recognition (KILLER MOMENT 1) | Organizational knowledge | `[^cross-incident]` `[^tribal-knowledge]` `[^value-prop]` |
+| 3:00-5:00 | Initial canvass & "we've seen this before" | Cross-incident pattern recognition (KILLER MOMENT 1) | Organizational knowledge | `[^cross-incident]` `[^organizational-knowledge]` `[^value-prop]` |
 | 5:00-8:00 | Lead development & shift handoff | Driver_id distinction + negative findings discipline | Contradiction detection, agent-operational memory, third-party data quarantine | `[^role-vs-person]` `[^driver-id]` `[^contradiction]` `[^operational-memory]` `[^data-curation]` `[^cross-incident]` |
 | 8:00-10:00 | Convergence | Multi-source convergence linking to prior hypothesis (KILLER MOMENT 2) | Negative findings payoff, source identification quarantine | `[^cross-incident]` `[^narrative-context]` `[^data-curation]` `[^value-prop]` `[^humans-in-loop]` |
 | 10:00-11:30 | Audit trail | Driver_id audit query | Role-vs-person + chain of accountability | `[^audit]` `[^driver-id]` `[^role-vs-person]` `[^identity-triple]` |
@@ -1401,7 +1401,7 @@ GitHub issue (if any) tracking the implementation.
     *Visible in the demo*: the working hypothesis throughout
     Segments 2-5; post-incident lesson capture in Segment 7.
 
-[^tribal-knowledge]: **Practitioner organizational knowledge memory
+[^organizational-knowledge]: **Practitioner organizational knowledge memory
     category**: the practices an agency or team has developed
     that aren't formal SOP but are how the team actually
     works. The "IC Sergeant Hammond's tip queue preference"


### PR DESCRIPTION
## Summary

- Follow-up to #320: renames all `[^tribal-knowledge]` footnote anchor IDs to `[^organizational-knowledge]` across the 5 demo scripts

## Test plan

- [x] All anchor references and definitions updated consistently (34 replacements)
- [x] Only remaining `tribal` in codebase is Meta's external blog post URL