### PR TITLE
retrieval: content_mode search preference + truncation honesty

### DIFF
--- a/.claude/rules/memoryhub-loading.md
+++ b/.claude/rules/memoryhub-loading.md
@@ -33,6 +33,21 @@ there is no working set in this pattern.
 This pattern minimizes startup token cost at the price of missing
 implicit context. Use it for narrow one-shot tooling sessions.
 
+## Content delivery
+
+- Search results may include **truncated content** for large memories
+  backed by S3 storage. Check `content_truncated` and `full_available`
+  flags on each result.
+- When `content_truncated` is true, call
+  `memory(action="read", memory_id="...", options={"hydrate": true})`
+  to retrieve the full content on demand.
+- For eval harnesses or batch pipelines that need complete content
+  inline, pass `options: {"content_mode": "full"}` to search. This
+  hydrates S3-backed content in the response at the cost of larger
+  payloads.
+- For interactive agent sessions, prefer the default (truncated) mode
+  and hydrate individual memories only when needed.
+
 ## Memory hygiene
 
 - Keep memories concise and self-contained. Another agent should

--- a/memory-hub-mcp/SYSTEM_PROMPT.md
+++ b/memory-hub-mcp/SYSTEM_PROMPT.md
@@ -22,6 +22,8 @@ When you need full metadata (weight, scope, timestamps, branches) for curation d
 
 To expand a stub or get version history for a specific memory, use `memory(action="read", memory_id=...)`.
 
+Large memories (S3-backed) may arrive truncated. Check `content_truncated` and `full_available` flags on each result. When `content_truncated` is true, call `memory(action="read", memory_id="...", options={"hydrate": true})` to get the full content.
+
 ## Hook-injected context
 
 If a `<memoryhub-context>` block is present in your conversation context, a SessionStart hook has already loaded project and user memories for you. Use these as your working set:

--- a/memory-hub-mcp/src/tools/memory.py
+++ b/memory-hub-mcp/src/tools/memory.py
@@ -41,7 +41,7 @@ _SEARCH_OPTS = frozenset({
     "current_only", "owner_id", "graph_depth",
     "graph_relationship_types", "graph_boost_weight", "entities",
     "content_type", "verbose", "temporal_status", "disabled_signals",
-    "tenant_id",
+    "tenant_id", "content_mode",
 })
 _LIST_OPTS = frozenset({
     "max_results", "cursor", "include_branches", "current_only",

--- a/memory-hub-mcp/src/tools/search_memory.py
+++ b/memory-hub-mcp/src/tools/search_memory.py
@@ -60,6 +60,7 @@ from src.tools._deps import (
     get_db_session,
     get_embedding_service,
     get_reranker_service,
+    get_s3_adapter,
     release_db_session,
 )
 
@@ -139,6 +140,8 @@ def _compact_entry(
         entry["content"] = item.content
     else:
         entry["content"] = item.stub
+    entry["content_truncated"] = item.content_truncated
+    entry["full_available"] = item.full_available
     if relevance_score is not None:
         entry["relevance_score"] = round(relevance_score, 4)
     return entry
@@ -700,6 +703,19 @@ async def search_memory(
             ),
         ),
     ] = None,
+    content_mode: Annotated[
+        Literal["stub", "full"],
+        Field(
+            description=(
+                "Content delivery mode for S3-backed memories. "
+                "'stub' (default): returns the stored prefix with honesty flags "
+                "(content_truncated, full_available) so agents can follow up "
+                "with read_memory(hydrate=true) for specific memories. "
+                "'full': hydrates full content from S3 storage before returning. "
+                "Use 'full' in eval/benchmark harnesses."
+            ),
+        ),
+    ] = "stub",
     ctx: Context = None,
 ) -> dict[str, Any]:
     """Search memories using semantic similarity.
@@ -992,6 +1008,32 @@ async def search_memory(
                 response["pivot_reason"] = focus_meta["pivot_reason"]
             return response
 
+        # --- S3 hydration for content_mode="full" ---
+        if content_mode == "full":
+            s3 = get_s3_adapter()
+            if s3 is not None:
+                for idx, (item, score) in enumerate(results):
+                    if (
+                        isinstance(item, MemoryNodeRead)
+                        and item.storage_type == "s3"
+                        and item.content_ref
+                    ):
+                        try:
+                            full_content = await s3.get_content(item.content_ref)
+                            results[idx] = (
+                                item.model_copy(update={
+                                    "content": full_content,
+                                    "content_truncated": False,
+                                    "full_available": False,
+                                }),
+                                score,
+                            )
+                        except Exception as exc:
+                            logger.warning(
+                                "S3 hydration failed for %s: %s",
+                                item.id, exc,
+                            )
+
         # mode='index' degrades every full result to stub form. Done before
         # branch handling so nested branches are also stubs in this mode.
         if mode == "index":
@@ -1181,6 +1223,7 @@ async def search_memory(
             "results": formatted,
             "total_matching": total_matching,
             "has_more": total_matching > len(formatted),
+            "content_mode": content_mode,
         }
         if compilation_meta is not None:
             response["compilation_hash"] = compilation_meta["compilation_hash"]

--- a/memory-hub-mcp/tests/tools/test_search_memory.py
+++ b/memory-hub-mcp/tests/tools/test_search_memory.py
@@ -1896,3 +1896,81 @@ async def test_search_memory_forwards_entities_to_service():
     assert count_kwargs.get("entity_names") == ["PostgreSQL"], (
         f"Expected entity_names=['PostgreSQL'] in count_search_matches kwargs, got {count_kwargs}"
     )
+
+
+# ---------------------------------------------------------------------------
+# #387 -- _compact_entry() honesty flags (content_truncated / full_available)
+# ---------------------------------------------------------------------------
+
+
+class TestCompactEntryHonestyFlags:
+    """Verify that _compact_entry includes content_truncated and full_available."""
+
+    def test_compact_entry_full_inline(self):
+        """Inline MemoryNodeRead: content_truncated=False, full_available=False."""
+        from src.tools.search_memory import _compact_entry
+
+        full, _score = _fake_full_result("full inline content", weight=0.9)
+        assert full.content_truncated is False
+        assert full.full_available is False
+
+        entry = _compact_entry(full, "full")
+        assert entry["content_truncated"] is False
+        assert entry["full_available"] is False
+
+    def test_compact_entry_full_s3(self):
+        """S3-backed MemoryNodeRead with explicit honesty flags."""
+        import uuid as _uuid
+        from datetime import datetime
+
+        from src.tools.search_memory import _compact_entry
+        from memoryhub_core.models.schemas import MemoryNodeRead, MemoryScope, StorageType
+
+        node = MemoryNodeRead(
+            id=_uuid.uuid4(),
+            parent_id=None,
+            content="truncated prefix...",
+            stub="truncated prefix...",
+            storage_type=StorageType.S3,
+            content_ref="s3://memoryhub/abc123",
+            weight=0.9,
+            scope=MemoryScope.USER,
+            branch_type=None,
+            owner_id="wjackson",
+            tenant_id="default",
+            is_current=True,
+            version=1,
+            previous_version_id=None,
+            metadata=None,
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
+            content_truncated=True,
+            full_available=True,
+        )
+
+        entry = _compact_entry(node, "full")
+        assert entry["content_truncated"] is True
+        assert entry["full_available"] is True
+
+    def test_compact_entry_stub_defaults(self):
+        """MemoryNodeStub defaults: content_truncated=True, full_available=True."""
+        from src.tools.search_memory import _compact_entry
+
+        stub, _score = _fake_search_result("stub text", weight=0.5)
+        assert stub.content_truncated is True
+        assert stub.full_available is True
+
+        entry = _compact_entry(stub, "stub")
+        assert entry["content_truncated"] is True
+        assert entry["full_available"] is True
+
+    def test_compact_entry_includes_relevance_score_when_provided(self):
+        """Relevance score is present alongside honesty flags in compact output."""
+        from src.tools.search_memory import _compact_entry
+
+        full, _score = _fake_full_result("test content", weight=0.9)
+        entry = _compact_entry(full, "full", relevance_score=0.85)
+
+        assert "content_truncated" in entry
+        assert "full_available" in entry
+        assert entry["relevance_score"] == 0.85

--- a/sdk/src/memoryhub/client.py
+++ b/sdk/src/memoryhub/client.py
@@ -484,6 +484,7 @@ class MemoryHubClient:
         content_type: str | None = None,
         disabled_signals: list[str] | None = None,
         tenant_id: str | None = None,
+        content_mode: Literal["stub", "full"] | None = None,
     ) -> SearchResult:
         """Search memories using semantic similarity.
 
@@ -578,6 +579,8 @@ class MemoryHubClient:
             opts["disabled_signals"] = disabled_signals
         if tenant_id is not None:
             opts["tenant_id"] = tenant_id
+        if content_mode is not None:
+            opts["content_mode"] = content_mode
 
         data = await self._call_action(
             "search",

--- a/sdk/src/memoryhub/models.py
+++ b/sdk/src/memoryhub/models.py
@@ -41,6 +41,8 @@ class Memory(BaseModel):
     result_type: str | None = None  # "full" or "stub"
     is_appendix: bool | None = None  # True when result is cache-stable appendix (#175)
     content_type: str | None = None  # "declarative" or "behavioral"
+    content_truncated: bool = False
+    full_available: bool = False
 
 
 class CurationInfo(BaseModel):

--- a/sdk/tests/test_models.py
+++ b/sdk/tests/test_models.py
@@ -105,6 +105,34 @@ def test_memory_extra_fields_allowed():
     assert mem.model_extra["another_extra"] == 42
 
 
+@pytest.mark.parametrize(
+    "content_truncated, full_available",
+    [
+        pytest.param(False, False, id="inline-defaults"),
+        pytest.param(True, True, id="s3-backed"),
+        pytest.param(True, False, id="s3-no-ref"),
+    ],
+)
+def test_memory_honesty_flags(content_truncated, full_available):
+    """SDK Memory model preserves content_truncated and full_available (#387)."""
+    data = dict(
+        MEMORY_MINIMAL,
+        content_truncated=content_truncated,
+        full_available=full_available,
+    )
+    mem = Memory(**data)
+
+    assert mem.content_truncated is content_truncated
+    assert mem.full_available is full_available
+
+
+def test_memory_honesty_flags_default():
+    """SDK Memory model defaults: content_truncated=False, full_available=False."""
+    mem = Memory(**MEMORY_MINIMAL)
+    assert mem.content_truncated is False
+    assert mem.full_available is False
+
+
 # ---------------------------------------------------------------------------
 # SearchResult tests
 # ---------------------------------------------------------------------------

--- a/src/memoryhub_core/config.py
+++ b/src/memoryhub_core/config.py
@@ -69,7 +69,7 @@ class AppSettings(BaseSettings):
 
     log_level: str = "INFO"
     version_retention_days: int = 90
-    s3_threshold_bytes: int = 1024    # Content above this is chunked (and goes to S3 if configured)
+    s3_threshold_bytes: int = 102400  # Content above this is chunked (and goes to S3 if configured)
     s3_prefix_chars: int = 1000       # Chars used for embedding on oversized content (~250 tokens)
     session_ttl_seconds: int = 3600   # API-key session lifetime; auto-extends on activity
 

--- a/src/memoryhub_core/models/schemas.py
+++ b/src/memoryhub_core/models/schemas.py
@@ -150,6 +150,8 @@ class MemoryNodeRead(BaseModel):
     # node is itself current.
     current_version_id: uuid.UUID | None = None
     relationships: list["RelationshipRead"] | None = None  # populated when requested
+    content_truncated: bool = False
+    full_available: bool = False
 
 
 class MemoryNodeStub(BaseModel):
@@ -168,6 +170,8 @@ class MemoryNodeStub(BaseModel):
     domains: list[str] | None = None
     content_type: ContentType | None = None
     created_at: datetime | None = None  # needed for cache-optimized sort ordering (#175)
+    content_truncated: bool = True
+    full_available: bool = True
 
 
 class RelationshipCreate(BaseModel):

--- a/src/memoryhub_core/services/memory.py
+++ b/src/memoryhub_core/services/memory.py
@@ -1971,6 +1971,10 @@ def node_to_read(
 
     relevant_until = getattr(node, "relevant_until", None)
 
+    is_s3 = node.storage_type == "s3"
+    content_truncated = is_s3
+    full_available = is_s3 and bool(node.content_ref)
+
     return MemoryNodeRead(
         id=node.id,
         parent_id=node.parent_id,
@@ -2000,4 +2004,6 @@ def node_to_read(
         has_rationale=has_rationale,
         branch_count=branch_count,
         current_version_id=current_version_id,
+        content_truncated=content_truncated,
+        full_available=full_available,
     )

--- a/tests/test_models/test_memory.py
+++ b/tests/test_models/test_memory.py
@@ -195,6 +195,24 @@ class TestMemoryNodeRead:
         assert restored.id == node.id
         assert restored.scope == node.scope
 
+    def test_honesty_flags_default_inline(self):
+        """MemoryNodeRead defaults: content_truncated=False, full_available=False.
+
+        Inline memories contain the full content, so no truncation signal is
+        needed and there is no S3 object to hydrate from.
+        """
+        data = _make_read_data()
+        node = MemoryNodeRead(**data)
+        assert node.content_truncated is False
+        assert node.full_available is False
+
+    def test_honesty_flags_explicit_override(self):
+        """MemoryNodeRead accepts explicit honesty flag values."""
+        data = _make_read_data(content_truncated=True, full_available=True)
+        node = MemoryNodeRead(**data)
+        assert node.content_truncated is True
+        assert node.full_available is True
+
 
 # ---------------------------------------------------------------------------
 # MemoryNodeStub
@@ -225,6 +243,34 @@ class TestMemoryNodeStub:
         assert stub.branch_type is None
         assert stub.has_children is False
         assert stub.has_rationale is False
+
+    def test_stub_honesty_flags_default(self):
+        """MemoryNodeStub defaults: content_truncated=True, full_available=True.
+
+        Stubs always represent a truncated view of the content, and by default
+        the full content is assumed to be retrievable from S3.
+        """
+        stub = MemoryNodeStub(
+            id=uuid.uuid4(),
+            stub="stub text",
+            scope="user",
+            weight=0.7,
+        )
+        assert stub.content_truncated is True
+        assert stub.full_available is True
+
+    def test_stub_honesty_flags_explicit_override(self):
+        """MemoryNodeStub accepts explicit honesty flag overrides."""
+        stub = MemoryNodeStub(
+            id=uuid.uuid4(),
+            stub="stub text",
+            scope="user",
+            weight=0.7,
+            content_truncated=False,
+            full_available=False,
+        )
+        assert stub.content_truncated is False
+        assert stub.full_available is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_services/test_memory_service.py
+++ b/tests/test_services/test_memory_service.py
@@ -19,6 +19,7 @@ from memoryhub_core.models.schemas import (
 from memoryhub_core.services.exceptions import ContradictionNotFoundError, MemoryNotCurrentError, MemoryNotFoundError
 from memoryhub_core.services.memory import (
     DEFAULT_PIVOT_THRESHOLD,
+    node_to_read,
     report_contradiction,
     resolve_contradiction,
 )
@@ -1875,4 +1876,85 @@ async def test_create_memory_passes_force(async_session, embedding_service, monk
     assert "force" in captured_kwargs, "force kwarg was not forwarded to run_curation_pipeline"
     assert captured_kwargs["force"] is True, (
         f"Expected force=True forwarded, got force={captured_kwargs.get('force')!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# #387 -- node_to_read() honesty flags (content_truncated / full_available)
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_node(**overrides):
+    """Build a minimal MemoryNode-like object for node_to_read tests.
+
+    Uses a SimpleNamespace instead of a real ORM instance to avoid needing
+    a database session. node_to_read only reads attributes, never queries.
+    """
+    from types import SimpleNamespace
+    from datetime import UTC, datetime
+
+    defaults = {
+        "id": uuid.uuid4(),
+        "parent_id": None,
+        "content": "test content",
+        "stub": "test stub",
+        "storage_type": "inline",
+        "content_ref": None,
+        "weight": 0.7,
+        "scope": "user",
+        "scope_id": None,
+        "branch_type": None,
+        "owner_id": "user-1",
+        "tenant_id": "default",
+        "domains": None,
+        "content_type": "experiential",
+        "content_hash": None,
+        "is_current": True,
+        "version": 1,
+        "previous_version_id": None,
+        "metadata_": None,
+        "created_at": datetime.now(tz=UTC),
+        "updated_at": datetime.now(tz=UTC),
+        "expires_at": None,
+        "relevant_until": None,
+        "actor_id": None,
+        "driver_id": None,
+    }
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+@pytest.mark.parametrize(
+    "storage_type, content_ref, expected_truncated, expected_available",
+    [
+        pytest.param(
+            "inline", None, False, False,
+            id="inline-memory",
+        ),
+        pytest.param(
+            "s3", "s3://memoryhub/abc123", True, True,
+            id="s3-backed-with-ref",
+        ),
+        pytest.param(
+            "s3", None, True, False,
+            id="s3-backed-without-ref",
+        ),
+    ],
+)
+def test_node_to_read_honesty_flags(
+    storage_type, content_ref, expected_truncated, expected_available,
+):
+    """node_to_read sets content_truncated and full_available based on
+    storage_type and content_ref presence (#387)."""
+    node = _make_mock_node(storage_type=storage_type, content_ref=content_ref)
+
+    result = node_to_read(node, has_children=False, has_rationale=False)
+
+    assert result.content_truncated is expected_truncated, (
+        f"storage_type={storage_type!r}, content_ref={content_ref!r}: "
+        f"expected content_truncated={expected_truncated}, got {result.content_truncated}"
+    )
+    assert result.full_available is expected_available, (
+        f"storage_type={storage_type!r}, content_ref={content_ref!r}: "
+        f"expected full_available={expected_available}, got {result.full_available}"
     )

--- a/tests/test_services/test_memory_service.py
+++ b/tests/test_services/test_memory_service.py
@@ -1437,15 +1437,15 @@ class MockS3Adapter:
 
 
 def _make_oversized_content() -> str:
-    """Return content exceeding the configured S3 threshold (default 1024 bytes).
+    """Return content exceeding the configured S3 threshold (102400 bytes).
 
     Uses distinct paragraphs separated by double-newlines so that the
     semantic chunker produces multiple chunks (it splits on paragraph
     boundaries first).
     """
     paragraphs = [
-        f"Paragraph {i}: " + "x" * 400
-        for i in range(15)
+        f"Paragraph {i}: " + "x" * 2000
+        for i in range(60)
     ]
     return "\n\n".join(paragraphs)
 
@@ -1454,7 +1454,7 @@ def _make_oversized_content() -> str:
 
 
 async def test_create_memory_inline_when_under_threshold(async_session, embedding_service):
-    """Content under 4096 bytes stays inline even with an S3 adapter present."""
+    """Content under s3_threshold_bytes stays inline even with an S3 adapter present."""
     s3 = MockS3Adapter()
     data = _make_create_data(content="Short content that fits inline")
     result, curation = await create_memory(data, async_session, embedding_service, s3_adapter=s3)
@@ -1466,10 +1466,10 @@ async def test_create_memory_inline_when_under_threshold(async_session, embeddin
 
 
 async def test_create_memory_s3_when_over_threshold(async_session, embedding_service):
-    """Content over 4096 bytes is uploaded to S3 when an adapter is provided."""
+    """Content over s3_threshold_bytes is uploaded to S3 when an adapter is provided."""
     s3 = MockS3Adapter()
     big_content = _make_oversized_content()
-    assert len(big_content.encode("utf-8")) > 4096
+    assert len(big_content.encode("utf-8")) > 102400
 
     data = _make_create_data(content=big_content)
     result, curation = await create_memory(data, async_session, embedding_service, s3_adapter=s3)
@@ -1626,9 +1626,9 @@ async def test_update_memory_s3_content_changed_rechunks(async_session, embeddin
     old_chunks = (await async_session.execute(old_chunks_stmt)).scalars().all()
     assert len(old_chunks) >= 2
 
-    # Update with new oversized content
+    # Update with new oversized content (must exceed s3_threshold_bytes=102400)
     new_content = "\n\n".join(
-        [f"Updated paragraph {i}: " + "y" * 400 for i in range(15)]
+        [f"Updated paragraph {i}: " + "y" * 2000 for i in range(60)]
     )
     updated = await update_memory(
         original.id,
@@ -1706,8 +1706,9 @@ async def test_update_memory_non_chunk_branches_still_copied(async_session, embe
     assert old_rationale_count == 1
 
     # Update content (triggers rechunk + deep-copy of non-chunk branches)
+    # Must exceed s3_threshold_bytes=102400
     new_content = "\n\n".join(
-        [f"Revised paragraph {i}: " + "z" * 400 for i in range(15)]
+        [f"Revised paragraph {i}: " + "z" * 2000 for i in range(60)]
     )
     updated = await update_memory(
         parent.id,
@@ -1784,9 +1785,9 @@ async def test_update_memory_oversized_no_s3_retires_old_chunks(async_session, e
     assert len(old_chunks) >= 2
     old_chunk_ids = {c.id for c in old_chunks}
 
-    # Update with different oversized content
+    # Update with different oversized content (must exceed s3_threshold_bytes=102400)
     new_content = "\n\n".join(
-        [f"Updated paragraph {i}: " + "z" * 400 for i in range(15)]
+        [f"Updated paragraph {i}: " + "z" * 2000 for i in range(60)]
     )
     updated = await update_memory(
         original.id,


### PR DESCRIPTION
## Summary

- Add `content_mode` parameter (`stub`|`full`) to search, threaded through
  service, MCP tool, SDK, and dispatcher. Default `stub` for agent callers
  (context-protective); eval harnesses set `full` for S3 hydration.
- Every search result now carries `content_truncated` and `full_available`
  honesty flags. Search never returns partial content silently again.
- Raise `s3_threshold_bytes` from 1024 to 102400 (100KB). Covers PersonaMem
  max document (60,818 chars) and typical agent memories.

## Context

Matrix A showed all 4 signal configs at 46.5% (274/589) because search
returns a 1000-char prefix of S3-backed memories. The H6 content-delivery
audit confirmed this is the root cause of the 21pp gap vs BM25-local
(67.7%). This PR is the substrate fix; #388 (backfill) and #389 (S3
hydration for >100KB) follow.

## Test plan

- [x] Core: `node_to_read()` flag computation (inline/S3/S3-no-ref) -- 3 parametrized tests
- [x] Core: Schema defaults for MemoryNodeRead and MemoryNodeStub -- 4 tests
- [x] MCP: `_compact_entry()` includes honesty flags -- 4 tests
- [x] SDK: Memory model flag defaults and overrides -- 4 tests
- [x] Existing S3 tests updated for 102400 threshold -- 15 passing
- [x] Full suite: core 109, MCP 561, SDK 262 -- all passing
- [ ] H6 side-by-side re-run after deploy (exit predicate)
- [ ] Golden test (preserve-DB)

Closes #387.