### PR TITLE
evalhub: Switch from SQLite to PostgreSQL for persistent state (#365)

### DIFF
--- a/benchmarks/evalhub-adapter/config/matrix/baseline.yaml
+++ b/benchmarks/evalhub-adapter/config/matrix/baseline.yaml
@@ -7,7 +7,7 @@ model:
     secret_ref: gemini-api-key
 benchmarks:
   - id: personamem-mcq
-    provider_id: 88a72afc-a6d5-4bf9-9751-6f52e4e1a091
+    provider_id: 9b72673c-c757-434e-909f-e2f21a616de5
     parameters:
       mode: library
       dataset: personamem

--- a/benchmarks/evalhub-adapter/config/matrix/bm25-only.yaml
+++ b/benchmarks/evalhub-adapter/config/matrix/bm25-only.yaml
@@ -7,7 +7,7 @@ model:
     secret_ref: gemini-api-key
 benchmarks:
   - id: personamem-mcq
-    provider_id: 88a72afc-a6d5-4bf9-9751-6f52e4e1a091
+    provider_id: 9b72673c-c757-434e-909f-e2f21a616de5
     parameters:
       mode: library
       dataset: personamem

--- a/benchmarks/evalhub-adapter/config/matrix/no-domain.yaml
+++ b/benchmarks/evalhub-adapter/config/matrix/no-domain.yaml
@@ -7,7 +7,7 @@ model:
     secret_ref: gemini-api-key
 benchmarks:
   - id: personamem-mcq
-    provider_id: 88a72afc-a6d5-4bf9-9751-6f52e4e1a091
+    provider_id: 9b72673c-c757-434e-909f-e2f21a616de5
     parameters:
       mode: library
       dataset: personamem

--- a/benchmarks/evalhub-adapter/config/matrix/no-focus.yaml
+++ b/benchmarks/evalhub-adapter/config/matrix/no-focus.yaml
@@ -7,7 +7,7 @@ model:
     secret_ref: gemini-api-key
 benchmarks:
   - id: personamem-mcq
-    provider_id: 88a72afc-a6d5-4bf9-9751-6f52e4e1a091
+    provider_id: 9b72673c-c757-434e-909f-e2f21a616de5
     parameters:
       mode: library
       dataset: personamem

--- a/benchmarks/evalhub-adapter/config/matrix/no-graph.yaml
+++ b/benchmarks/evalhub-adapter/config/matrix/no-graph.yaml
@@ -7,7 +7,7 @@ model:
     secret_ref: gemini-api-key
 benchmarks:
   - id: personamem-mcq
-    provider_id: 88a72afc-a6d5-4bf9-9751-6f52e4e1a091
+    provider_id: 9b72673c-c757-434e-909f-e2f21a616de5
     parameters:
       mode: library
       dataset: personamem

--- a/benchmarks/evalhub-adapter/config/matrix/no-keyword.yaml
+++ b/benchmarks/evalhub-adapter/config/matrix/no-keyword.yaml
@@ -7,7 +7,7 @@ model:
     secret_ref: gemini-api-key
 benchmarks:
   - id: personamem-mcq
-    provider_id: 88a72afc-a6d5-4bf9-9751-6f52e4e1a091
+    provider_id: 9b72673c-c757-434e-909f-e2f21a616de5
     parameters:
       mode: library
       dataset: personamem

--- a/benchmarks/evalhub-adapter/config/matrix/no-reranker.yaml
+++ b/benchmarks/evalhub-adapter/config/matrix/no-reranker.yaml
@@ -7,7 +7,7 @@ model:
     secret_ref: gemini-api-key
 benchmarks:
   - id: personamem-mcq
-    provider_id: 88a72afc-a6d5-4bf9-9751-6f52e4e1a091
+    provider_id: 9b72673c-c757-434e-909f-e2f21a616de5
     parameters:
       mode: library
       dataset: personamem

--- a/benchmarks/evalhub-adapter/config/matrix/smoke-keyword-off.yaml
+++ b/benchmarks/evalhub-adapter/config/matrix/smoke-keyword-off.yaml
@@ -7,7 +7,7 @@ model:
     secret_ref: gemini-api-key
 benchmarks:
   - id: personamem-mcq
-    provider_id: 88a72afc-a6d5-4bf9-9751-6f52e4e1a091
+    provider_id: 9b72673c-c757-434e-909f-e2f21a616de5
     parameters:
       mode: library
       dataset: personamem

--- a/benchmarks/evalhub-adapter/config/matrix/smoke-keyword-on.yaml
+++ b/benchmarks/evalhub-adapter/config/matrix/smoke-keyword-on.yaml
@@ -7,7 +7,7 @@ model:
     secret_ref: gemini-api-key
 benchmarks:
   - id: personamem-mcq
-    provider_id: 88a72afc-a6d5-4bf9-9751-6f52e4e1a091
+    provider_id: 9b72673c-c757-434e-909f-e2f21a616de5
     parameters:
       mode: library
       dataset: personamem

--- a/benchmarks/evalhub-adapter/config/smoke-eval.yaml
+++ b/benchmarks/evalhub-adapter/config/smoke-eval.yaml
@@ -7,7 +7,7 @@ model:
     secret_ref: gemini-api-key
 benchmarks:
   - id: personamem-mcq
-    provider_id: 88a72afc-a6d5-4bf9-9751-6f52e4e1a091
+    provider_id: 9b72673c-c757-434e-909f-e2f21a616de5
     parameters:
       mode: library
       dataset: personamem

--- a/benchmarks/evalhub-adapter/manifests/evalhub.yaml
+++ b/benchmarks/evalhub-adapter/manifests/evalhub.yaml
@@ -6,9 +6,8 @@ metadata:
 spec:
   replicas: 1
   database:
-    type: sqlite
+    type: postgresql
+    secret: evalhub-db-credentials
   env:
     - name: MLFLOW_TRACKING_URI
       value: https://mlflow.redhat-ods-applications.svc:8443
-    - name: DB_URL
-      value: "file:/tmp/evalhub.db?cache=shared"

--- a/scripts/deploy-evalhub.sh
+++ b/scripts/deploy-evalhub.sh
@@ -148,16 +148,33 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# EvalHub database Secret (PostgreSQL on shared memoryhub-pg)
+# ---------------------------------------------------------------------------
+banner "EvalHub database"
+
+if oc get secret evalhub-db-credentials --context "$CONTEXT" -n "$NS" &>/dev/null; then
+    info "Secret evalhub-db-credentials already exists"
+else
+    info "Creating evalhub database and secret..."
+    MEMORYHUB_DB_PASSWORD=$(oc get secret memoryhub-pg-credentials --context "$CONTEXT" -n memoryhub-db \
+        -o jsonpath='{.data.POSTGRES_PASSWORD}' 2>/dev/null | base64 -d || true)
+    if [ -z "$MEMORYHUB_DB_PASSWORD" ]; then
+        die "Cannot read memoryhub-pg-credentials from memoryhub-db namespace"
+    fi
+    DB_URL="postgresql://memoryhub:${MEMORYHUB_DB_PASSWORD}@memoryhub-pg.memoryhub-db.svc.cluster.local:5432/evalhub"
+    oc create secret generic evalhub-db-credentials \
+        --from-literal=db-url="$DB_URL" \
+        --context "$CONTEXT" -n "$NS"
+    info "Secret evalhub-db-credentials created"
+fi
+
+# ---------------------------------------------------------------------------
 # EvalHub CR
 # ---------------------------------------------------------------------------
 banner "EvalHub"
 
-if oc get evalhub memoryhub-evalhub --context "$CONTEXT" -n "$NS" &>/dev/null; then
-    info "EvalHub CR memoryhub-evalhub already exists"
-else
-    info "Creating EvalHub CR..."
-    oc apply --context "$CONTEXT" -f "$MANIFEST_DIR/evalhub.yaml"
-fi
+info "Applying EvalHub CR..."
+oc apply --context "$CONTEXT" -f "$MANIFEST_DIR/evalhub.yaml"
 
 # ---------------------------------------------------------------------------
 # MLflow
@@ -226,7 +243,6 @@ else
     [ -n "$TOKEN" ] && evalhub config set token "$TOKEN" 2>/dev/null || true
     evalhub config set tenant "$NS" 2>/dev/null || true
 
-    # SQLite file-backed DB loses providers on pod restart; always re-register
     # Generate provider spec with MemoryHub connection env vars
     MEMORYHUB_MCP_URL="http://memory-hub-mcp.memory-hub-mcp.svc:8080/mcp/"
     MEMORYHUB_KEY=$(bash -c 'cat ~/.config/memoryhub/api-key 2>/dev/null' | tr -d '[:space:]')


### PR DESCRIPTION
## Summary

- Switches EvalHub from in-memory SQLite to PostgreSQL (shared memoryhub-pg instance, dedicated `evalhub` database) so provider registrations, collections, and job history survive pod restarts
- Adds `evalhub-db-credentials` secret creation to `deploy-evalhub.sh`
- Updates all eval configs with stable provider ID `9b72673c-c757-434e-909f-e2f21a616de5`

## Verification

- Applied updated EvalHub CR on cluster, operator reconciled to PostgreSQL backend
- Registered BYOF provider `memoryhub-amb`
- Deleted EvalHub pod, confirmed provider survived automatic restart
- Logs confirm: `driver: pgx, database: evalhub`

## Test plan

- [x] EvalHub pod starts with PostgreSQL backend
- [x] Provider registration persists across pod restart
- [x] Deploy script creates secret idempotently

Closes #365