### PR TITLE
bench: Benchmark system map + enforced preflight manifest

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -15,7 +15,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Install gitleaks
+        run: |
+          GITLEAKS_VERSION=8.24.3
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+            | tar -xz -C /usr/local/bin gitleaks
+
       - name: Run gitleaks
-        uses: gitleaks/gitleaks-action@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gitleaks detect --source . --verbose --no-banner

--- a/benchmarks/evalhub-adapter/config/matrix/baseline.yaml
+++ b/benchmarks/evalhub-adapter/config/matrix/baseline.yaml
@@ -15,5 +15,16 @@ benchmarks:
       memory_provider: memoryhub
       skip_ingestion: true
       query_limit: 589
+      expected_manifest:
+        signals:
+          vector: {active: true}
+          reranker: {active: false}
+          keyword: {active: true}
+          focus: {active: false}
+          domain: {active: false}
+          graph: {active: false}
+        corpus:
+          tenant_id: amb-benchmark
+          chunk_nodes: 0
 experiment:
   name: memoryhub/personamem-mcq/32k

--- a/benchmarks/evalhub-adapter/config/matrix/bm25-only.yaml
+++ b/benchmarks/evalhub-adapter/config/matrix/bm25-only.yaml
@@ -16,5 +16,16 @@ benchmarks:
       skip_ingestion: true
       query_limit: 589
       disabled_signals: reranker,focus,keyword,domain,graph
+      expected_manifest:
+        signals:
+          vector: {active: true}
+          reranker: {active: false}
+          keyword: {active: true}
+          focus: {active: false}
+          domain: {active: false}
+          graph: {active: false}
+        corpus:
+          tenant_id: amb-benchmark
+          chunk_nodes: 0
 experiment:
   name: memoryhub/personamem-mcq/32k

--- a/benchmarks/evalhub-adapter/config/matrix/no-domain.yaml
+++ b/benchmarks/evalhub-adapter/config/matrix/no-domain.yaml
@@ -16,5 +16,16 @@ benchmarks:
       skip_ingestion: true
       query_limit: 589
       disabled_signals: domain
+      expected_manifest:
+        signals:
+          vector: {active: true}
+          reranker: {active: false}
+          keyword: {active: true}
+          focus: {active: false}
+          domain: {active: false}
+          graph: {active: false}
+        corpus:
+          tenant_id: amb-benchmark
+          chunk_nodes: 0
 experiment:
   name: memoryhub/personamem-mcq/32k

--- a/benchmarks/evalhub-adapter/config/matrix/no-focus.yaml
+++ b/benchmarks/evalhub-adapter/config/matrix/no-focus.yaml
@@ -16,5 +16,16 @@ benchmarks:
       skip_ingestion: true
       query_limit: 589
       disabled_signals: focus
+      expected_manifest:
+        signals:
+          vector: {active: true}
+          reranker: {active: false}
+          keyword: {active: true}
+          focus: {active: false}
+          domain: {active: false}
+          graph: {active: false}
+        corpus:
+          tenant_id: amb-benchmark
+          chunk_nodes: 0
 experiment:
   name: memoryhub/personamem-mcq/32k

--- a/benchmarks/evalhub-adapter/config/matrix/no-graph.yaml
+++ b/benchmarks/evalhub-adapter/config/matrix/no-graph.yaml
@@ -16,5 +16,16 @@ benchmarks:
       skip_ingestion: true
       query_limit: 589
       disabled_signals: graph
+      expected_manifest:
+        signals:
+          vector: {active: true}
+          reranker: {active: false}
+          keyword: {active: true}
+          focus: {active: false}
+          domain: {active: false}
+          graph: {active: false}
+        corpus:
+          tenant_id: amb-benchmark
+          chunk_nodes: 0
 experiment:
   name: memoryhub/personamem-mcq/32k

--- a/benchmarks/evalhub-adapter/config/matrix/no-keyword.yaml
+++ b/benchmarks/evalhub-adapter/config/matrix/no-keyword.yaml
@@ -16,5 +16,16 @@ benchmarks:
       skip_ingestion: true
       query_limit: 589
       disabled_signals: keyword
+      expected_manifest:
+        signals:
+          vector: {active: true}
+          reranker: {active: false}
+          keyword: {active: true}
+          focus: {active: false}
+          domain: {active: false}
+          graph: {active: false}
+        corpus:
+          tenant_id: amb-benchmark
+          chunk_nodes: 0
 experiment:
   name: memoryhub/personamem-mcq/32k

--- a/benchmarks/evalhub-adapter/config/matrix/no-reranker.yaml
+++ b/benchmarks/evalhub-adapter/config/matrix/no-reranker.yaml
@@ -16,5 +16,16 @@ benchmarks:
       skip_ingestion: true
       query_limit: 589
       disabled_signals: reranker
+      expected_manifest:
+        signals:
+          vector: {active: true}
+          reranker: {active: false}
+          keyword: {active: true}
+          focus: {active: false}
+          domain: {active: false}
+          graph: {active: false}
+        corpus:
+          tenant_id: amb-benchmark
+          chunk_nodes: 0
 experiment:
   name: memoryhub/personamem-mcq/32k

--- a/benchmarks/evalhub-adapter/config/matrix/smoke-keyword-off.yaml
+++ b/benchmarks/evalhub-adapter/config/matrix/smoke-keyword-off.yaml
@@ -16,5 +16,16 @@ benchmarks:
       skip_ingestion: true
       query_limit: 20
       disabled_signals: keyword
+      expected_manifest:
+        signals:
+          vector: {active: true}
+          reranker: {active: false}
+          keyword: {active: true}
+          focus: {active: false}
+          domain: {active: false}
+          graph: {active: false}
+        corpus:
+          tenant_id: amb-benchmark
+          chunk_nodes: 0
 experiment:
   name: memoryhub/personamem-mcq/32k

--- a/benchmarks/evalhub-adapter/config/matrix/smoke-keyword-on.yaml
+++ b/benchmarks/evalhub-adapter/config/matrix/smoke-keyword-on.yaml
@@ -15,5 +15,16 @@ benchmarks:
       memory_provider: memoryhub
       skip_ingestion: true
       query_limit: 20
+      expected_manifest:
+        signals:
+          vector: {active: true}
+          reranker: {active: false}
+          keyword: {active: true}
+          focus: {active: false}
+          domain: {active: false}
+          graph: {active: false}
+        corpus:
+          tenant_id: amb-benchmark
+          chunk_nodes: 0
 experiment:
   name: memoryhub/personamem-mcq/32k

--- a/benchmarks/evalhub-adapter/main.py
+++ b/benchmarks/evalhub-adapter/main.py
@@ -30,6 +30,16 @@ def main() -> None:
 
     results = adapter.run_benchmark_job(job, callbacks)
 
+    manifest = getattr(adapter, "preflight_manifest", None)
+    if manifest:
+        import json
+        from pathlib import Path
+
+        manifest_path = Path("outputs") / "preflight-manifest.json"
+        manifest_path.parent.mkdir(parents=True, exist_ok=True)
+        manifest_path.write_text(json.dumps(manifest, indent=2))
+        logger.info("Preflight manifest written to %s", manifest_path)
+
     # Save to MLflow before reporting so mlflow_run_id is included
     mlflow_run_id = callbacks.mlflow.save(results, job)
     if mlflow_run_id:

--- a/benchmarks/evalhub-adapter/src/memoryhub_evalhub/adapter.py
+++ b/benchmarks/evalhub-adapter/src/memoryhub_evalhub/adapter.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 import time
@@ -104,6 +105,40 @@ class AMBAdapter(FrameworkAdapter):
             if params.get(param_key):
                 os.environ[db_key] = str(params[param_key])
 
+        # -- Preflight: probe deployment and enforce expectations --------
+        from memoryhub_evalhub.preflight import run_preflight, enforce_manifest
+
+        db_url = (
+            f"postgresql://{os.environ.get('MEMORYHUB_DB_USER', 'memoryhub')}"
+            f":{os.environ.get('MEMORYHUB_DB_PASS', '')}"
+            f"@{os.environ.get('MEMORYHUB_DB_HOST', 'localhost')}"
+            f":{os.environ.get('MEMORYHUB_DB_PORT', '25432')}"
+            f"/{os.environ.get('MEMORYHUB_DB_NAME', 'memoryhub')}"
+        )
+        tenant_id = os.environ.get("MEMORYHUB_TENANT_ID", "amb-benchmark")
+
+        self.preflight_manifest = asyncio.run(run_preflight(
+            db_url=db_url,
+            tenant_id=tenant_id,
+            reranker_url=os.environ.get("MEMORYHUB_RERANKER_URL"),
+        ))
+
+        expected = params.get("expected_manifest")
+        if expected:
+            ok, diff = enforce_manifest(self.preflight_manifest, expected)
+            if not ok:
+                raise RuntimeError(
+                    f"Preflight manifest mismatch -- deployment does not "
+                    f"match config expectations.\n\n{diff}\n\n"
+                    f"Fix the deployment or update expected_manifest in "
+                    f"the config."
+                )
+            logger.info("Preflight passed: manifest matches expected_manifest")
+        else:
+            logger.warning(
+                "No expected_manifest in config; preflight ran but not enforced"
+            )
+
         dataset_name = params.get("dataset", "personamem")
         split = params.get("dataset_variant", "32k")
         mode_name = params.get("mode", "library")
@@ -194,6 +229,7 @@ class AMBAdapter(FrameworkAdapter):
             "ingested_docs": summary.ingested_docs,
             "answer_llm": summary.answer_llm,
             "judge_llm": summary.judge_llm,
+            "preflight_manifest": getattr(self, "preflight_manifest", None),
         }
 
         env_card = EnvironmentCardMetadata(
@@ -212,6 +248,7 @@ class AMBAdapter(FrameworkAdapter):
                     "disabled_signals": params.get("disabled_signals"),
                 },
                 "harness_commit": params.get("pipeline_sha", "unknown"),
+                "preflight_manifest": getattr(self, "preflight_manifest", None),
             },
         )
 

--- a/benchmarks/evalhub-adapter/src/memoryhub_evalhub/preflight.py
+++ b/benchmarks/evalhub-adapter/src/memoryhub_evalhub/preflight.py
@@ -15,7 +15,7 @@ import logging
 import os
 import subprocess
 import sys
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 import asyncpg
 import httpx
@@ -195,7 +195,7 @@ async def run_preflight(
             },
             "corpus": await check_corpus(conn, tenant_id),
             "versions": get_version_shas(),
-            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "timestamp": datetime.now(UTC).isoformat(),
         }
     finally:
         await conn.close()

--- a/benchmarks/evalhub-adapter/src/memoryhub_evalhub/preflight.py
+++ b/benchmarks/evalhub-adapter/src/memoryhub_evalhub/preflight.py
@@ -1,0 +1,327 @@
+"""Benchmark preflight: probe deployment, emit manifest, enforce expectations.
+
+Standalone:
+    python -m memoryhub_evalhub.preflight
+
+From adapter:
+    from memoryhub_evalhub.preflight import run_preflight, enforce_manifest
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import subprocess
+import sys
+from datetime import datetime, timezone
+
+import asyncpg
+import httpx
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Signal checks
+# ---------------------------------------------------------------------------
+
+
+async def check_signal_vector(
+    conn: asyncpg.Connection, tenant_id: str
+) -> dict:
+    """Check whether vector embeddings are populated for the tenant."""
+    count = await conn.fetchval(
+        "SELECT COUNT(*) FROM memory_nodes "
+        "WHERE embedding IS NOT NULL AND tenant_id = $1",
+        tenant_id,
+    )
+    return {"active": bool(count > 0), "node_count": count}
+
+
+async def check_signal_reranker(reranker_url: str | None) -> dict:
+    """Probe the reranker endpoint for availability."""
+    if not reranker_url:
+        return {"active": False, "reason": "MEMORYHUB_RERANKER_URL not set"}
+
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(
+                f"{reranker_url.rstrip('/')}/info", timeout=5
+            )
+        if resp.status_code == 200:
+            return {"active": True, "url": reranker_url}
+        return {
+            "active": False,
+            "url": reranker_url,
+            "reason": f"HTTP {resp.status_code}",
+        }
+    except Exception as err:
+        return {"active": False, "url": reranker_url, "reason": str(err)}
+
+
+async def check_signal_keyword(
+    conn: asyncpg.Connection, tenant_id: str
+) -> dict:
+    """Check search_vector column, index, and populated row count."""
+    col_exists = bool(
+        await conn.fetchval(
+            "SELECT 1 FROM information_schema.columns "
+            "WHERE table_name = 'memory_nodes' "
+            "AND column_name = 'search_vector'"
+        )
+    )
+    idx_exists = bool(
+        await conn.fetchval(
+            "SELECT 1 FROM pg_indexes "
+            "WHERE tablename = 'memory_nodes' "
+            "AND indexname = 'ix_memory_nodes_search_vector'"
+        )
+    )
+    count = await conn.fetchval(
+        "SELECT COUNT(*) FROM memory_nodes "
+        "WHERE search_vector IS NOT NULL AND tenant_id = $1",
+        tenant_id,
+    )
+    return {
+        "active": bool(col_exists and idx_exists and count > 0),
+        "column_exists": col_exists,
+        "index_exists": idx_exists,
+        "populated_count": count,
+    }
+
+
+def check_signal_focus() -> dict:
+    """Focus signal -- always inactive in benchmark mode.
+
+    The benchmark harness never calls set_focus, so there is no Valkey
+    state to inspect.
+    """
+    return {"active": False, "reason": "benchmark does not call set_focus"}
+
+
+async def check_signal_domain(
+    conn: asyncpg.Connection, tenant_id: str
+) -> dict:
+    """Check whether any memory nodes have domain tags."""
+    count = await conn.fetchval(
+        "SELECT COUNT(*) FROM memory_nodes "
+        "WHERE domains IS NOT NULL "
+        "AND array_length(domains, 1) > 0 "
+        "AND tenant_id = $1",
+        tenant_id,
+    )
+    return {"active": bool(count > 0), "tagged_count": count}
+
+
+async def check_signal_graph(
+    conn: asyncpg.Connection, tenant_id: str
+) -> dict:
+    """Check whether graph edges exist for the tenant's nodes."""
+    count = await conn.fetchval(
+        "SELECT COUNT(*) FROM memory_relationships mr "
+        "JOIN memory_nodes mn ON mr.source_id = mn.id "
+        "WHERE mn.tenant_id = $1",
+        tenant_id,
+    )
+    return {"active": bool(count > 0), "edge_count": count}
+
+
+# ---------------------------------------------------------------------------
+# Corpus snapshot
+# ---------------------------------------------------------------------------
+
+
+async def check_corpus(conn: asyncpg.Connection, tenant_id: str) -> dict:
+    """Return a corpus size breakdown for the tenant."""
+    row = await conn.fetchrow(
+        "SELECT "
+        "  COUNT(*) AS total, "
+        "  COUNT(*) FILTER (WHERE branch_type = 'chunk') AS chunks, "
+        "  COUNT(*) FILTER (WHERE branch_type IS NULL "
+        "    OR branch_type != 'chunk') AS parents "
+        "FROM memory_nodes WHERE tenant_id = $1",
+        tenant_id,
+    )
+    return {
+        "tenant_id": tenant_id,
+        "total_nodes": row["total"],
+        "parent_nodes": row["parents"],
+        "chunk_nodes": row["chunks"],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Version info
+# ---------------------------------------------------------------------------
+
+
+def get_version_shas() -> dict:
+    """Return the pipeline git SHA (or 'unknown' if git is unavailable)."""
+    try:
+        sha = subprocess.check_output(
+            ["git", "rev-parse", "HEAD"],
+            cwd=os.path.dirname(os.path.abspath(__file__)),
+            stderr=subprocess.DEVNULL,
+            text=True,
+        ).strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        sha = "unknown"
+    return {"pipeline_sha": sha}
+
+
+# ---------------------------------------------------------------------------
+# Run all checks
+# ---------------------------------------------------------------------------
+
+
+async def run_preflight(
+    db_url: str,
+    tenant_id: str = "amb-benchmark",
+    reranker_url: str | None = None,
+) -> dict:
+    """Execute all preflight checks and return the manifest dict."""
+    conn = await asyncpg.connect(db_url)
+    try:
+        manifest = {
+            "signals": {
+                "vector": await check_signal_vector(conn, tenant_id),
+                "reranker": await check_signal_reranker(reranker_url),
+                "keyword": await check_signal_keyword(conn, tenant_id),
+                "focus": check_signal_focus(),
+                "domain": await check_signal_domain(conn, tenant_id),
+                "graph": await check_signal_graph(conn, tenant_id),
+            },
+            "corpus": await check_corpus(conn, tenant_id),
+            "versions": get_version_shas(),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }
+    finally:
+        await conn.close()
+    return manifest
+
+
+# ---------------------------------------------------------------------------
+# Manifest enforcement
+# ---------------------------------------------------------------------------
+
+
+def _compare(
+    actual: object,
+    expected: object,
+    path: str,
+    mismatches: list[str],
+) -> None:
+    """Recursively compare *expected* as a subset of *actual*."""
+    if isinstance(expected, dict):
+        if not isinstance(actual, dict):
+            mismatches.append(
+                f"{path}: expected dict, got {type(actual).__name__}"
+            )
+            return
+        for key, exp_val in expected.items():
+            child_path = f"{path}.{key}" if path else key
+            if key not in actual:
+                mismatches.append(f"{child_path}: key missing in actual")
+            else:
+                _compare(actual[key], exp_val, child_path, mismatches)
+    else:
+        if actual != expected:
+            mismatches.append(
+                f"{path}: expected {expected!r}, got {actual!r}"
+            )
+
+
+def enforce_manifest(
+    actual: dict, expected: dict
+) -> tuple[bool, str]:
+    """Check that *actual* is a superset of *expected*.
+
+    Returns ``(True, "")`` on success, or ``(False, diff_string)`` listing
+    every mismatch.
+    """
+    mismatches: list[str] = []
+    _compare(actual, expected, "", mismatches)
+    if mismatches:
+        return False, "\n".join(mismatches)
+    return True, ""
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_db_url() -> str:
+    """Assemble a raw asyncpg-compatible DSN from environment variables."""
+    host = os.environ.get("MEMORYHUB_DB_HOST", "localhost")
+    port = os.environ.get("MEMORYHUB_DB_PORT", "25432")
+    user = os.environ.get("MEMORYHUB_DB_USER", "memoryhub")
+    password = os.environ.get("MEMORYHUB_DB_PASS", "")
+    dbname = os.environ.get("MEMORYHUB_DB_NAME", "memoryhub")
+    return f"postgresql://{user}:{password}@{host}:{port}/{dbname}"
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    """Run preflight from the command line."""
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Run MemoryHub benchmark preflight checks"
+    )
+    parser.add_argument(
+        "--config",
+        type=str,
+        default=None,
+        help="Path to a YAML config file with expected_manifest",
+    )
+    args = parser.parse_args()
+
+    db_url = _build_db_url()
+    reranker_url = os.environ.get("MEMORYHUB_RERANKER_URL")
+    tenant_id = os.environ.get("MEMORYHUB_TENANT_ID", "amb-benchmark")
+
+    manifest = asyncio.run(
+        run_preflight(db_url, tenant_id=tenant_id, reranker_url=reranker_url)
+    )
+    print(json.dumps(manifest, indent=2))
+
+    if args.config:
+        import yaml  # noqa: F811 -- lazy import keeps module light
+
+        with open(args.config) as fh:
+            cfg = yaml.safe_load(fh)
+
+        expected = cfg.get("parameters", {}).get("expected_manifest")
+        if expected is None:
+            benchmarks = cfg.get("benchmarks", [])
+            if benchmarks:
+                expected = benchmarks[0].get("parameters", {}).get(
+                    "expected_manifest"
+                )
+
+        if expected is None:
+            print(
+                "warning: --config provided but no expected_manifest found",
+                file=sys.stderr,
+            )
+            return
+
+        ok, diff = enforce_manifest(manifest, expected)
+        if ok:
+            print("preflight: manifest matches expected", file=sys.stderr)
+        else:
+            print(
+                f"preflight: manifest mismatch\n{diff}", file=sys.stderr
+            )
+            sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/evalhub-adapter/tests/test_preflight.py
+++ b/benchmarks/evalhub-adapter/tests/test_preflight.py
@@ -1,0 +1,180 @@
+"""Tests for the preflight manifest module.
+
+Imports bypass the package __init__.py to avoid pulling in the EvalHub SDK
+dependency chain (oras, olot, etc.) which is only needed at runtime.
+"""
+
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+# Direct import of the preflight module without triggering __init__.py
+_src = Path(__file__).resolve().parent.parent / "src"
+_spec = importlib.util.spec_from_file_location(
+    "memoryhub_evalhub.preflight",
+    _src / "memoryhub_evalhub" / "preflight.py",
+)
+_mod = importlib.util.module_from_spec(_spec)
+sys.modules[_mod.__name__] = _mod
+_spec.loader.exec_module(_mod)
+
+check_signal_focus = _mod.check_signal_focus
+check_signal_reranker = _mod.check_signal_reranker
+enforce_manifest = _mod.enforce_manifest
+get_version_shas = _mod.get_version_shas
+
+
+# ---------------------------------------------------------------------------
+# Sample manifest for reuse across tests
+# ---------------------------------------------------------------------------
+
+SAMPLE_MANIFEST = {
+    "signals": {
+        "vector": {"active": True, "node_count": 1024},
+        "reranker": {"active": False, "reason": "MEMORYHUB_RERANKER_URL not set"},
+        "keyword": {
+            "active": True,
+            "column_exists": True,
+            "index_exists": True,
+            "populated_count": 900,
+        },
+        "focus": {"active": False, "reason": "benchmark does not call set_focus"},
+        "domain": {"active": True, "tagged_count": 500},
+        "graph": {"active": False, "edge_count": 0},
+    },
+    "corpus": {
+        "tenant_id": "amb-benchmark",
+        "total_nodes": 1024,
+        "parent_nodes": 128,
+        "chunk_nodes": 896,
+    },
+    "versions": {"pipeline_sha": "abc123"},
+    "timestamp": "2026-07-14T00:00:00+00:00",
+}
+
+
+# ---------------------------------------------------------------------------
+# enforce_manifest tests
+# ---------------------------------------------------------------------------
+
+
+class TestEnforceManifest:
+    def test_exact_match(self):
+        ok, diff = enforce_manifest(SAMPLE_MANIFEST, SAMPLE_MANIFEST)
+        assert ok is True
+        assert diff == ""
+
+    def test_subset_match(self):
+        expected = {"signals": {"vector": {"active": True}}}
+        ok, diff = enforce_manifest(SAMPLE_MANIFEST, expected)
+        assert ok is True
+        assert diff == ""
+
+    def test_extra_keys_ignored(self):
+        actual = {**SAMPLE_MANIFEST, "extra_top": "ignored"}
+        ok, diff = enforce_manifest(actual, SAMPLE_MANIFEST)
+        assert ok is True
+        assert diff == ""
+
+    def test_mismatch_boolean(self):
+        expected = {"signals": {"reranker": {"active": True}}}
+        ok, diff = enforce_manifest(SAMPLE_MANIFEST, expected)
+        assert ok is False
+        assert "signals.reranker.active" in diff
+
+    def test_mismatch_integer(self):
+        expected = {"corpus": {"chunk_nodes": 100}}
+        ok, diff = enforce_manifest(SAMPLE_MANIFEST, expected)
+        assert ok is False
+        assert "corpus.chunk_nodes" in diff
+        assert "100" in diff
+
+    def test_missing_key(self):
+        expected = {"signals": {"reranker": {"model": "bge-reranker"}}}
+        ok, diff = enforce_manifest(SAMPLE_MANIFEST, expected)
+        assert ok is False
+        assert "signals.reranker.model" in diff
+        assert "missing" in diff.lower()
+
+    def test_nested_mismatch(self):
+        expected = {
+            "signals": {
+                "keyword": {
+                    "active": True,
+                    "populated_count": 9999,
+                }
+            }
+        }
+        ok, diff = enforce_manifest(SAMPLE_MANIFEST, expected)
+        assert ok is False
+        assert "signals.keyword.populated_count" in diff
+        # active should still match, so only populated_count appears
+        assert "signals.keyword.active" not in diff
+
+    def test_empty_expected(self):
+        ok, diff = enforce_manifest(SAMPLE_MANIFEST, {})
+        assert ok is True
+        assert diff == ""
+
+    def test_mismatch_string(self):
+        expected = {"corpus": {"tenant_id": "other-tenant"}}
+        ok, diff = enforce_manifest(SAMPLE_MANIFEST, expected)
+        assert ok is False
+        assert "corpus.tenant_id" in diff
+        assert "other-tenant" in diff
+
+
+# ---------------------------------------------------------------------------
+# check_signal_focus
+# ---------------------------------------------------------------------------
+
+
+class TestCheckSignalFocus:
+    def test_focus_always_inactive(self):
+        result = check_signal_focus()
+        assert result["active"] is False
+        assert "reason" in result
+
+
+# ---------------------------------------------------------------------------
+# get_version_shas
+# ---------------------------------------------------------------------------
+
+
+class TestGetVersionShas:
+    def test_version_shas_returns_dict(self):
+        result = get_version_shas()
+        assert isinstance(result, dict)
+        assert "pipeline_sha" in result
+        # In a git repo the SHA should be a hex string; if git isn't
+        # available it falls back to "unknown".
+        sha = result["pipeline_sha"]
+        assert sha == "unknown" or len(sha) == 40
+
+
+# ---------------------------------------------------------------------------
+# check_signal_reranker (no-db cases)
+# ---------------------------------------------------------------------------
+
+
+class TestCheckSignalReranker:
+    @pytest.mark.asyncio
+    async def test_reranker_no_url(self):
+        result = await check_signal_reranker(None)
+        assert result["active"] is False
+        assert "not set" in result.get("reason", "").lower()
+
+    @pytest.mark.asyncio
+    async def test_reranker_empty_url(self):
+        result = await check_signal_reranker("")
+        assert result["active"] is False
+
+    @pytest.mark.asyncio
+    async def test_reranker_unreachable(self):
+        # Use a URL that will definitely fail to connect
+        result = await check_signal_reranker("http://192.0.2.1:1")
+        assert result["active"] is False
+        assert result["url"] == "http://192.0.2.1:1"
+        assert "reason" in result

--- a/benchmarks/preflight.py
+++ b/benchmarks/preflight.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """Standalone preflight runner.
 
-Delegates to memoryhub_evalhub.preflight. Requires the evalhub-adapter
-package on the Python path.
+Imports the preflight module directly (bypassing the adapter package
+__init__.py which pulls in the full EvalHub SDK chain).
 
 Usage:
     python benchmarks/preflight.py [--config path/to/config.yaml]
@@ -14,15 +14,23 @@ Environment:
     MEMORYHUB_TENANT_ID -- target tenant (default: amb-benchmark)
 """
 
+import importlib.util
 import sys
 from pathlib import Path
 
-# Add the adapter package to the path so the import works from repo root
-_adapter_src = Path(__file__).resolve().parent / "evalhub-adapter" / "src"
-if str(_adapter_src) not in sys.path:
-    sys.path.insert(0, str(_adapter_src))
-
-from memoryhub_evalhub.preflight import main  # noqa: E402
+_preflight_path = (
+    Path(__file__).resolve().parent
+    / "evalhub-adapter"
+    / "src"
+    / "memoryhub_evalhub"
+    / "preflight.py"
+)
+_spec = importlib.util.spec_from_file_location(
+    "memoryhub_evalhub.preflight", _preflight_path
+)
+_mod = importlib.util.module_from_spec(_spec)
+sys.modules[_mod.__name__] = _mod
+_spec.loader.exec_module(_mod)
 
 if __name__ == "__main__":
-    main()
+    _mod.main()

--- a/benchmarks/preflight.py
+++ b/benchmarks/preflight.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+"""Standalone preflight runner.
+
+Delegates to memoryhub_evalhub.preflight. Requires the evalhub-adapter
+package on the Python path.
+
+Usage:
+    python benchmarks/preflight.py [--config path/to/config.yaml]
+
+Environment:
+    MEMORYHUB_DB_HOST, MEMORYHUB_DB_PORT, MEMORYHUB_DB_USER,
+    MEMORYHUB_DB_PASS, MEMORYHUB_DB_NAME -- database connection
+    MEMORYHUB_RERANKER_URL -- reranker endpoint (optional)
+    MEMORYHUB_TENANT_ID -- target tenant (default: amb-benchmark)
+"""
+
+import sys
+from pathlib import Path
+
+# Add the adapter package to the path so the import works from repo root
+_adapter_src = Path(__file__).resolve().parent / "evalhub-adapter" / "src"
+if str(_adapter_src) not in sys.path:
+    sys.path.insert(0, str(_adapter_src))
+
+from memoryhub_evalhub.preflight import main  # noqa: E402
+
+if __name__ == "__main__":
+    main()

--- a/docs/benchmark-system-map.md
+++ b/docs/benchmark-system-map.md
@@ -1,0 +1,104 @@
+# Benchmark System Map
+
+Reference document for the MemoryHub benchmark stack. Describes the
+data flow, signal activation state, and corpus provenance. Updated
+when signals activate or the deployment changes.
+
+## Stack Diagram
+
+```
+EvalHub Server (memoryhub-eval namespace)
+  submits JobSpec
+    │
+    ▼
+AMBAdapter
+  benchmarks/evalhub-adapter/src/memoryhub_evalhub/adapter.py
+  wires env vars, runs preflight, delegates to EvalRunner
+    │
+    ▼
+EvalRunner
+  benchmarks/amb-harness/src/memory_bench/runner.py
+  iterates queries, calls memory provider, scores answers
+    │
+    ▼
+MemoryHubProvider
+  benchmarks/amb-harness/src/memory_bench/memory/memoryhub.py
+  ingest via client.write(), retrieve via client.search()
+    │  uses memoryhub SDK (MemoryHubClient)
+    ▼
+MCP Server  (memory-hub-mcp namespace, streamable-HTTP on /mcp/)
+  routes to search_memories() or search_memories_with_focus()
+    │
+    ▼
+PostgreSQL + pgvector  (memoryhub-db namespace)
+  + Valkey  (memory-hub-mcp namespace)  for focus state cache
+  + TEI reranker  (when deployed, currently inactive)
+```
+
+The benchmark exercises the **non-focus** `search_memories()` path because
+the harness never calls `set_focus`. This path supports vector + keyword
+signals. The focused path supports all six signals but requires an
+active session with focus declared.
+
+## Signal Activation Matrix
+
+| Signal | Code location | Activation prerequisite | Verify-active check | Active today? |
+|--------|--------------|------------------------|--------------------|----|
+| **vector** | `memory.py` cosine_distance query | pgvector extension + embedding column populated | `SELECT COUNT(*) FROM memory_nodes WHERE embedding IS NOT NULL AND tenant_id='amb-benchmark'` equals total node count | YES |
+| **reranker** | `memory.py:1418` (focused path only) | `MEMORYHUB_RERANKER_URL` env var + TEI service reachable | `curl -sf $MEMORYHUB_RERANKER_URL/info` returns 200 | NO (#342) |
+| **keyword** | `memory.py:1019` (non-focus), `memory.py:1507` (focused) | `search_vector` tsvector column (migration 024) + GIN index + `keyword_boost_weight > 0` | `SELECT COUNT(*) FROM memory_nodes WHERE search_vector IS NOT NULL AND tenant_id='amb-benchmark'` | YES (PR #379) |
+| **focus** | `memory.py:1454` (focused path only) | `set_focus()` called + Valkey reachable + focus_string non-empty | `HGET memoryhub:sessions:<session_id> focus` | NO (benchmark never calls set_focus) |
+| **domain** | `memory.py:1470` (focused path only) | `domains` array populated on nodes + domain tags in query | `SELECT COUNT(*) FROM memory_nodes WHERE domains IS NOT NULL AND array_length(domains, 1) > 0 AND tenant_id='amb-benchmark'` | NO (no domain tags) |
+| **graph** | `memory.py:1378` (focused path only) | `memory_relationships` edges exist + `graph_depth > 0` | `SELECT COUNT(*) FROM memory_relationships mr JOIN memory_nodes mn ON mr.source_id = mn.id WHERE mn.tenant_id='amb-benchmark'` | NO (no edges) |
+
+`VALID_SIGNAL_NAMES = frozenset({"reranker", "focus", "keyword", "domain", "graph"})` (memory.py L61).
+
+Activation is **path-dependent**: signals only fire if the search path
+invokes them AND the infrastructure prerequisite is met. The benchmark
+uses `search_memories()` (non-focus), so reranker/focus/domain/graph are
+structurally inactive regardless of deployment.
+
+## Corpus Provenance
+
+### amb-benchmark tenant
+
+195 parent documents, 0 chunk nodes (post-cleanup per #369).
+
+The original corpus had 6,419 chunk nodes (`branch_type='chunk'`) which
+contaminated retrieval results with a 33:1 chunk-to-parent ratio. Chunks
+were deleted as part of the #369 baseline discrepancy investigation.
+
+Ingested via SDK `client.write()` from the PersonaMem 32k dataset. No
+`semantic_chunk()` call (raw documents only in current corpus).
+
+### Verification SQL
+
+```sql
+SELECT
+  COUNT(*) AS total,
+  COUNT(*) FILTER (WHERE branch_type = 'chunk') AS chunks,
+  COUNT(*) FILTER (WHERE branch_type IS NULL OR branch_type != 'chunk') AS parents
+FROM memory_nodes
+WHERE tenant_id = 'amb-benchmark';
+-- Expected: total=195, chunks=0, parents=195
+```
+
+Run this before each matrix run. The `benchmarks/preflight.py` module
+automates this check along with signal activation verification.
+
+## Preflight
+
+Before any benchmark run, the preflight module (`benchmarks/preflight.py`)
+probes the live deployment and emits a manifest JSON documenting signal
+activation state and corpus provenance. Benchmark configs declare an
+`expected_manifest` block; the adapter refuses to run if the deployment
+doesn't match.
+
+```bash
+# Standalone (requires DB port-forward):
+oc port-forward -n memoryhub-db svc/postgresql 25432:5432 --context mcp-rhoai &
+python benchmarks/preflight.py
+
+# With config enforcement:
+python benchmarks/preflight.py --config benchmarks/evalhub-adapter/config/matrix/baseline.yaml
+```

--- a/reconciliations/2026-07-14-dreaming.md
+++ b/reconciliations/2026-07-14-dreaming.md
@@ -1,0 +1,34 @@
+# Reconciliation -- 2026-07-14 - dreaming
+
+**Range:** summaries 2026-07-13..2026-07-14 (3 sessions: ablation matrix, keyword activation, benchmark preflight)
+**Plan:** NEXT_SESSION-dreaming.md
+
+## Backlog reconciled
+
+| # | Was | Action | Why |
+|---|-----|--------|-----|
+| #371 | System map + preflight | Closed | PR #380, live-verified. Exit predicate met |
+| #372 | Keyword signal activation | Closed | PR #379. Code wired, signal activates, delta deferred to larger corpus |
+| #378 | disabled_signals silent ignore | Closed | Fixed in PR #379 |
+| #355 | Ablation matrix (manual cron) | Closed | Superseded by #360 (body already noted) |
+| #333 | RRF ablation tracker | Closed | Sub-issues done/superseded; #360 is the active tracker |
+| #344 | Layer 1 benchmark re-run | Closed | Validation rides with #360 Pro runs; redundant as separate issue |
+| #360 | Matrix A | Re-scoped | Blockers: 4 -> 2 (#342 reranker, #365 PVC). Scope: 4 configs not 7 |
+| #365 | EvalHub PVC | Re-scoped | "PVC not possible" was wrong; now a config fix (pvcManaged/pvcName) |
+| #342 | Reranker upgrade | Kept | Unblocked, GPU capacity confirmed |
+| #343 | Chunking fix | Kept | Unblocked, will also grow corpus for keyword differentiation |
+| #374 | CI CLI test failure | Kept | Pre-existing, not dreaming-scoped |
+| #375 | Local test suite hang | Kept | Pre-existing, not dreaming-scoped |
+
+## Forward-collisions banked
+
+- Preflight (#371) auto-detects reranker activation via /info probe. When #342 ships, update expected_manifest in configs. By design, no comment needed.
+- CI gitleaks fix (8eb7dd0) resolves Secret Scanning failure across all branches. Unblocks cleaner CI for #374 investigation.
+
+## Critique
+
+On track. Phase 4's investigation arc (#369) and tooling arc (#371, #372) are fully resolved. Critical path to Matrix A is short: #365 (small config fix) then #342 (reranker deploy). Recurring friction: provider ID instability (3 consecutive summaries) -- #365 PVC fix should eliminate it; escalate at retro if it persists.
+
+## Guidance for next
+
+#365 first (cheapest remaining #360 blocker, ~30 min). Then #342 (reranker upgrade, activates a new signal). Together they unblock Matrix A (#360) which is the payoff for the last 6 sessions of tooling work.

--- a/session-summaries/2026-07-14-dreaming-benchmark-preflight.md
+++ b/session-summaries/2026-07-14-dreaming-benchmark-preflight.md
@@ -1,0 +1,45 @@
+# Session Summary -- 2026-07-14 - dreaming - Benchmark system map + enforced preflight
+
+**Plan:** NEXT_SESSION-dreaming.md / #371   **Commits:** 643fdfc..717d125 (feat/benchmark-preflight)
+**Deployed:** none   **Model:** Opus 4.6 (1M)
+
+## Plan vs. actual
+Planned: system map doc + preflight module + adapter integration + expected_manifest on all configs. Shipped: all four, plus live verification against mcp-rhoai and a CLI import fix discovered during verification. Slipped: none.
+Scope: stayed in scope. No MCP server or memoryhub_core changes.
+
+## Shipped
+- `643fdfc` docs: benchmark system map with stack diagram, signal activation matrix (6 signals), corpus provenance
+- `866aaa7` bench: preflight module (check_signal_* probes, enforce_manifest recursive subset match, CLI entry point); 14 unit tests
+- `b5b7abd` bench: adapter integration (preflight before every run, RuntimeError on mismatch, manifest in MLflow metadata)
+- `0430510` bench: expected_manifest on all 9 matrix configs (vector+keyword active, reranker/focus/domain/graph inactive, 0 chunks)
+- `717d125` bench: CLI import fix (bypass adapter __init__.py to avoid EvalHub SDK chain)
+- Live verification: standalone preflight, config enforcement pass, deliberate mismatch fail with readable diff
+
+## Verification & confidence
+- 14 unit tests pass (enforce_manifest 9 cases, check_signal_focus, check_signal_reranker 3 cases, get_version_shas)
+- Live preflight against mcp-rhoai: manifest matches expected deployment (195 parents, 0 chunks, vector+keyword active)
+- Deliberate mismatch test: exit 1 with diff showing `signals.reranker.active: expected True, got False` and `corpus.chunk_nodes: expected 500, got 0`
+- Confidence: **high** on preflight correctness (live-verified against real cluster), **high** on adapter integration (compile-checked, path-tested)
+
+## Judgment calls & deviations
+- Used `importlib.util.spec_from_file_location` for CLI wrapper to bypass `__init__.py` SDK chain (same pattern as tests). Discovered during live verification.
+- Placed preflight module inside adapter package (`memoryhub_evalhub/preflight.py`) for clean container imports, with thin CLI wrapper at `benchmarks/preflight.py` per issue spec.
+- Used asyncpg directly (not SQLAlchemy) for lightweight DB probes. Matches the provider's existing pattern for corpus reset.
+
+## Backlog delta
+Filed: none. Closes: #371 (via PR #380). Memory: none new. Deferred: adapter lint pre-existing issues (import sort L56, unused get_llm L57).
+
+## Drift & forward-collisions
+- Backward: #360 (Matrix A) now has one fewer blocker (#371 done). Remaining: #372 (PR #379), #342 (reranker), #365 (EvalHub PVC).
+- Backward: #372 (keyword) unaffected; PR #379 still pending review.
+- Forward: #342 (reranker) -- when TEI is deployed, the reranker signal check in preflight will automatically detect it (probes /info endpoint). Config expected_manifest will need updating from `reranker: {active: false}` to `true`. No comment needed; this is by design.
+
+## For the reviewer
+- Sanity-check: the expected_manifest is identical across all 9 configs because they share the same deployment. When signals activate (#342 reranker, #343 chunking), each config's expected_manifest will diverge -- is that manageable at 9 configs?
+- Thin verification: adapter integration not tested end-to-end through EvalHub (would require submitting a real job). The preflight call itself is proven; the integration path from adapter to MLflow metadata is compile-checked only.
+- Wants guidance: none.
+
+## Risks / watch-fors
+- Pre-existing CI failure: Secret Scanning (gitleaks) fails on both feat/benchmark-preflight pushes. Tests workflow passes.
+- Pre-existing test failures: 8 failures in test_conversation_extraction.py on main (dreaming.py TypeError). Not from this session.
+- Pre-existing lint: adapter.py has 2 pre-existing ruff findings (import sort, unused import). Not from this session; noted for future cleanup.


### PR DESCRIPTION
## Summary

- Add `docs/benchmark-system-map.md` documenting the full benchmark stack, signal activation matrix (6 signals with code locations and verify-active checks), and corpus provenance for the amb-benchmark tenant
- Add `benchmarks/preflight.py` module that probes the live deployment and emits a manifest JSON documenting signal activation state and corpus provenance
- Integrate preflight into the EvalHub adapter: `run_preflight()` executes before every benchmark run, `enforce_manifest()` does recursive subset matching against config expectations and refuses to run on mismatch
- Add `expected_manifest` to all 9 matrix configs (7 ablation + 2 smoke) reflecting current deployment state

The preflight prevents the waste that happened in the first matrix run (#360) where all 7 configs produced identical results because only vector similarity was active. Now the adapter checks deployment state before running and fails fast with a readable diff.

## Test plan

- [x] 14 unit tests for enforce_manifest (9 cases), check_signal_focus, check_signal_reranker, get_version_shas
- [x] All files compile clean
- [x] All 9 YAML configs validate (parse + expected_manifest structure check)
- [ ] Standalone preflight run against mcp-rhoai (requires DB port-forward)
- [ ] Deliberate mismatch test (declare reranker active, verify exit 1 with diff)

Closes #371.