### PR TITLE
security: scrub leaked API key, add gitleaks rule and credential hygiene policy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ seed-clients.json
 .mcp.json
 
 NEXT_SESSION*.md
+ISSUE-postsession-*.md
 planning/rfe_draft.md
 
 

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,3 +1,15 @@
+[[rules]]
+id = "memoryhub-hex-api-key"
+description = "MemoryHub API key (hex format: mh-(dev|prod)-<16 hex chars>)"
+regex = '''mh-(dev|prod)-[a-f0-9]{16}'''
+
+  [rules.allowlist]
+  paths = [
+    '''dev-users\.json$''',
+    '''tests\/.*\.py$''',
+    '''\.claude\/worktrees\/''',
+  ]
+
 [allowlist]
   description = "MemoryHub project allowlist for false positives"
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,6 +85,10 @@ Shipped architecture and subsystem designs live in docs/. In-flight designs for 
 Use conventional commit format: `subsystem: Description in imperative mood`
 Example: `memory-tree: Add versioning with isCurrent flag`
 
+## Credential Hygiene
+
+Credentials, API keys, and tokens must never appear in session summaries, plans, issues, or any committed documentation. Reference the secret's storage location instead (e.g., "stored in memoryhub-auth cluster secret" or "see ~/.config/memoryhub/api-key"). This applies to all key formats including hex-format keys (`mh-dev-<hex>`), OAuth client secrets, and database passwords. Incident: a hex-format API key committed in a session summary (2026-07-14) required rotation and git history scrubbing.
+
 ## Deployment Reproducibility (IaC)
 
 Every change must be deployable from code without manual steps. When implementing a feature, verify that all of the following are captured in version-controlled code:

--- a/session-summaries/2026-07-14-dreaming-content-mode.md
+++ b/session-summaries/2026-07-14-dreaming-content-mode.md
@@ -29,7 +29,7 @@ Planned: implement content_mode (stub|full) on search, honesty flags, threshold 
 - S3 hydration placed at MCP layer (not service layer) to match existing read_memory pattern and avoid threading S3 adapter through service signatures
 - Graceful per-item degradation over fail-fast on S3 errors -- a single unreachable S3 object shouldn't tank the whole search
 - Golden test incomplete (UI not deployed) -- accepted since UI isn't relevant to #387's exit predicate
-- Created amb-benchmark API key via auth admin rotate-api-key for verification (key: mh-dev-5c3c065b659ad4b0)
+- Created amb-benchmark API key via auth admin rotate-api-key for verification (rotated; stored in memoryhub-auth cluster secret)
 
 ## Backlog delta
 


### PR DESCRIPTION
## Summary

- Rotated the amb-benchmark API key on the cluster (burned key is now invalid)
- Scrubbed the literal key from `session-summaries/2026-07-14-dreaming-content-mode.md`, replaced with storage location reference
- Added a gitleaks `[[rules]]` detection rule for hex-format MemoryHub API keys (`mh-(dev|prod)-[a-f0-9]{16}`) -- the existing config only had an allowlist for username-year format keys, no detection rule at all
- Added rule-level allowlist for `dev-users.json` and test files (intentional fixture keys)
- Gitignored `ISSUE-postsession-*.md` scratch files
- Added "Credential Hygiene" standing rule to CLAUDE.md: credentials never in summaries/plans/issues

## Context

The session summary for 2026-07-14 included a literal API key for the amb-benchmark client. The gitleaks config (added in 8eb7dd0) had no detection rule for hex-format keys -- it only had an allowlist to suppress false positives on the `mh-dev-<user>-<year>` format. The key has been rotated; this PR scrubs the committed value and closes the detection gap.

## Test plan

- [x] `gitleaks detect --no-git` returns 0 findings on tracked files
- [x] `gitleaks detect` catches the burned key in git history (confirms rule works)
- [x] `gitleaks protect --staged` clean on all commits in this PR
- [x] Verified rotated key works: auth admin returned new key for amb-benchmark