### PR TITLE
authz: Per-request tenant_id selection

### DIFF
--- a/benchmarks/evalhub-adapter/Containerfile
+++ b/benchmarks/evalhub-adapter/Containerfile
@@ -9,15 +9,19 @@ ENV PYTHONUNBUFFERED=1 \
 
 WORKDIR /opt/app-root/src
 
-# Install the AMB harness and adapter together
+# Install the AMB harness, SDK, and adapter together
 COPY benchmarks/amb-harness/pyproject.toml benchmarks/amb-harness/
 COPY benchmarks/amb-harness/src/ benchmarks/amb-harness/src/
 COPY benchmarks/evalhub-adapter/src/ benchmarks/evalhub-adapter/src/
 COPY benchmarks/evalhub-adapter/main.py .
 COPY benchmarks/evalhub-adapter/pyproject.toml benchmarks/evalhub-adapter/
+COPY sdk/pyproject.toml sdk/
+COPY sdk/README.md sdk/
+COPY sdk/src/ sdk/src/
 
-# Install dependencies
+# Install dependencies (local SDK overrides PyPI version)
 RUN pip install --no-cache-dir \
+    ./sdk \
     ./benchmarks/amb-harness \
     ./benchmarks/evalhub-adapter \
     oras>=0.2.42 \

--- a/benchmarks/evalhub-adapter/config/matrix/baseline.yaml
+++ b/benchmarks/evalhub-adapter/config/matrix/baseline.yaml
@@ -1,0 +1,19 @@
+name: ablation-baseline
+description: Full RRF pipeline (all signals enabled)
+model:
+  url: https://generativelanguage.googleapis.com
+  name: gemini-3.1-flash-lite
+  auth:
+    secret_ref: gemini-api-key
+benchmarks:
+  - id: personamem-mcq
+    provider_id: b7a94a1e-f499-4deb-afe9-e52d53445604
+    parameters:
+      mode: library
+      dataset: personamem
+      dataset_variant: "32k"
+      memory_provider: memoryhub
+      skip_ingestion: true
+      query_limit: 589
+experiment:
+  name: memoryhub/personamem-mcq/32k

--- a/benchmarks/evalhub-adapter/config/matrix/bm25-only.yaml
+++ b/benchmarks/evalhub-adapter/config/matrix/bm25-only.yaml
@@ -1,0 +1,20 @@
+name: ablation-bm25-only
+description: Pure BM25 baseline (all non-BM25 signals disabled)
+model:
+  url: https://generativelanguage.googleapis.com
+  name: gemini-3.1-flash-lite
+  auth:
+    secret_ref: gemini-api-key
+benchmarks:
+  - id: personamem-mcq
+    provider_id: b7a94a1e-f499-4deb-afe9-e52d53445604
+    parameters:
+      mode: library
+      dataset: personamem
+      dataset_variant: "32k"
+      memory_provider: memoryhub
+      skip_ingestion: true
+      query_limit: 589
+      disabled_signals: reranker,focus,keyword,domain,graph
+experiment:
+  name: memoryhub/personamem-mcq/32k

--- a/benchmarks/evalhub-adapter/config/matrix/no-domain.yaml
+++ b/benchmarks/evalhub-adapter/config/matrix/no-domain.yaml
@@ -1,0 +1,20 @@
+name: ablation-no-domain
+description: RRF without domain filtering
+model:
+  url: https://generativelanguage.googleapis.com
+  name: gemini-3.1-flash-lite
+  auth:
+    secret_ref: gemini-api-key
+benchmarks:
+  - id: personamem-mcq
+    provider_id: b7a94a1e-f499-4deb-afe9-e52d53445604
+    parameters:
+      mode: library
+      dataset: personamem
+      dataset_variant: "32k"
+      memory_provider: memoryhub
+      skip_ingestion: true
+      query_limit: 589
+      disabled_signals: domain
+experiment:
+  name: memoryhub/personamem-mcq/32k

--- a/benchmarks/evalhub-adapter/config/matrix/no-focus.yaml
+++ b/benchmarks/evalhub-adapter/config/matrix/no-focus.yaml
@@ -1,0 +1,20 @@
+name: ablation-no-focus
+description: RRF without focus-weighted boost
+model:
+  url: https://generativelanguage.googleapis.com
+  name: gemini-3.1-flash-lite
+  auth:
+    secret_ref: gemini-api-key
+benchmarks:
+  - id: personamem-mcq
+    provider_id: b7a94a1e-f499-4deb-afe9-e52d53445604
+    parameters:
+      mode: library
+      dataset: personamem
+      dataset_variant: "32k"
+      memory_provider: memoryhub
+      skip_ingestion: true
+      query_limit: 589
+      disabled_signals: focus
+experiment:
+  name: memoryhub/personamem-mcq/32k

--- a/benchmarks/evalhub-adapter/config/matrix/no-graph.yaml
+++ b/benchmarks/evalhub-adapter/config/matrix/no-graph.yaml
@@ -1,0 +1,20 @@
+name: ablation-no-graph
+description: RRF without graph-based retrieval
+model:
+  url: https://generativelanguage.googleapis.com
+  name: gemini-3.1-flash-lite
+  auth:
+    secret_ref: gemini-api-key
+benchmarks:
+  - id: personamem-mcq
+    provider_id: b7a94a1e-f499-4deb-afe9-e52d53445604
+    parameters:
+      mode: library
+      dataset: personamem
+      dataset_variant: "32k"
+      memory_provider: memoryhub
+      skip_ingestion: true
+      query_limit: 589
+      disabled_signals: graph
+experiment:
+  name: memoryhub/personamem-mcq/32k

--- a/benchmarks/evalhub-adapter/config/matrix/no-keyword.yaml
+++ b/benchmarks/evalhub-adapter/config/matrix/no-keyword.yaml
@@ -1,0 +1,20 @@
+name: ablation-no-keyword
+description: RRF without keyword signal
+model:
+  url: https://generativelanguage.googleapis.com
+  name: gemini-3.1-flash-lite
+  auth:
+    secret_ref: gemini-api-key
+benchmarks:
+  - id: personamem-mcq
+    provider_id: b7a94a1e-f499-4deb-afe9-e52d53445604
+    parameters:
+      mode: library
+      dataset: personamem
+      dataset_variant: "32k"
+      memory_provider: memoryhub
+      skip_ingestion: true
+      query_limit: 589
+      disabled_signals: keyword
+experiment:
+  name: memoryhub/personamem-mcq/32k

--- a/benchmarks/evalhub-adapter/config/matrix/no-reranker.yaml
+++ b/benchmarks/evalhub-adapter/config/matrix/no-reranker.yaml
@@ -1,0 +1,20 @@
+name: ablation-no-reranker
+description: RRF without reranker signal
+model:
+  url: https://generativelanguage.googleapis.com
+  name: gemini-3.1-flash-lite
+  auth:
+    secret_ref: gemini-api-key
+benchmarks:
+  - id: personamem-mcq
+    provider_id: b7a94a1e-f499-4deb-afe9-e52d53445604
+    parameters:
+      mode: library
+      dataset: personamem
+      dataset_variant: "32k"
+      memory_provider: memoryhub
+      skip_ingestion: true
+      query_limit: 589
+      disabled_signals: reranker
+experiment:
+  name: memoryhub/personamem-mcq/32k

--- a/benchmarks/evalhub-adapter/config/provider.yaml
+++ b/benchmarks/evalhub-adapter/config/provider.yaml
@@ -16,6 +16,9 @@ runtime:
     memory_request: "1Gi"
     cpu_limit: "2"
     memory_limit: "4Gi"
+    # MemoryHub connection env vars are injected at registration time
+    # by deploy-evalhub.sh (not committed to git with real values).
+    # DB env vars only needed when skip_ingestion is false.
 benchmarks:
   - id: personamem-mcq
     name: PersonaMem MCQ

--- a/benchmarks/evalhub-adapter/config/smoke-eval.yaml
+++ b/benchmarks/evalhub-adapter/config/smoke-eval.yaml
@@ -7,7 +7,7 @@ model:
     secret_ref: gemini-api-key
 benchmarks:
   - id: personamem-mcq
-    provider_id: 7b488af5-50b7-4793-8cdc-7e0f2efee1d8
+    provider_id: b7a94a1e-f499-4deb-afe9-e52d53445604
     parameters:
       mode: library
       dataset: personamem

--- a/benchmarks/evalhub-adapter/src/memoryhub_evalhub/adapter.py
+++ b/benchmarks/evalhub-adapter/src/memoryhub_evalhub/adapter.py
@@ -38,6 +38,7 @@ class AMBAdapter(FrameworkAdapter):
             memoryhub_url:   MemoryHub server URL (optional)
             memoryhub_api_key: MemoryHub API key (optional)
             disabled_signals: comma-separated signal names to disable (optional)
+            skip_ingestion:  if true, skip data ingestion (reuse existing data)
             query_limit:     max queries (optional, None = all)
             category:        category filter (optional)
             output_dir:      output directory (optional)
@@ -96,12 +97,20 @@ class AMBAdapter(FrameworkAdapter):
         elif "MEMORYHUB_DISABLED_SIGNALS" in os.environ:
             del os.environ["MEMORYHUB_DISABLED_SIGNALS"]
 
+        # Wire DB connection for memoryhub provider (params override env vars)
+        for db_key in ("MEMORYHUB_DB_HOST", "MEMORYHUB_DB_PORT", "MEMORYHUB_DB_USER",
+                       "MEMORYHUB_DB_PASS", "MEMORYHUB_DB_NAME"):
+            param_key = db_key.lower()
+            if params.get(param_key):
+                os.environ[db_key] = str(params[param_key])
+
         dataset_name = params.get("dataset", "personamem")
         split = params.get("dataset_variant", "32k")
         mode_name = params.get("mode", "library")
         memory_name = params.get("memory_provider", "memoryhub")
         query_limit = params.get("query_limit")
         category = params.get("category")
+        skip_ingestion = params.get("skip_ingestion", False)
         output_dir = Path(params.get("output_dir", "outputs"))
 
         ds = get_dataset(dataset_name)
@@ -127,6 +136,7 @@ class AMBAdapter(FrameworkAdapter):
             mode=mode,
             category=category,
             query_limit=query_limit,
+            skip_ingestion=skip_ingestion,
             run_name=run_name,
             description=f"EvalHub job {config.id}",
         )

--- a/memory-hub-mcp/deploy/users-configmap.example.yaml
+++ b/memory-hub-mcp/deploy/users-configmap.example.yaml
@@ -27,6 +27,7 @@ data:
           "user_id": "wjackson",
           "name": "Wes Jackson",
           "api_key": "REPLACE-ME-GENERATE-WITH-openssl-rand-hex-16",
+          "tenant_id": "default",
           "scopes": ["user", "project", "role", "organizational", "enterprise"],
           "project_memberships": [],
           "_comment": "primary operator"
@@ -35,6 +36,7 @@ data:
           "user_id": "dev-test",
           "name": "Test User",
           "api_key": "REPLACE-ME-GENERATE-WITH-openssl-rand-hex-16",
+          "tenant_id": "default",
           "scopes": ["user", "project"],
           "project_memberships": [],
           "_comment": "local development and integration testing"
@@ -43,6 +45,7 @@ data:
           "user_id": "rdwj-agent-1",
           "name": "RDWJ Agent 1",
           "api_key": "REPLACE-ME-GENERATE-WITH-openssl-rand-hex-16",
+          "tenant_id": "default",
           "scopes": ["user", "project", "role", "organizational", "enterprise"],
           "project_memberships": [],
           "_comment": "agent automation slot 1"
@@ -51,6 +54,7 @@ data:
           "user_id": "rdwj-agent-2",
           "name": "RDWJ Agent 2",
           "api_key": "REPLACE-ME-GENERATE-WITH-openssl-rand-hex-16",
+          "tenant_id": "default",
           "scopes": ["user", "project", "role", "organizational", "enterprise"],
           "project_memberships": [],
           "_comment": "agent automation slot 2"
@@ -59,6 +63,7 @@ data:
           "user_id": "kagenti-ci",
           "name": "Kagenti CI",
           "api_key": "REPLACE-ME-GENERATE-WITH-openssl-rand-hex-16",
+          "tenant_id": "default",
           "scopes": ["user", "project"],
           "project_memberships": [],
           "_comment": "kagenti-adk E2E test runner (see docs/SYSTEMS.md)"
@@ -68,6 +73,7 @@ data:
           "name": "Trace Reviewer Agent",
           "api_key": "REPLACE-ME-GENERATE-WITH-openssl-rand-hex-16",
           "identity_type": "service",
+          "tenant_id": "default",
           "scopes": ["user", "project"],
           "project_memberships": [],
           "_comment": "reviews completed session traces to extract missed memories (#284)"
@@ -77,6 +83,7 @@ data:
           "name": "Curator Agent",
           "api_key": "REPLACE-ME-GENERATE-WITH-openssl-rand-hex-16",
           "identity_type": "service",
+          "tenant_id": "default",
           "scopes": ["organizational", "role", "campaign"],
           "project_memberships": [],
           "_comment": "periodic deep curation: dedup, merge, promotion (#284)"
@@ -86,6 +93,7 @@ data:
           "name": "Fact Checker Agent",
           "api_key": "REPLACE-ME-GENERATE-WITH-openssl-rand-hex-16",
           "identity_type": "service",
+          "tenant_id": "default",
           "scopes": ["user", "project", "campaign"],
           "project_memberships": [],
           "_comment": "periodic verification of factual claims in memories (#284)"
@@ -95,6 +103,7 @@ data:
           "name": "Statistician Agent",
           "api_key": "REPLACE-ME-GENERATE-WITH-openssl-rand-hex-16",
           "identity_type": "service",
+          "tenant_id": "default",
           "scopes": ["organizational", "campaign"],
           "project_memberships": [],
           "_comment": "population-level pattern aggregation and convergence signals (#284)"

--- a/memory-hub-mcp/src/core/authz.py
+++ b/memory-hub-mcp/src/core/authz.py
@@ -8,7 +8,7 @@ authorize_read / authorize_write helpers consume uniformly.
 import os
 
 from src.core.logging import get_logger
-from src.tools.auth import get_current_user
+from src.tools.auth import DEFAULT_TENANT_ID, get_current_user
 
 log = get_logger("authz")
 
@@ -86,7 +86,7 @@ def get_claims_from_context() -> dict:
         claims = {
             "sub": token.claims.get("sub", token.client_id),
             "identity_type": token.claims.get("identity_type", "user"),
-            "tenant_id": token.claims.get("tenant_id", "default"),
+            "tenant_id": token.claims.get("tenant_id", DEFAULT_TENANT_ID),
             "scopes": list(token.scopes),
             "project_memberships": token.claims.get("project_memberships", []),
         }
@@ -105,7 +105,7 @@ def get_claims_from_context() -> dict:
         claims = {
             "sub": jwt_claims.get("sub", "unknown"),
             "identity_type": jwt_claims.get("identity_type", "user"),
-            "tenant_id": jwt_claims.get("tenant_id", "default"),
+            "tenant_id": jwt_claims.get("tenant_id", DEFAULT_TENANT_ID),
             "scopes": scopes,
             "project_memberships": jwt_claims.get("project_memberships", []),
         }
@@ -125,7 +125,7 @@ def get_claims_from_context() -> dict:
         claims = {
             "sub": user["user_id"],
             "identity_type": user.get("identity_type", "user"),
-            "tenant_id": user.get("tenant_id", "default"),
+            "tenant_id": user.get("tenant_id", DEFAULT_TENANT_ID),
             "scopes": scopes,
             "project_memberships": user.get("project_memberships", []),
         }
@@ -150,7 +150,7 @@ def authorize_read(
     # not even learn that the memory exists. Run BEFORE scope/owner checks
     # so a tenant mismatch short-circuits everything else, including blanket
     # "memory:read" scopes.
-    if memory.tenant_id != claims.get("tenant_id", "default"):
+    if memory.tenant_id != claims.get("tenant_id", DEFAULT_TENANT_ID):
         return False
 
     scopes = claims.get("scopes", [])
@@ -202,7 +202,7 @@ def authorize_write(
     # The tenant_id passed in is the tenant of the memory being written; the
     # caller's tenant comes from claims. Mismatch is a hard reject regardless
     # of scope/identity_type.
-    if tenant_id != claims.get("tenant_id", "default"):
+    if tenant_id != claims.get("tenant_id", DEFAULT_TENANT_ID):
         return False
 
     scopes = claims.get("scopes", [])
@@ -305,7 +305,31 @@ def get_tenant_filter(claims: dict) -> str:
     Phase 2 introduces this helper; Phase 4 wires it into the read/search
     service paths.
     """
-    return claims.get("tenant_id", "default")
+    return claims.get("tenant_id", DEFAULT_TENANT_ID)
+
+
+def resolve_tenant(claims: dict, override: str | None = None) -> str:
+    """Return the effective tenant for this request.
+
+    When *override* is provided and the caller is authorized for that
+    tenant, it takes precedence over the session/claims tenant. When
+    omitted (or matches the caller's own tenant), falls back to the
+    claims tenant.
+
+    Phase 1: callers may only use their own tenant.
+    Phase 2: ``authorized_tenants`` in claims enables cross-tenant access.
+    """
+    own_tenant = claims.get("tenant_id", DEFAULT_TENANT_ID)
+    if override is None or override == own_tenant:
+        return own_tenant
+    authorized = claims.get("authorized_tenants")
+    if authorized and override in authorized:
+        return override
+    from fastmcp.exceptions import ToolError
+    raise ToolError(
+        f"Not authorized for tenant '{override}'. "
+        f"Your session is scoped to tenant '{own_tenant}'."
+    )
 
 
 def authorize_thread_read(
@@ -319,7 +343,7 @@ def authorize_thread_read(
     Scope-level threads:read permissions provide broader access.
     """
     # Tenant isolation first
-    if thread.tenant_id != claims.get("tenant_id", "default"):
+    if thread.tenant_id != claims.get("tenant_id", DEFAULT_TENANT_ID):
         return False
 
     caller_id = claims["sub"]
@@ -368,7 +392,7 @@ def authorize_thread_write(
     threads:write permissions provide broader access.
     """
     # Tenant isolation first
-    if thread.tenant_id != claims.get("tenant_id", "default"):
+    if thread.tenant_id != claims.get("tenant_id", DEFAULT_TENANT_ID):
         return False
 
     caller_id = claims["sub"]
@@ -419,7 +443,7 @@ def authorize_thread_admin(
 
     Only thread owner or holders of threads:admin scope permission.
     """
-    if thread.tenant_id != claims.get("tenant_id", "default"):
+    if thread.tenant_id != claims.get("tenant_id", DEFAULT_TENANT_ID):
         return False
 
     caller_id = claims["sub"]

--- a/memory-hub-mcp/src/tools/auth.py
+++ b/memory-hub-mcp/src/tools/auth.py
@@ -23,6 +23,8 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_TENANT_ID = os.environ.get("MEMORYHUB_DEFAULT_TENANT", "default")
+
 # Module-level session state (one session per MCP process/connection).
 _current_session: dict[str, Any] | None = None
 _session_expires_at: datetime | None = None
@@ -82,6 +84,12 @@ def _load_users() -> None:
     try:
         data = json.loads(raw)
         users: list[dict[str, Any]] = data.get("users", [])
+        for u in users:
+            if "tenant_id" not in u:
+                logger.warning(
+                    "User %s missing tenant_id, will use default: %s",
+                    u.get("user_id", "?"), DEFAULT_TENANT_ID,
+                )
         _users_by_key = {u["api_key"]: u for u in users if "api_key" in u}
         logger.info("Loaded %d user record(s) for authentication", len(_users_by_key))
     except (json.JSONDecodeError, KeyError) as exc:
@@ -147,7 +155,7 @@ async def authenticate_remote(api_key: str) -> dict[str, Any] | None:
             "user_id": data["user_id"],
             "name": data["name"],
             "identity_type": data.get("identity_type", "user"),
-            "tenant_id": data.get("tenant_id", "default"),
+            "tenant_id": data.get("tenant_id", DEFAULT_TENANT_ID),
             "scopes": data["scopes"],
         }
         _remote_key_cache[key_hash] = (user_dict, time.time() + _CACHE_TTL)

--- a/memory-hub-mcp/src/tools/list_memory.py
+++ b/memory-hub-mcp/src/tools/list_memory.py
@@ -23,7 +23,7 @@ from src.core.authz import (
     AuthenticationError,
     build_authorized_scopes,
     get_claims_from_context,
-    get_tenant_filter,
+    resolve_tenant,
 )
 from src.tools._deps import get_db_session, release_db_session
 
@@ -93,6 +93,15 @@ async def list_memory(
             ),
         ),
     ] = True,
+    tenant_id: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Target tenant to list from. Omit to use the session's "
+                "own tenant. Must be a tenant the caller is authorized for."
+            ),
+        ),
+    ] = None,
     ctx: Context = None,
 ) -> dict[str, Any]:
     """List memories in a scope without semantic search.
@@ -107,7 +116,7 @@ async def list_memory(
         raise ToolError(str(exc)) from None
 
     authorized = build_authorized_scopes(claims)
-    tenant = get_tenant_filter(claims)
+    tenant = resolve_tenant(claims, tenant_id)
 
     campaign_ids: set[str] | None = None
     if project_id:

--- a/memory-hub-mcp/src/tools/manage_graph.py
+++ b/memory-hub-mcp/src/tools/manage_graph.py
@@ -33,6 +33,7 @@ from memoryhub_core.services.role import get_roles_for_user
 from src.core.app import mcp
 from src.core.audit import record_event
 from src.core.authz import (
+    DEFAULT_TENANT_ID,
     AuthenticationError,
     authorize_read,
     get_claims_from_context,
@@ -478,7 +479,7 @@ async def _handle_get_relationships(
                 proxy = SimpleNamespace(
                     scope=node_data.get("scope", "user"),
                     owner_id=node_data.get("owner_id", ""),
-                    tenant_id=node_data.get("tenant_id", "default"),
+                    tenant_id=node_data.get("tenant_id", DEFAULT_TENANT_ID),
                 )
                 if not authorize_read(
                     claims, proxy,
@@ -504,7 +505,7 @@ async def _handle_get_relationships(
             proxy = SimpleNamespace(
                 scope=node_dump.get("scope", "user"),
                 owner_id=node_dump.get("owner_id", ""),
-                tenant_id=node_dump.get("tenant_id", "default"),
+                tenant_id=node_dump.get("tenant_id", DEFAULT_TENANT_ID),
             )
             if authorize_read(
                 claims, proxy,

--- a/memory-hub-mcp/src/tools/memory.py
+++ b/memory-hub-mcp/src/tools/memory.py
@@ -41,13 +41,15 @@ _SEARCH_OPTS = frozenset({
     "current_only", "owner_id", "graph_depth",
     "graph_relationship_types", "graph_boost_weight", "entities",
     "content_type", "verbose", "temporal_status", "disabled_signals",
+    "tenant_id",
 })
 _LIST_OPTS = frozenset({
     "max_results", "cursor", "include_branches", "current_only",
-    "content_type", "verbose",
+    "content_type", "verbose", "tenant_id",
 })
 _READ_OPTS = frozenset({
     "include_versions", "history_offset", "history_max_versions", "hydrate",
+    "tenant_id",
 })
 _SIMILAR_OPTS = frozenset({"threshold", "max_results", "offset"})
 _RELATIONSHIPS_OPTS = frozenset({
@@ -59,7 +61,7 @@ _RECONSTRUCT_OPTS = frozenset({"owner_id"})
 _WRITE_OPTS = frozenset({
     "weight", "parent_id", "branch_type", "metadata", "domains",
     "project_description", "force", "owner_id", "content_type",
-    "driver_id", "relevant_until",
+    "driver_id", "relevant_until", "tenant_id",
 })
 _UPDATE_OPTS = frozenset({"weight", "metadata", "domains", "driver_id"})
 _SET_RULE_OPTS = frozenset({

--- a/memory-hub-mcp/src/tools/read_memory.py
+++ b/memory-hub-mcp/src/tools/read_memory.py
@@ -20,7 +20,7 @@ from src.core.authz import (
     AuthenticationError,
     authorize_read,
     get_claims_from_context,
-    get_tenant_filter,
+    resolve_tenant,
 )
 from src.tools._deps import get_db_session, get_s3_adapter, release_db_session
 
@@ -91,6 +91,15 @@ async def read_memory(
             ),
         ),
     ] = None,
+    tenant_id: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Target tenant to read from. Omit to use the session's "
+                "own tenant. Must be a tenant the caller is authorized for."
+            ),
+        ),
+    ] = None,
     ctx: Context = None,
 ) -> dict[str, Any]:
     """Retrieve a memory by ID, with optional paginated version history.
@@ -124,7 +133,7 @@ async def read_memory(
             claims = get_claims_from_context()
         except AuthenticationError as exc:
             raise ToolError(str(exc)) from exc
-        tenant = get_tenant_filter(claims)
+        tenant = resolve_tenant(claims, tenant_id)
 
         session, gen = await get_db_session()
 

--- a/memory-hub-mcp/src/tools/register_session.py
+++ b/memory-hub-mcp/src/tools/register_session.py
@@ -37,6 +37,7 @@ from src.core.audit import record_event
 from src.core.authz import get_tenant_filter
 from src.tools._deps import get_db_session, release_db_session
 from src.tools.auth import (
+    DEFAULT_TENANT_ID,
     AuthServiceUnavailableError,
     authenticate,
     authenticate_remote,
@@ -339,7 +340,7 @@ async def register_session(
         await ctx.info(f"Session {session_id} registered for user: {user['user_id']}")
 
     tenant = get_tenant_filter(
-        {"sub": user["user_id"], "tenant_id": user.get("tenant_id", "default")}
+        {"sub": user["user_id"], "tenant_id": user.get("tenant_id", DEFAULT_TENANT_ID)}
     )
     projects = await _fetch_user_projects(user["user_id"], tenant)
 

--- a/memory-hub-mcp/src/tools/search_memory.py
+++ b/memory-hub-mcp/src/tools/search_memory.py
@@ -54,7 +54,7 @@ from src.core.authz import (
     AuthenticationError,
     build_authorized_scopes,
     get_claims_from_context,
-    get_tenant_filter,
+    resolve_tenant,
 )
 from src.tools._deps import (
     get_db_session,
@@ -691,6 +691,15 @@ async def search_memory(
             ),
         ),
     ] = None,
+    tenant_id: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Target tenant to search in. Omit to use the session's "
+                "own tenant. Must be a tenant the caller is authorized for."
+            ),
+        ),
+    ] = None,
     ctx: Context = None,
 ) -> dict[str, Any]:
     """Search memories using semantic similarity.
@@ -774,7 +783,7 @@ async def search_memory(
     # Build RBAC visibility filter + resolve caller tenant for SQL-level
     # isolation. Tenant filter is ALWAYS applied, independent of scopes.
     authorized = build_authorized_scopes(claims)
-    tenant = get_tenant_filter(claims)
+    tenant = resolve_tenant(claims, tenant_id)
 
     # Resolve campaign membership when project_id is provided. The
     # campaign_ids set feeds into _build_search_filters so campaign-scoped

--- a/memory-hub-mcp/src/tools/write_memory.py
+++ b/memory-hub-mcp/src/tools/write_memory.py
@@ -30,7 +30,7 @@ from src.core.authz import (
     AuthenticationError,
     authorize_write,
     get_claims_from_context,
-    get_tenant_filter,
+    resolve_tenant,
 )
 from src.tools._deps import (
     get_db_session,
@@ -202,6 +202,15 @@ async def write_memory(
             ),
         ),
     ] = None,
+    tenant_id: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Target tenant for this write. Omit to use the session's "
+                "own tenant. Must be a tenant the caller is authorized for."
+            ),
+        ),
+    ] = None,
     ctx: Context = None,
 ) -> dict[str, Any]:
     """Create a new memory node or branch in the memory tree.
@@ -230,12 +239,7 @@ async def write_memory(
     if owner_id is None:
         owner_id = claims["sub"]
 
-    # Tool-layer writes always create new memories in the caller's own
-    # tenant. Phase 2 wired this into authorize_write; Phase 3 plumbs the
-    # same tenant_id through the service-layer insert so every row is
-    # stamped explicitly (rather than relying on the column's
-    # server_default of "default").
-    write_tenant_id = get_tenant_filter(claims)
+    write_tenant_id = resolve_tenant(claims, tenant_id)
 
     # Resolve campaign membership when writing to campaign scope.
     campaign_ids: set[str] | None = None

--- a/scripts/deploy-evalhub.sh
+++ b/scripts/deploy-evalhub.sh
@@ -227,17 +227,43 @@ else
     evalhub config set tenant "$NS" 2>/dev/null || true
 
     # SQLite file-backed DB loses providers on pod restart; always re-register
+    # Generate provider spec with MemoryHub connection env vars
+    MEMORYHUB_MCP_URL="http://memory-hub-mcp.memory-hub-mcp.svc:8080/mcp/"
+    MEMORYHUB_KEY=$(bash -c 'cat ~/.config/memoryhub/api-key 2>/dev/null' | tr -d '[:space:]')
+    MEMORYHUB_DB_PASSWORD=$(oc get secret memoryhub-db-credentials --context "$CONTEXT" -n memory-hub-mcp \
+        -o jsonpath='{.data.MEMORYHUB_DB_PASSWORD}' 2>/dev/null | base64 -d || true)
+
+    PROVIDER_SPEC=$(mktemp)
+    trap "rm -f $PROVIDER_SPEC" EXIT
+    python3 -c "
+import yaml, sys
+with open('$CONFIG_DIR/provider.yaml') as f:
+    spec = yaml.safe_load(f)
+spec.setdefault('runtime', {}).setdefault('k8s', {})['env'] = [
+    {'name': 'MEMORYHUB_URL', 'value': '$MEMORYHUB_MCP_URL'},
+    {'name': 'MEMORYHUB_API_KEY', 'value': '$MEMORYHUB_KEY'},
+    {'name': 'MEMORYHUB_DB_HOST', 'value': 'memoryhub-pg.memoryhub-db.svc.cluster.local'},
+    {'name': 'MEMORYHUB_DB_PORT', 'value': '5432'},
+    {'name': 'MEMORYHUB_DB_USER', 'value': 'memoryhub'},
+    {'name': 'MEMORYHUB_DB_PASS', 'value': '$MEMORYHUB_DB_PASSWORD'},
+    {'name': 'MEMORYHUB_DB_NAME', 'value': 'memoryhub'},
+]
+yaml.dump(spec, sys.stdout, default_flow_style=False)
+" > "$PROVIDER_SPEC"
+
     info "Registering provider memoryhub-amb..."
-    PROVIDER_OUTPUT=$(evalhub providers create --file "$CONFIG_DIR/provider.yaml" 2>&1) || true
+    PROVIDER_OUTPUT=$(evalhub providers create --file "$PROVIDER_SPEC" 2>&1) || true
     PROVIDER_ID=$(echo "$PROVIDER_OUTPUT" | sed -n 's/.*Provider created: \([a-f0-9-]*\).*/\1/p')
     if [ -n "$PROVIDER_ID" ]; then
         info "Provider registered: $PROVIDER_ID"
-        # Update smoke-eval.yaml with current provider ID
-        if [ -f "$CONFIG_DIR/smoke-eval.yaml" ]; then
-            sed -i.bak "s|provider_id: .*|provider_id: $PROVIDER_ID|" "$CONFIG_DIR/smoke-eval.yaml"
-            rm -f "$CONFIG_DIR/smoke-eval.yaml.bak"
-            info "Updated smoke-eval.yaml with provider ID"
-        fi
+        # Update all eval configs with current provider ID
+        for cfg in "$CONFIG_DIR/smoke-eval.yaml" "$CONFIG_DIR"/matrix/*.yaml; do
+            if [ -f "$cfg" ]; then
+                sed -i.bak "s|provider_id: .*|provider_id: $PROVIDER_ID|" "$cfg"
+                rm -f "${cfg}.bak"
+            fi
+        done
+        info "Updated eval configs with provider ID"
     else
         warn "Provider registration failed (server may not be reachable yet)"
         warn "Re-run after EvalHub is accessible:"

--- a/sdk/src/memoryhub/client.py
+++ b/sdk/src/memoryhub/client.py
@@ -483,6 +483,7 @@ class MemoryHubClient:
         raw_results: bool = False,
         content_type: str | None = None,
         disabled_signals: list[str] | None = None,
+        tenant_id: str | None = None,
     ) -> SearchResult:
         """Search memories using semantic similarity.
 
@@ -537,6 +538,7 @@ class MemoryHubClient:
             disabled_signals: RRF signals to disable for ablation testing.
                 Valid names: reranker, focus, keyword, domain, graph.
                 Vector similarity is always active.
+            tenant_id: Optional tenant identifier.
         """
         defaults = self._project_config.retrieval_defaults
         loading = self._project_config.memory_loading
@@ -574,6 +576,8 @@ class MemoryHubClient:
             opts["content_type"] = content_type
         if disabled_signals is not None:
             opts["disabled_signals"] = disabled_signals
+        if tenant_id is not None:
+            opts["tenant_id"] = tenant_id
 
         data = await self._call_action(
             "search",
@@ -640,6 +644,7 @@ class MemoryHubClient:
         history_offset: int = 0,
         history_max_versions: int = 10,
         project_id: str | None = None,
+        tenant_id: str | None = None,
     ) -> Memory:
         """Read a memory by ID, optionally with paginated version history.
 
@@ -658,11 +663,14 @@ class MemoryHubClient:
             history_offset: Versions to skip from newest (default 0).
             history_max_versions: Max versions to return (1-100, default 10).
             project_id: Project identifier for campaign enrollment verification.
+            tenant_id: Optional tenant identifier.
         """
         opts: dict[str, Any] = {"include_versions": include_versions}
         if include_versions:
             opts["history_offset"] = history_offset
             opts["history_max_versions"] = history_max_versions
+        if tenant_id is not None:
+            opts["tenant_id"] = tenant_id
         data = await self._call_action(
             "read",
             memory_id=memory_id,
@@ -681,6 +689,7 @@ class MemoryHubClient:
         include_branches: bool = False,
         current_only: bool = True,
         content_type: str | None = None,
+        tenant_id: str | None = None,
     ) -> dict[str, Any]:
         """Enumerate memories without semantic ranking.
 
@@ -697,6 +706,7 @@ class MemoryHubClient:
             current_only: If True, only current versions.
             content_type: Filter by content type. "declarative" for facts and
                 preferences, "behavioral" for demonstrated patterns. Omit to list all types.
+            tenant_id: Optional tenant identifier.
         """
         opts: dict[str, Any] = {
             "max_results": max_results,
@@ -707,6 +717,8 @@ class MemoryHubClient:
             opts["cursor"] = cursor
         if content_type is not None:
             opts["content_type"] = content_type
+        if tenant_id is not None:
+            opts["tenant_id"] = tenant_id
         return await self._call_action(
             "list",
             scope=scope,
@@ -758,6 +770,7 @@ class MemoryHubClient:
         domains: list[str] | None = None,
         force: bool = False,
         content_type: str | None = None,
+        tenant_id: str | None = None,
     ) -> WriteResult:
         """Write a new memory.
 
@@ -777,6 +790,7 @@ class MemoryHubClient:
                 and preferences, "behavioral" for demonstrated patterns and
                 successful approaches. Behavioral memories are not injected by
                 default — use the reconstruct action to retrieve them.
+            tenant_id: Optional tenant identifier.
 
         Returns:
             A WriteResult. When curation detects a near-duplicate, the memory is
@@ -800,6 +814,8 @@ class MemoryHubClient:
             opts["force"] = True
         if content_type is not None:
             opts["content_type"] = content_type
+        if tenant_id is not None:
+            opts["tenant_id"] = tenant_id
         data = await self._call_action(
             "write",
             content=content,
@@ -818,6 +834,7 @@ class MemoryHubClient:
         metadata: dict[str, Any] | None = None,
         project_id: str | None = None,
         domains: list[str] | None = None,
+        tenant_id: str | None = None,
     ) -> Memory:
         """Update an existing memory (creates a new version).
 
@@ -830,6 +847,7 @@ class MemoryHubClient:
             metadata: New metadata dict (replaces existing).
             project_id: Project identifier for campaign enrollment verification.
             domains: Domain tags for the memory, e.g. ['React', 'Spring Boot'].
+            tenant_id: Optional tenant identifier.
         """
         if content is None and weight is None and metadata is None:
             raise ValueError("update() requires at least one of: content, weight, metadata")
@@ -840,6 +858,8 @@ class MemoryHubClient:
             opts["metadata"] = metadata
         if domains is not None:
             opts["domains"] = domains
+        if tenant_id is not None:
+            opts["tenant_id"] = tenant_id
         data = await self._call_action(
             "update",
             memory_id=memory_id,
@@ -849,17 +869,28 @@ class MemoryHubClient:
         )
         return Memory.model_validate(data)
 
-    async def delete(self, memory_id: str, *, project_id: str | None = None) -> DeleteResult:
+    async def delete(
+        self,
+        memory_id: str,
+        *,
+        project_id: str | None = None,
+        tenant_id: str | None = None,
+    ) -> DeleteResult:
         """Soft-delete a memory and its entire version chain.
 
         Args:
             memory_id: ID of the memory to delete.
             project_id: Project identifier for campaign enrollment verification.
+            tenant_id: Optional tenant identifier.
         """
+        opts: dict[str, Any] = {}
+        if tenant_id is not None:
+            opts["tenant_id"] = tenant_id
         data = await self._call_action(
             "delete",
             memory_id=memory_id,
             project_id=project_id,
+            options=opts or None,
         )
         return DeleteResult.model_validate(data)
 
@@ -1758,12 +1789,12 @@ class MemoryHubClient:
 
         return self._run_sync(_do())
 
-    def delete_sync(self, memory_id: str) -> DeleteResult:
+    def delete_sync(self, memory_id: str, **kwargs) -> DeleteResult:
         """Synchronous wrapper for delete()."""
 
         async def _do():
             async with self:
-                return await self.delete(memory_id)
+                return await self.delete(memory_id, **kwargs)
 
         return self._run_sync(_do())
 


### PR DESCRIPTION
## Summary

- Add `resolve_tenant(claims, override)` to authz.py for per-request tenant selection. Phase 1 restricts callers to their own tenant; Phase 2 will add `authorized_tenants` JWT claim for cross-tenant access.
- Centralize `DEFAULT_TENANT_ID` constant (from `MEMORYHUB_DEFAULT_TENANT` env var), replacing 12 hardcoded `"default"` fallbacks across the MCP server.
- Wire `tenant_id` as optional parameter through SDK client, MCP dispatcher, and tool functions (write/search/read/list).
- EvalHub adapter: add `skip_ingestion` parameter, bundle local SDK in container, wire MemoryHub connection env vars via deploy script.
- Add 7-config ablation matrix for RRF signal testing (#360).

## Test plan

- [x] All 557 MCP server tests pass
- [ ] Deploy updated MCP server, verify `register_session` returns correct tenant
- [ ] Run EvalHub smoke test with `memory_provider: memoryhub` and `skip_ingestion: true`
- [ ] Verify omitting `tenant_id` preserves existing behavior

Closes #360 (partial -- matrix configs ready, runs pending deployment)

Assisted-by: Claude Code (Opus 4.6)