### PR TITLE
retrieval: Deploy bge-reranker-v2-m3 on L40S GPU (#342)

### DIFF
--- a/deploy/reranker/deployment.yaml
+++ b/deploy/reranker/deployment.yaml
@@ -1,0 +1,64 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: bge-reranker-v2-m3
+  namespace: reranker-model
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: bge-reranker-v2-m3
+  template:
+    metadata:
+      labels:
+        app: bge-reranker-v2-m3
+    spec:
+      tolerations:
+        - key: nvidia.com/gpu
+          operator: Exists
+          effect: NoSchedule
+      containers:
+        - name: tei
+          image: ghcr.io/huggingface/text-embeddings-inference:1.6
+          args:
+            - --model-id
+            - BAAI/bge-reranker-v2-m3
+            - --port
+            - "8080"
+          env:
+            - name: HF_HUB_CACHE
+              value: /data/models
+            - name: TRANSFORMERS_CACHE
+              value: /data/models
+          ports:
+            - containerPort: 8080
+          resources:
+            requests:
+              cpu: "1"
+              memory: 4Gi
+              nvidia.com/gpu: "1"
+            limits:
+              cpu: "4"
+              memory: 8Gi
+              nvidia.com/gpu: "1"
+          volumeMounts:
+            - name: cache
+              mountPath: /data
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 180
+            periodSeconds: 30
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 180
+            periodSeconds: 10
+            failureThreshold: 10
+      volumes:
+        - name: cache
+          persistentVolumeClaim:
+            claimName: reranker-model-cache

--- a/deploy/reranker/kustomization.yaml
+++ b/deploy/reranker/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: reranker-model
+resources:
+  - deployment.yaml
+  - service.yaml
+  - route.yaml
+  - pvc.yaml

--- a/deploy/reranker/pvc.yaml
+++ b/deploy/reranker/pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: reranker-model-cache
+  namespace: reranker-model
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi

--- a/deploy/reranker/route.yaml
+++ b/deploy/reranker/route.yaml
@@ -1,0 +1,13 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: bge-reranker-v2-m3
+  namespace: reranker-model
+spec:
+  to:
+    kind: Service
+    name: bge-reranker-v2-m3
+  port:
+    targetPort: 8080
+  tls:
+    termination: edge

--- a/deploy/reranker/service.yaml
+++ b/deploy/reranker/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: bge-reranker-v2-m3
+  namespace: reranker-model
+spec:
+  selector:
+    app: bge-reranker-v2-m3
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP


### PR DESCRIPTION
## Summary

- Replace ms-marco-MiniLM-L12-v2 (CPU, 512-token max) with bge-reranker-v2-m3 (GPU, 8192-token max) via TEI 1.6
- Add `deploy/reranker/` kustomize manifests with GPU toleration
- Wire `MEMORYHUB_RERANKER_URL` into MCP server deployment
- Fix `deploy-full.sh` auth infra ordering (pre-existing issue: MCP pod startup raced with auth secret creation)

## Verification

- Reranker deployed and responding on GPU node `ip-10-0-19-78`
- Preflight confirms `signals.reranker.active: true`
- Golden test (preserve-DB) passes in 7m 7s
- Test rerank query returns correct ranking

## Reranker specs
| | Old | New |
|---|---|---|
| Model | ms-marco-MiniLM-L12-v2 | bge-reranker-v2-m3 |
| Runtime | TEI CPU 1.6 | TEI GPU 1.6 |
| Max input | 512 tokens | 8192 tokens |
| Precision | float32 | float16 |
| Hardware | CPU (2 cores) | L40S GPU |

## Test plan

- [x] Reranker endpoint responds to /info and /rerank
- [x] Preflight shows reranker active
- [x] Golden test (preserve-DB) passes
- [x] MCP server starts with MEMORYHUB_RERANKER_URL

Closes #342