### PR TITLE
research: Update ergonomics research docs to reflect shipped behavior

### DIFF
--- a/research/agent-memory-ergonomics/pivot-detection.md
+++ b/research/agent-memory-ergonomics/pivot-detection.md
@@ -1,12 +1,12 @@
 # Research: Pivot Detection for Pattern C
 
-**Status:** Options identified 2026-04-07. No empirical data yet. Recommendation is a hybrid but needs validation against real agents.
+**Status:** Resolved in implementation. The recommended hybrid shipped: server-side `pivot_suggested` at cosine-distance threshold 0.55 landed with #58 (see docs/design/two-vector-retrieval.md §Pivot detection), and the agent-side rule ships via `memoryhub config init` (#60) in the generated `.claude/rules/memoryhub-loading.md`. One mechanism differs from this research: focus is stateless (a per-call `search_memory` argument), so the server computes distance against the focus passed with the call, not a stored session vector. The validation plan below (empirical threshold tuning, agent-agreement measurement) was never formally run — the 0.55 threshold remains the starting guess in production. Analysis preserved as written.
 
 **Feeds into:** [`../../docs/agent-memory-ergonomics/design.md`](../../docs/agent-memory-ergonomics/design.md) §Loading Patterns (Pattern C), issue #58 (adjacent), open question Q2.
 
 ## Question
 
-Pattern C in the design doc is "lazy load after the first user turn, then rebias the working set when the session pivots to a new topic." This pattern needs a concrete trigger for "a pivot just happened." The vague instruction "watch for pivots and search again" produces inconsistent agent behavior — we know this because the current `.claude/rules/memoryhub-integration.md` already has a version of it and the pivot detection is ad-hoc.
+Pattern C in the design doc is "lazy load after the first user turn, then rebias the working set when the session pivots to a new topic." This pattern needs a concrete trigger for "a pivot just happened." The vague instruction "watch for pivots and search again" produces inconsistent agent behavior — we know this because the pre-#60 hand-written rule (`memoryhub-integration.md`, now the generated `memoryhub-loading.md`) already had a version of it and the pivot detection is ad-hoc.
 
 What's the right way to detect a pivot, and where should the detection live?
 
@@ -91,7 +91,7 @@ still be relevant.
 
 **Cons:**
 - Inconsistent across agents — different LLMs (or different versions of the same LLM) will interpret the rule differently
-- Doesn't scale to non-LLM agents (though this might not matter — the primary consumer is Claude Code and kagenti LangGraph agents)
+- Doesn't scale to non-LLM agents (though this might not matter — the primary consumer is Claude Code and LangGraph agents)
 - No central observability — you can't measure "how often did pivots happen this week" from the server
 - Depends on the agent being disciplined about checking the rule after each turn
 
@@ -161,6 +161,6 @@ Only meaningful once both component validations pass. At that point, run the age
 - `../../docs/agent-memory-ergonomics/design.md` §Loading Patterns (Pattern C) — the design this research supports
 - `../../planning/agent-memory-ergonomics-open-questions.md` Q2 — the question this research tracks
 - `two-vector-retrieval.md` — the session focus vector this detection reuses
-- `../../.claude/rules/memoryhub-integration.md` — current hand-written loading rule with an ad-hoc version of pivot detection
+- `../../.claude/rules/memoryhub-loading.md` (generated; formerly hand-written `memoryhub-integration.md`) — the loading rule containing pivot detection
 - Issue #58 — implementation tracking (the rule template, not the session vector itself)
 - Issue #60 — where the rule file generation lives

--- a/research/agent-memory-ergonomics/two-vector-retrieval.md
+++ b/research/agent-memory-ergonomics/two-vector-retrieval.md
@@ -1,12 +1,12 @@
 # Research: Two-Vector Retrieval Ranking Math
 
-**Status:** Resolved 2026-04-07 (benchmark complete). NEW-1 (RRF blend over cross-encoder rerank) wins. Benchmark results and decision are documented in [§Recommendation (final)](#recommendation-final) below; the original three-option analysis remains for historical reference.
+**Status:** Resolved 2026-04-07 (benchmark complete). NEW-1 (RRF blend over cross-encoder rerank) wins. **Shipped-behavior note:** this research assumed a focus vector stored at `register_session` time; the shipped design is **stateless** — `focus` is passed per `search_memory` call and embedded per call (~50ms warm). The ranking math is identical either way; only where the focus string lives changed. See docs/design/two-vector-retrieval.md. Benchmark results and decision are documented in [§Recommendation (final)](#recommendation-final) below; the original three-option analysis remains for historical reference.
 
 **Feeds into:** [`../../docs/agent-memory-ergonomics/design.md`](../../docs/agent-memory-ergonomics/design.md) §Session Focus and Retrieval Biasing, issue #58, open question Q1 (resolved).
 
 ## Question
 
-Given a query vector `q` (from the current `search_memory` call) and a session focus vector `f` (embedded once at `register_session` time from a declared or inferred focus string), how should `search_memory` combine them into a single ranking?
+Given a query vector `q` (from the current `search_memory` call) and a session focus vector `f` (in this research, assumed embedded once at `register_session` time; as shipped, embedded from the per-call `focus` argument), how should `search_memory` combine them into a single ranking?
 
 The constraint: out-of-focus memories should be **down-weighted, not excluded**. A focused "deployment" session should still surface a UI memory if the user asks a pointed UI question — the session bias should lose to a strong direct query match. But a vague query during a focused session should drift toward memories in the session's focus area rather than the global top-K.
 


### PR DESCRIPTION
## Summary

- Updated status sections in `pivot-detection.md` and `two-vector-retrieval.md` to document what shipped vs proposed
- Key difference: focus is stateless (per-call `search_memory` argument), not a stored session vector
- Fixed stale file references (`memoryhub-integration.md` to `memoryhub-loading.md`)
- Removed stale kagenti reference from pivot-detection cons list