### PR TITLE
search: decouple reranker, add return_chunks, pipeline tracing

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,6 @@
+# Rotated credentials in git history -- keys are dead, history rewrite
+# would break every fork/clone for no security benefit (PR #394 scrubbed
+# the files from HEAD).
+64a66d7e4207657a5cb025c6c7eb4e0ab48fe296:session-summaries/2026-07-14-dreaming-content-mode.md:memoryhub-hex-api-key:32
+0a5131502bed5919e0894055babf1ebaa008b06a:session-summaries/2026-07-14-dreaming-content-mode.md:memoryhub-hex-api-key:32
+9fb9aa8e6a30f8d3b19e124be6970b810bdc37e2:NEXT_SESSION.md:memoryhub-hex-api-key:36

--- a/benchmarks/amb-harness/src/memory_bench/memory/memoryhub.py
+++ b/benchmarks/amb-harness/src/memory_bench/memory/memoryhub.py
@@ -12,6 +12,8 @@ Optional env vars:
     MEMORYHUB_TENANT_ID        -- explicit tenant for search/write (default: session tenant)
     MEMORYHUB_DISABLED_SIGNALS -- comma-separated signal names to disable
                                   (reranker, focus, keyword, domain, graph)
+    MEMORYHUB_FOCUS_MODE       -- "persona" to pass persona name as focus string,
+                                  enabling 2-vector retrieval (default: off)
 
 Reset-only env vars (raw SQL DELETE for test scaffolding):
     MEMORYHUB_DB_HOST    -- default localhost
@@ -55,6 +57,7 @@ class MemoryHubProvider(MemoryProvider):
         self._reset = False
         self._disabled_signals: list[str] | None = None
         self._tenant_id: str | None = None
+        self._focus_mode: str | None = None
 
     def prepare(self, store_dir: Path, unit_ids: set[str] | None = None, reset: bool = True) -> None:
         self._url = os.environ.get("MEMORYHUB_URL")
@@ -80,6 +83,8 @@ class MemoryHubProvider(MemoryProvider):
             [s.strip() for s in raw_disabled.split(",") if s.strip()]
             if raw_disabled else None
         )
+
+        self._focus_mode = os.environ.get("MEMORYHUB_FOCUS_MODE", "").strip().lower() or None
 
         self._doc_to_memory_id.clear()
         self._memory_to_doc_id.clear()
@@ -151,6 +156,13 @@ class MemoryHubProvider(MemoryProvider):
     ) -> tuple[list[Document], dict | None]:
         return asyncio.run(self._run_retrieve(query, k, user_id, query_timestamp))
 
+    @staticmethod
+    def _extract_persona_name(query: str) -> str | None:
+        """Extract persona name from "User: Name\n..." prefix."""
+        if query.startswith("User: "):
+            return query.split("\n", 1)[0].removeprefix("User: ").strip() or None
+        return None
+
     async def _run_retrieve(
         self, query: str, k: int, user_id: str | None, query_timestamp: str | None,
     ) -> tuple[list[Document], dict | None]:
@@ -169,6 +181,10 @@ class MemoryHubProvider(MemoryProvider):
             )
             if self._tenant_id:
                 search_kwargs["tenant_id"] = self._tenant_id
+            if self._focus_mode == "persona":
+                name = self._extract_persona_name(query)
+                if name:
+                    search_kwargs["focus"] = name
             results = await client.search(**search_kwargs)
 
         documents = []

--- a/benchmarks/amb-harness/src/memory_bench/memory/memoryhub.py
+++ b/benchmarks/amb-harness/src/memory_bench/memory/memoryhub.py
@@ -194,6 +194,7 @@ class MemoryHubProvider(MemoryProvider):
                     search_kwargs["focus"] = name
             if self._return_chunks:
                 search_kwargs["return_chunks"] = True
+                search_kwargs["raw_results"] = True
             results = await client.search(**search_kwargs)
 
         documents = []

--- a/benchmarks/amb-harness/src/memory_bench/memory/memoryhub.py
+++ b/benchmarks/amb-harness/src/memory_bench/memory/memoryhub.py
@@ -151,9 +151,11 @@ class MemoryHubProvider(MemoryProvider):
             await engine.dispose()
 
     def retrieve(
-        self, query: str, k: int = 70, user_id: str | None = None,
+        self, query: str, k: int | None = None, user_id: str | None = None,
         query_timestamp: str | None = None,
     ) -> tuple[list[Document], dict | None]:
+        if k is None:
+            k = int(os.environ.get("MEMORYHUB_K", "70"))
         return asyncio.run(self._run_retrieve(query, k, user_id, query_timestamp))
 
     @staticmethod

--- a/benchmarks/amb-harness/src/memory_bench/memory/memoryhub.py
+++ b/benchmarks/amb-harness/src/memory_bench/memory/memoryhub.py
@@ -14,6 +14,9 @@ Optional env vars:
                                   (reranker, focus, keyword, domain, graph)
     MEMORYHUB_FOCUS_MODE       -- "persona" to pass persona name as focus string,
                                   enabling 2-vector retrieval (default: off)
+    MEMORYHUB_RETURN_CHUNKS    -- "true" to return matched chunks directly
+                                  instead of expanding to parent memories
+    MEMORYHUB_K                -- retrieval depth, default 70
 
 Reset-only env vars (raw SQL DELETE for test scaffolding):
     MEMORYHUB_DB_HOST    -- default localhost
@@ -58,6 +61,7 @@ class MemoryHubProvider(MemoryProvider):
         self._disabled_signals: list[str] | None = None
         self._tenant_id: str | None = None
         self._focus_mode: str | None = None
+        self._return_chunks: bool = False
 
     def prepare(self, store_dir: Path, unit_ids: set[str] | None = None, reset: bool = True) -> None:
         self._url = os.environ.get("MEMORYHUB_URL")
@@ -85,6 +89,7 @@ class MemoryHubProvider(MemoryProvider):
         )
 
         self._focus_mode = os.environ.get("MEMORYHUB_FOCUS_MODE", "").strip().lower() or None
+        self._return_chunks = os.environ.get("MEMORYHUB_RETURN_CHUNKS", "").lower() in ("1", "true", "yes")
 
         self._doc_to_memory_id.clear()
         self._memory_to_doc_id.clear()
@@ -187,6 +192,8 @@ class MemoryHubProvider(MemoryProvider):
                 name = self._extract_persona_name(query)
                 if name:
                     search_kwargs["focus"] = name
+            if self._return_chunks:
+                search_kwargs["return_chunks"] = True
             results = await client.search(**search_kwargs)
 
         documents = []

--- a/memory-hub-mcp/src/core/authz.py
+++ b/memory-hub-mcp/src/core/authz.py
@@ -128,6 +128,7 @@ def get_claims_from_context() -> dict:
             "tenant_id": user.get("tenant_id", DEFAULT_TENANT_ID),
             "scopes": scopes,
             "project_memberships": user.get("project_memberships", []),
+            "authorized_tenants": user.get("authorized_tenants"),
         }
         log.debug("Resolved session identity: sub=%s", claims["sub"])
         return claims

--- a/memory-hub-mcp/src/main.py
+++ b/memory-hub-mcp/src/main.py
@@ -41,6 +41,10 @@ from src.tools.thread import thread
 from src.tools.update_memory import update_memory
 from src.tools.write_memory import write_memory
 
+logging.basicConfig(
+    level=getattr(logging, os.getenv("MCP_LOG_LEVEL", "INFO").upper(), logging.INFO),
+    format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+)
 logger = logging.getLogger(__name__)
 
 TOOL_PROFILE = os.getenv("MEMORYHUB_TOOL_PROFILE", "compact")

--- a/memory-hub-mcp/src/tools/memory.py
+++ b/memory-hub-mcp/src/tools/memory.py
@@ -41,7 +41,7 @@ _SEARCH_OPTS = frozenset({
     "current_only", "owner_id", "graph_depth",
     "graph_relationship_types", "graph_boost_weight", "entities",
     "content_type", "verbose", "temporal_status", "disabled_signals",
-    "tenant_id", "content_mode",
+    "tenant_id", "content_mode", "return_chunks",
 })
 _LIST_OPTS = frozenset({
     "max_results", "cursor", "include_branches", "current_only",

--- a/memory-hub-mcp/src/tools/search_memory.py
+++ b/memory-hub-mcp/src/tools/search_memory.py
@@ -937,6 +937,7 @@ async def search_memory(
             }
             pattern_signals = bundle.pattern_signals
         else:
+            reranker = get_reranker_service()
             results = await search_memories(
                 query=query,
                 session=session,
@@ -955,6 +956,7 @@ async def search_memory(
                 content_type=content_type,
                 temporal_status=temporal_status,
                 disabled_signals=set(disabled_signals) if disabled_signals else None,
+                reranker=reranker,
             )
 
             # Pattern detection on the non-focus path: embed the query

--- a/memory-hub-mcp/src/tools/search_memory.py
+++ b/memory-hub-mcp/src/tools/search_memory.py
@@ -1238,15 +1238,12 @@ async def search_memory(
             response["compilation_epoch"] = compilation_meta["compilation_epoch"]
             response["appendix_count"] = compilation_meta["appendix_count"]
         if focus_meta is not None:
-            # Surface only the agent-facing pivot fields by default. The
-            # internal `used_reranker` and `fallback_reason` are useful
-            # for operator debugging but noisy for the agent surface;
-            # they are still exposed when the rerank fell back so an
-            # operator can grep response logs.
             response["pivot_suggested"] = focus_meta["pivot_suggested"]
             response["pivot_reason"] = focus_meta["pivot_reason"]
+            response["used_reranker"] = focus_meta.get("used_reranker", False)
+            response["keyword_matches"] = focus_meta.get("keyword_matches", 0)
             if focus_meta["fallback_reason"]:
-                response["focus_fallback_reason"] = focus_meta["fallback_reason"]
+                response["reranker_fallback_reason"] = focus_meta["fallback_reason"]
         if focus_meta is not None and focus_meta.get("disabled_signals"):
             response["disabled_signals"] = focus_meta["disabled_signals"]
         elif focus_meta is None and disabled_signals:

--- a/memory-hub-mcp/src/tools/search_memory.py
+++ b/memory-hub-mcp/src/tools/search_memory.py
@@ -645,6 +645,17 @@ async def search_memory(
             ),
         ),
     ] = None,
+    return_chunks: Annotated[
+        bool,
+        Field(
+            description=(
+                "(Advanced) When True, return matched chunks directly instead "
+                "of expanding them to their parent memories. Produces smaller, "
+                "more focused results. Use read_memory(hydrate=true) on the "
+                "parent_id if full context is needed. Default False."
+            ),
+        ),
+    ] = False,
     raw_results: Annotated[
         bool,
         Field(
@@ -922,6 +933,7 @@ async def search_memory(
                 content_type=content_type,
                 temporal_status=temporal_status,
                 disabled_signals=set(disabled_signals) if disabled_signals else None,
+                return_chunks=return_chunks,
             )
             graph_bundle = bundle
             results = bundle.results
@@ -957,6 +969,7 @@ async def search_memory(
                 temporal_status=temporal_status,
                 disabled_signals=set(disabled_signals) if disabled_signals else None,
                 reranker=reranker,
+                return_chunks=return_chunks,
             )
 
             # Pattern detection on the non-focus path: embed the query

--- a/sdk/src/memoryhub/client.py
+++ b/sdk/src/memoryhub/client.py
@@ -485,6 +485,7 @@ class MemoryHubClient:
         disabled_signals: list[str] | None = None,
         tenant_id: str | None = None,
         content_mode: Literal["stub", "full"] | None = None,
+        return_chunks: bool = False,
     ) -> SearchResult:
         """Search memories using semantic similarity.
 
@@ -581,6 +582,8 @@ class MemoryHubClient:
             opts["tenant_id"] = tenant_id
         if content_mode is not None:
             opts["content_mode"] = content_mode
+        if return_chunks:
+            opts["return_chunks"] = True
 
         data = await self._call_action(
             "search",

--- a/session-summaries/2026-07-15-dreaming-reranker-decoupling.md
+++ b/session-summaries/2026-07-15-dreaming-reranker-decoupling.md
@@ -1,0 +1,93 @@
+# Session Summary -- 2026-07-15 -- Dreaming -- Reranker decoupling + retrieval signal audit
+
+**Plan:** NEXT_SESSION-dreaming.md (harness audit + ablation matrix)
+**Commits:** 7906a64..9ca9e32 (feat/reranker-decoupling-and-focus-harness)
+**Deployed:** dev (MCP server, 6 deploys)   **Model:** Opus 4.6
+
+## Plan vs. actual
+
+Planned: harness audit, enable keyword+reranker, run 4-config ablation matrix, analyze.
+Shipped: harness audit (clean), 2-config matrix (vector-only and vector+keyword both 70.8%),
+discovered reranker was gated behind focus path, decoupled it, added return_chunks feature,
+verified full pipeline via response metadata and server tracing.
+Slipped: full 589-query runs with reranker and focus deferred -- corpus too small per persona
+(4-7 parents) for signals to differentiate; chunking experiment showed promise (94% context
+reduction) but needs the full run.
+
+## Shipped
+
+- 7906a64 chore: .gitleaksignore for 3 rotated credentials in git history
+- 8b1bb8f search: decouple reranker from focus path + harness focus mode + authorized_tenants fix
+- 4094e47 search: pipeline tracing (INFO logs + used_reranker/keyword_matches in MCP response)
+- 4432078 search: return_chunks option to skip chunk-to-parent expansion
+- aac9d71 search: filter to chunks-only when return_chunks=True (parents were competing)
+- 1f93989 search: add return_chunks to compact dispatcher whitelist
+- 9ca9e32 bench: raw_results=True when return_chunks active (cache ordering backfills parents)
+
+Also: `.env` for benchmark harness (dotenv format, no secrets), `dev-users.json` + `users-configmap.yaml`
+updated with `authorized_tenants` for cross-tenant benchmark access.
+
+## Verification & confidence
+
+- Harness audit: byte-for-byte diff against neutral AMB harness (vectorize-io/agent-memory-benchmark).
+  PersonaMem dataset, RAG mode, runner wiring all identical. k=70 within benchmark norms.
+- Pipeline stages verified via response metadata: `used_reranker: True`, `keyword_matches: 0-5`,
+  `pivot_suggested: False`, `disabled_signals: ['domain', 'graph']`.
+- Server trace logs confirm: `focused_search: reranker applied to 24 candidates`,
+  `candidates=50 reranker=True keyword_hits=N focus=True`.
+- Chunks experiment: 10 queries, 94% context reduction (28K to 1.6K tokens), 7/10 vs 8/10 accuracy.
+- Confidence: **medium** -- all pipeline stages fire and produce correct metadata, but the
+  PersonaMem 32k corpus is too small per persona to differentiate retrieval strategies.
+  Full 589-query runs needed for statistical significance on chunks vs parents.
+
+## Judgment calls & deviations
+
+- Decoupled reranker from focus path (product fix) rather than just wiring focus into the harness.
+  The harness-only fix would have been faster but the reranker-requires-focus coupling was a real
+  product limitation.
+- Skipped the planned 4-config matrix (vector-only / +keyword / +reranker / +both). After
+  vector+keyword showed identical results (100% recall at k=70), the remaining configs would
+  have been redundant. Pivoted to the more interesting question: chunk-level retrieval.
+- Created `.env` file with shell command substitution that poisoned the API key via
+  `load_dotenv(override=True)`. Fixed by removing shell commands and using plain dotenv format.
+  Root cause was Kepner-Tregoe-diagnosed by Wes: "what changed between when it worked and when it didn't."
+
+## Backlog delta
+
+Filed: none.
+Closed: none formally (branch not yet merged).
+Deferred: full 589-query chunk-vs-parent run, chunking hyperparameter tuning, GPU machineset
+scale-down (still at 3 nodes).
+
+Lessons captured in CLAUDE.md: none yet (branch not merged). Candidates:
+- When adding a parameter to `search_memory`, also add it to `_SEARCH_OPTS` in `memory.py`.
+- `.env` files loaded by python-dotenv don't evaluate shell commands; use plain values only.
+
+## Drift & forward-collisions
+
+- Backward: #343 (chunk tuning) -- the return_chunks feature changes the evaluation surface;
+  chunk size/overlap now directly affects LLM context quality, not just recall pool coverage.
+- Forward: #345 (reflection), #347 (reconciliation) -- the pipeline tracing infrastructure
+  (used_reranker, keyword_matches in response) will be needed for these phases to verify
+  signal contributions.
+
+## For the reviewer
+
+- Sanity-check: the return_chunks feature filters parents post-RRF rather than excluding them
+  from the recall pool. This means parents still influence chunk ranking via RRF competition.
+  Is that the right design, or should chunks-only mode also exclude parents from the recall query?
+- Thin verification: the 10-query chunk experiment (7/10 vs 8/10) is noise-level. The full
+  589-query run is needed before drawing conclusions.
+- Wants guidance: chunking strategy (size, overlap, semantic boundaries) is the next high-leverage
+  area. Should this be a dedicated tuning session or part of the next dreaming session?
+
+## Risks / watch-fors
+
+- 6 MCP deploys in one session is fragile -- each deploy takes ~2 min and can hit timing issues
+  (auth error from pod restart during benchmark). Consider batching changes.
+- CI Secret Scanning still fails on main due to old credential in history. The .gitleaksignore
+  fix is on this branch; will resolve when merged.
+- Benchmark .env with `load_dotenv(override=True)` is a footgun -- any shell-style syntax
+  in the file silently corrupts env vars. The file now has a warning comment.
+- GPU machineset at 3 nodes (scaled from 2 last session). Confirm both Granite models fit on
+  2 nodes before scaling back.

--- a/src/memoryhub_core/services/memory.py
+++ b/src/memoryhub_core/services/memory.py
@@ -963,6 +963,7 @@ async def search_memories(
     temporal_status: str | None = None,
     keyword_boost_weight: float = 0.15,
     disabled_signals: set[str] | None = None,
+    reranker: RerankerService | None = None,
 ) -> list[tuple[MemoryNodeRead | MemoryNodeStub, float]]:
     """Search memories using pgvector cosine similarity with optional keyword recall.
 
@@ -972,6 +973,10 @@ async def search_memories(
     When keyword recall is active (default), the relevance score is an RRF
     blend of cosine and keyword ranks. When keyword is disabled, scoring
     falls back to cosine-rank-only RRF (equivalent to the previous behavior).
+
+    When a reranker is provided and not disabled, the top RERANK_POOL_SIZE
+    candidates are re-scored by a cross-encoder before the RRF blend. This
+    replaces cosine ranks with cross-encoder ranks for those candidates.
 
     Falls back to weight-based ordering with synthetic scores when pgvector
     is not available (e.g., SQLite in tests).
@@ -1089,7 +1094,27 @@ async def search_memories(
             logger.warning("keyword recall failed, skipping: %s", exc)
             use_keyword = False
 
-    # RRF blend: cosine rank + keyword rank (when active).
+    # Cross-encoder rerank stage (optional, independent of focus).
+    if (
+        reranker is not None
+        and getattr(reranker, "is_configured", True)
+        and "reranker" not in _disabled
+    ):
+        rerank_pool = candidate_nodes[:RERANK_POOL_SIZE]
+        try:
+            order = await batched_rerank(
+                reranker, query, [n.content for n in rerank_pool]
+            )
+            for new_rank, original_idx in enumerate(order, start=1):
+                node = rerank_pool[original_idx]
+                rank_cosine[node.id] = new_rank
+            for idx in range(len(rerank_pool), len(candidate_nodes)):
+                rank_cosine[candidate_nodes[idx].id] = idx + 1
+            logger.debug("search_memories: reranker applied to %d candidates", len(rerank_pool))
+        except Exception as exc:
+            logger.warning("search_memories reranker fallback: %s", exc)
+
+    # RRF blend: cosine/reranker rank + keyword rank (when active).
     weight_k = keyword_boost_weight if use_keyword else 0.0
     weight_q = 1.0 - weight_k
     miss_rank = k_recall + 1
@@ -1326,10 +1351,6 @@ async def search_memories_with_focus(
     _disabled = disabled_signals or set()
 
     if not focus_string or session_focus_weight <= 0.0:
-        # No-focus short-circuit. Skips both the focus embed and the
-        # rerank network call. Mirrors the production-tuning rule
-        # from the benchmark: when there's no focus signal, the
-        # cross-encoder doesn't help, so don't pay for it.
         plain = await search_memories(
             query=query,
             session=session,
@@ -1347,6 +1368,8 @@ async def search_memories_with_focus(
             entity_names=entity_names,
             content_type=content_type,
             temporal_status=temporal_status,
+            disabled_signals=disabled_signals,
+            reranker=reranker,
         )
         return FocusedSearchResult(results=plain)
 

--- a/src/memoryhub_core/services/memory.py
+++ b/src/memoryhub_core/services/memory.py
@@ -1134,7 +1134,9 @@ async def search_memories(
         )
         scored.append((node, score_q + score_k))
     scored.sort(key=lambda pair: pair[1], reverse=True)
-    if not return_chunks:
+    if return_chunks:
+        scored = [(n, s) for n, s in scored if n.branch_type == "chunk"]
+    else:
         scored = await _expand_chunks_to_parents(scored, session)
 
     top_nodes = scored[:max_results]
@@ -1662,7 +1664,9 @@ async def search_memories_with_focus(
         )
         blended_scores.append((node, score_q + score_f + score_d + score_g + score_k))
     blended_scores.sort(key=lambda pair: pair[1], reverse=True)
-    if not return_chunks:
+    if return_chunks:
+        blended_scores = [(n, s) for n, s in blended_scores if n.branch_type == "chunk"]
+    else:
         blended_scores = await _expand_chunks_to_parents(blended_scores, session)
 
     top_nodes = [node for node, _ in blended_scores[:max_results]]

--- a/src/memoryhub_core/services/memory.py
+++ b/src/memoryhub_core/services/memory.py
@@ -1110,7 +1110,7 @@ async def search_memories(
                 rank_cosine[node.id] = new_rank
             for idx in range(len(rerank_pool), len(candidate_nodes)):
                 rank_cosine[candidate_nodes[idx].id] = idx + 1
-            logger.debug("search_memories: reranker applied to %d candidates", len(rerank_pool))
+            logger.info("search_memories: reranker applied to %d candidates", len(rerank_pool))
         except Exception as exc:
             logger.warning("search_memories reranker fallback: %s", exc)
 
@@ -1154,6 +1154,17 @@ async def search_memories(
                 has_rationale=has_rationale,
                 content_type=node.content_type, created_at=node.created_at,
             ), rrf_score))
+    used_reranker = (
+        reranker is not None
+        and getattr(reranker, "is_configured", True)
+        and "reranker" not in _disabled
+    )
+    logger.info(
+        "search_memories trace: candidates=%d reranker=%s keyword_hits=%d "
+        "results=%d disabled=%s",
+        len(candidate_nodes), used_reranker, len(rank_keyword),
+        len(results), sorted(_disabled),
+    )
     return results
 
 
@@ -1502,6 +1513,7 @@ async def search_memories_with_focus(
             for idx in range(len(rerank_pool), len(candidate_nodes)):
                 rank_query[candidate_nodes[idx].id] = idx + 1
             used_reranker = True
+            logger.info("focused_search: reranker applied to %d candidates", len(rerank_pool))
         except Exception as exc:  # pragma: no cover - network error
             fallback_reason = (
                 f"reranker call failed ({type(exc).__name__}); "
@@ -1514,10 +1526,12 @@ async def search_memories_with_focus(
         fallback_reason = (
             "no reranker configured; using cosine rank for query stage"
         )
+        logger.info("focused_search: no reranker configured")
     else:
         fallback_reason = (
             "reranker not configured (is_configured=False); using cosine rank"
         )
+        logger.info("focused_search: reranker disabled (is_configured=False or in disabled_signals)")
 
     # Focus cosine ranks across the candidate pool. Distance from the
     # focus vector ascending = best focus match first.
@@ -1734,6 +1748,13 @@ async def search_memories_with_focus(
         except Exception:
             pass  # pattern detection is best-effort
 
+    logger.info(
+        "focused_search trace: candidates=%d reranker=%s keyword_hits=%d "
+        "focus=%s pivot=%.3f/%s results=%d disabled=%s",
+        len(candidate_nodes), used_reranker, len(rank_keyword),
+        bool(use_focus), pivot_distance or 0.0, pivot_suggested,
+        len(formatted), sorted(_disabled),
+    )
     return FocusedSearchResult(
         results=formatted,
         pivot_suggested=pivot_suggested,

--- a/src/memoryhub_core/services/memory.py
+++ b/src/memoryhub_core/services/memory.py
@@ -964,6 +964,7 @@ async def search_memories(
     keyword_boost_weight: float = 0.15,
     disabled_signals: set[str] | None = None,
     reranker: RerankerService | None = None,
+    return_chunks: bool = False,
 ) -> list[tuple[MemoryNodeRead | MemoryNodeStub, float]]:
     """Search memories using pgvector cosine similarity with optional keyword recall.
 
@@ -977,6 +978,10 @@ async def search_memories(
     When a reranker is provided and not disabled, the top RERANK_POOL_SIZE
     candidates are re-scored by a cross-encoder before the RRF blend. This
     replaces cosine ranks with cross-encoder ranks for those candidates.
+
+    When return_chunks is True, chunk hits are returned directly instead
+    of being expanded to their parent memories. This produces smaller,
+    more focused results at the cost of losing surrounding context.
 
     Falls back to weight-based ordering with synthetic scores when pgvector
     is not available (e.g., SQLite in tests).
@@ -1129,7 +1134,8 @@ async def search_memories(
         )
         scored.append((node, score_q + score_k))
     scored.sort(key=lambda pair: pair[1], reverse=True)
-    scored = await _expand_chunks_to_parents(scored, session)
+    if not return_chunks:
+        scored = await _expand_chunks_to_parents(scored, session)
 
     top_nodes = scored[:max_results]
 
@@ -1330,6 +1336,7 @@ async def search_memories_with_focus(
     temporal_status: str | None = None,
     keyword_boost_weight: float = 0.15,
     disabled_signals: set[str] | None = None,
+    return_chunks: bool = False,
 ) -> FocusedSearchResult:
     """Two-vector retrieval with session focus bias.
 
@@ -1381,6 +1388,7 @@ async def search_memories_with_focus(
             temporal_status=temporal_status,
             disabled_signals=disabled_signals,
             reranker=reranker,
+            return_chunks=return_chunks,
         )
         return FocusedSearchResult(results=plain)
 
@@ -1654,7 +1662,8 @@ async def search_memories_with_focus(
         )
         blended_scores.append((node, score_q + score_f + score_d + score_g + score_k))
     blended_scores.sort(key=lambda pair: pair[1], reverse=True)
-    blended_scores = await _expand_chunks_to_parents(blended_scores, session)
+    if not return_chunks:
+        blended_scores = await _expand_chunks_to_parents(blended_scores, session)
 
     top_nodes = [node for node, _ in blended_scores[:max_results]]
     if not top_nodes:


### PR DESCRIPTION
## Summary

- Decouple the cross-encoder reranker from the focus path so it works as a standalone signal
- Add `return_chunks` option to return matched chunks directly instead of expanding to parents (94% context reduction)
- Expose `used_reranker` and `keyword_matches` in MCP search response for pipeline observability
- Add `authorized_tenants` to claims builder for cross-tenant benchmark access
- Add `.gitleaksignore` for rotated credentials in git history
- Harness: `MEMORYHUB_FOCUS_MODE`, `MEMORYHUB_RETURN_CHUNKS`, `MEMORYHUB_K` env vars

## Test plan

- [x] Pipeline verified via response metadata (`used_reranker: True`, `keyword_matches: 0-5`)
- [x] Server trace logs confirm all stages fire
- [x] 10-query smoke test: chunks mode produces 94% smaller context (1.6K vs 28K tokens)
- [x] Lint clean, gitleaks clean, unit tests pass
- [ ] Full 589-query run with chunks mode (deferred to next session)

Generated with [Claude Code](https://claude.ai/claude-code)