### PR TITLE
docs: add eager fact extraction design, client intelligence strategy, and d5 readiness audit

### DIFF
--- a/planning/d5-readiness-audit.md
+++ b/planning/d5-readiness-audit.md
@@ -1,0 +1,124 @@
+# D5 Readiness Audit — Assumed vs Real MemoryHub Capability
+
+**Status:** Claim inventory drafted 2026-07-15; verification sweep not yet run
+**Design refs:** `planning/platform-memory-benchmark.md` (Dimension 5 taxonomy
++ scoring design), `docs/benchmark-system-map.md` (methodology precedent),
+CLAUDE.md "Verify Before Propagating"
+
+## Why
+
+Dimension 5 (downstream agent behavior) scores whether memory changes agent
+behavior toward user intent. Its scoring protocol makes hard demands on
+MemoryHub: retrieval attribution, injection records, contradiction machinery,
+version-chain reads, SDK parity. Several of these are *claimed* in project
+docs, agent rules, or design sketches but have never been verified against
+the deployed server — and the project has now logged four incidents of
+unverified capability claims propagating (chunking, PVC, sidecar, upstream
+triage). This audit applies the lesson proactively: inventory every
+capability D5 depends on, verify each against code/live state, and file the
+gaps as product issues BEFORE D5 design work begins.
+
+Rule for this document: no row gets a verdict without a cited artifact.
+Every row below is UNVERIFIED until the sweep session fills it in.
+
+## Claim inventory
+
+Columns: capability / where it's claimed / what D5 needs it for /
+verification method / verdict (REAL, PARTIAL, ASPIRATIONAL) + citation.
+
+### A. Attribution and telemetry (the hard requirements)
+
+| # | Capability | Claimed in | D5 needs it for | Verify by | Verdict |
+|---|-----------|-----------|-----------------|-----------|---------|
+| A1 | Per-session retrieval log: query -> returned memory IDs, timestamps | implied by "audit trails" in governance story | Memory-attribution check (correct behavior must trace to a retrieval) | Read audit-log schema + code: does it record READS or only writes? | UNVERIFIED |
+| A2 | Injection record: what the SessionStart hook injected per session | `.claude/rules/memoryhub-loading.md` (hook injects `<memoryhub-context>`) | Distinguish "memory in context via injection" from "retrieved mid-session" | Trace hook path; is the injected working set recorded server-side? | UNVERIFIED |
+| A3 | Session identity: `register_session` ties a run to a queryable session record | memoryhub-loading.md | Per-run traces; memoryless-vs-enabled pairing | Call it; inspect what's stored | UNVERIFIED |
+| A4 | Version-chain read API via MCP (get history for a memory) | `MemoryPlatform` ABC sketch (`get_version_history`), versioning claims in CLAUDE.md/README | Temporal + correction tasks; churn verification | Enumerate MCP tool surface; is history actually exposed, or DB-only? | UNVERIFIED |
+
+### B. Behavior machinery (correction / escalation classes)
+
+| # | Capability | Claimed in | D5 needs it for | Verify by | Verdict |
+|---|-----------|-----------|-----------------|-----------|---------|
+| B1 | `report_contradiction` records contradictions with counts | memoryhub-loading.md | Correction tasks (agent surfaces conflict) | Call it; check schema + count increment | UNVERIFIED |
+| B2 | Server "surfaces stale memories for review" from contradiction counts | memoryhub-loading.md — **likely ASPIRATIONAL: this is #353 (staleness sweep), not built** | Correction-task ground truth; also honesty of agent-facing docs | Grep for any surfacing mechanism; if absent, fix the rules doc | UNVERIFIED |
+| B3 | `branch_type="rationale"` branches via `parent_id` | memoryhub-loading.md; used by MH-FIRST memory write | Policy memories with load-bearing "why" (escalation tasks) | Write one; read it back; check search behavior | UNVERIFIED |
+| B4 | Weight semantics: weight actually affects injection/ranking (1.0 policies surface reliably) | memoryhub-loading.md ("set weights deliberately"); `generate_stub` docstring ("injection weight") | Escalation tasks depend on policy memories reliably reaching context | Trace weight through search ranking + working-set selection; test 1.0-vs-0.5 surfacing | UNVERIFIED |
+| B5 | Scope isolation: user/project/organizational/enterprise all enforced end-to-end | memoryhub-loading.md; RBAC claims | Task isolation; multi-principal D5 scenarios | Existing tests? Cross-scope read attempt | UNVERIFIED |
+
+### C. SDK / MCP surface parity (the ambiguity Wes observed)
+
+| # | Capability | Claimed in | D5 needs it for | Verify by | Verdict |
+|---|-----------|-----------|-----------------|-----------|---------|
+| C1 | Released SDK parity with server surface (disabled_signals, tenant_id) | assumed by harness; **known-lagging: PyPI 0.14.0 lacks both** | D5 harness drives agents through the SDK; every lag is a blocker | Diff released-SDK surface vs MCP tool schema; publish parity matrix; define release cadence | **PARTIAL** -- characterized 2026-07-14. PyPI 0.14.0 `search()` lacks `disabled_signals` (added `d7dd3f0` #354) and `tenant_id` (added `42be4ed` #368). Server supports both. Adapter Containerfile bundles local SDK as workaround. Customers on PyPI cannot use these server capabilities. C2 merged here: the "SDK-to-MCP send limitation" IS this release-parity gap, not a separate structural issue. Filed as #381. |
+| C3 | Per-request tenant selection Phase 2 (`authorized_tenants` in JWT) | #368 Phase 1 shipped own-tenant-only; Phase 2 is a hook, not an implementation | Multi-tenant D5 scenarios; benchmark service accounts | Read `resolve_tenant()`; confirm Phase 2 status | UNVERIFIED (known partial) |
+| C4 | MCP search response content fidelity (full content vs stubs/truncation) | assumed by all benchmark runs; **H6 in the theory doc suspects lossiness** | All classes — behavior depends on what actually reaches context | The H6 context-delivery audit (already planned in Matrix A session) | UNVERIFIED |
+
+### D. Baseline and control (harness-side, listed for completeness)
+
+| # | Capability | Needed for | Note |
+|---|-----------|-----------|------|
+| D1 | Memoryless baseline mode (same agent, no memory) | Delta-scoring | Harness-side: skip registration / empty tenant. Verify no hidden fallback injection. |
+| D2 | Controlled memory pre-load (seed exact memories for a task) | Task construction | write_memory suffices? Verify determinism (embedding versioning). |
+| D3 | Run reproducibility: pin memory-state snapshot per task | pass^k repeated trials | Needs corpus snapshot/restore per trial — relates to #348 rollback machinery. |
+
+## Sweep session (file via /issue-tracker when ready)
+
+`benchmarking: D5 readiness audit — verify assumed MemoryHub capabilities` (#382)
+
+- **Session scope:** read/trace/verify every UNVERIFIED row above; fill
+  verdicts with citations; correct any agent-facing doc making
+  aspirational claims (B2 is the known suspect — memoryhub-loading.md
+  must not promise what #353 hasn't built); file one MH issue per
+  confirmed gap (MemoryHub-first: these are product gaps found early,
+  same as tenant_id/#368).
+- **Exit predicate:** zero UNVERIFIED rows; every verdict cited; agent-
+  facing docs match verified reality; gap issues filed and linked here.
+- **Verifier:** each verdict has a code path, live call output, or test.
+- **Not blocking:** Matrix A or Phases 5-7. Natural slot: filler /
+  parallel-ok, but MUST complete before #337's D5 implementation starts.
+  Note overlaps: A1 relates to #347's decision log; B2 to #353; D3 to
+  #348; C4 rides the already-planned H6 audit.
+- **Circuit breaker:** timebox one session; rows still unverified at
+  the end stay UNVERIFIED in the doc (honest) with a follow-up filed —
+  do not guess verdicts to hit the exit predicate.
+
+## Companion sweep: agent-facing docs (separate issue, cheaper, do first)
+
+`docs: Capability-claim sweep of agent-facing documents — provable-only` (#383)
+
+**Principle (decided 2026-07-15):** documents are swept by *audience*, not
+by a blanket provability rule. Agent-facing docs are executed, not read —
+an aspirational claim there is a bug (the agent behaves as if the
+capability exists). Planning docs keep their aspirations; that is their
+function. `docs/` holds shipped reality per the existing CLAUDE.md
+convention. Mixed-audience docs (README) mark every capability claim
+Shipped / Partial (+issue) / Planned (+issue).
+
+- **Session scope (loop-shaped):** enumerate agent-facing surfaces —
+  `.claude/rules/memoryhub-loading.md`, CLAUDE.md capability statements,
+  `memory-hub-mcp` SYSTEM_PROMPT.md and tool descriptions/docstrings,
+  SDK docstrings. For each capability claim: verify against code/live
+  state; keep (with citation), demote to planning/ + backlog issue link,
+  or rewrite to match reality. B2 (contradiction "surfacing") is the
+  known first offender.
+- **Exit predicate:** every capability claim in agent-facing surfaces is
+  either verified or removed/rewritten; demotions link to a tracking
+  issue; a one-line placement rule proposed for CLAUDE.md (via the
+  dedicated-PR approval process): "Agent-facing docs state only verified
+  capabilities; intended features live in planning/ with an issue link."
+- **Verifier:** grep sweep list with per-claim verdict; second pass
+  returns zero unmarked claims.
+- **Circuit breaker:** one session; unfinished surfaces listed at the
+  end of this doc, not silently skipped.
+
+## Sequencing position (answers "features before benchmarking?")
+
+Neither-first — the interleave already in the epic plan, with the ratio
+rebalanced: Matrix A closes the retrieval question, then Phase 5
+(reconciliation/rollback) becomes the priority. Phase 5-7 work closes
+most D5 gaps as a side effect (A1~#347 decision log, B2=#353, D3=#348),
+so feature development IS the D5 unblocking path. The benchmark tiers
+that need features (Matrix B, D5) are already sequenced after them.
+Benchmarking's record this epic: found #368, disabled_signals, SDK
+parity, and one production defect (chunk recall) — it orders feature
+work by demonstrated need; it does not compete with it.

--- a/planning/eager-fact-extraction.md
+++ b/planning/eager-fact-extraction.md
@@ -1,0 +1,177 @@
+# Eager Fact Extraction via MCP Sampling
+
+**Status:** Design (extends `memory-extraction-pipeline.md`; for the
+write-time extraction issue, TBD via issue-tracker)
+**Date:** 2026-07-16
+**Author:** @rdwj (designed with Claude in Cowork)
+**Builds on:** `planning/memory-extraction-pipeline.md` (the extraction
+pipeline this feeds), #339 (unified stage contracts), #347
+(reconciliation), #348 (run provenance)
+**Validated by:** chunk sweep + fact extraction prototype
+(session 2026-07-15, `benchmarks/amb-harness/extract_facts.py`)
+
+---
+
+## 1. Position: a second trigger, not a fourth pipeline
+
+This project once had three overlapping extraction/curation paths; #339
+exists to unify them. Eager fact extraction MUST NOT become the fourth.
+It is defined as a second *entry point* into the one extraction pipeline:
+
+| | Background ("dreaming") | Eager (this design) |
+|---|---|---|
+| Trigger | cron / extraction_runner over stored threads | `write_memory` call with oversized content |
+| LLM | server-configured extraction model | **the client's own model, via MCP sampling** |
+| Latency | minutes-hours after write | seconds, within the write interaction |
+| Output | fact candidates | fact candidates (identical shape) |
+| Downstream | reconciliation (#347), provenance (#348), curation | **same — no separate path** |
+
+Everything after candidate production — reconciliation, dedup,
+provenance, versioning, curation gates — is shared. If an implementation
+decision would fork the downstream, the decision is wrong.
+
+## 2. Why (evidence)
+
+The 2026-07-15 sweep established that retrieval-unit granularity, not
+tuning, is the lever on PersonaMem:
+
+| Mode | Accuracy | Ctx tokens | k |
+|------|----------|-----------|---|
+| facts-lite-k70 | **63.3%** | **1,256** | 70 |
+| c256-o10-k10 (best chunk) | 62.6% | 1,588 | 10 |
+| c512-o25-k10 | 62.6% | 2,984 | 10 |
+| parents-mode (== corpus-stuffing at this scale) | 70.8% | ~28,000 | 70 |
+
+Chunk size is irrelevant (62.0-62.6% flat across 32-512 tokens, all
+overlaps). Facts are the best *budgeted* mode at 22x fewer tokens than
+full-context. The per-category signature is the design driver:
+
+| Category | Facts k=70 | Chunks c256 | Delta |
+|----------|-----------|-------------|-------|
+| generalizing_to_new_scenarios | 89.5% | 73.7% | +15.8pp |
+| recalling_reasons_behind_updates | 85.9% | 77.8% | +8.1pp |
+| track_full_preference_evolution | 74.8% | 72.7% | +2.1pp |
+| provide_preference_aligned_recs | 61.8% | 63.6% | -1.8pp |
+| recall_user_shared_facts | 58.9% | 64.3% | -5.4pp |
+| recalling_facts_mentioned_by_user | 47.1% | 41.2% | +5.9pp |
+| suggest_new_ideas | 16.1% | 23.7% | -7.6pp |
+
+Reading: facts dominate the *synthesis* categories (generalization,
+reasons, evolution — the "know me" core, and exactly the substrate
+reconciliation/Layer 3 need), and lose where broad raw context helps
+(idea suggestion, some recall). Implication: facts are the primary
+retrieval unit; parents remain reachable via `content_mode`/
+`read_memory` hydration. Category-adaptive delivery is future work
+(Section 8).
+
+Caveats carried from the session: single extraction model (Flash Lite),
+single run; the +0.7pp over chunks is noise. The pipeline is justified
+by token efficiency and by facts being the substrate of Phases 5-7 —
+not by that margin.
+
+## 3. Mechanism: MCP sampling
+
+FastMCP (>= 3.4.2) supports server-initiated sampling: during a tool
+call, the server sends a `sampling/createMessage` request back to the
+client, and the CLIENT's LLM produces the completion.
+
+Strategic property (see `strategy/client-supplied-intelligence.md`):
+MemoryHub performs LLM extraction **without server-side model
+credentials, GPU inference capacity, or model egress**. The caller's
+model — whatever it is, wherever it runs — does the work, under the
+caller's existing model governance. For FIPS/air-gapped deployments this
+converts extraction from an infrastructure dependency into a protocol
+feature.
+
+Flow:
+
+1. `write_memory` receives content above the extraction threshold.
+2. Parent memory is written normally (chunk children per existing path).
+3. Server issues a sampling request: extraction prompt + content window.
+4. Client's LLM returns fact candidates (structured JSON).
+5. Candidates enter the shared pipeline: written as `branch_type="fact"`
+   children of the parent, tagged with an extraction run ID, subject to
+   curation/reconciliation downstream.
+
+## 4. Design decisions (resolved 2026-07-16 review)
+
+1. **Threshold:** same trigger as chunking (content large enough to
+   chunk is large enough to extract). Small writes are already
+   fact-sized; extracting them is a paraphrase tax. One threshold, one
+   concept of "oversized."
+2. **Sync vs async:** sampling is client-mediated, so it inherently
+   lives inside the request lifecycle — the client must be connected.
+   Design: initiate during write handling, await with a hard timeout
+   (config, ~10-15s), and on timeout/failure ENQUEUE for the background
+   path instead. The write itself never fails because extraction
+   failed. Response includes `facts_extracted: n | "deferred"`.
+3. **Extraction prompt:** start from the prototype's prompt, moved to
+   `prompts/fact_extraction.yaml` per project convention, versioned —
+   the prompt version is part of the extraction run ID (#348 pattern).
+4. **Deduplication: deferred to #347 reconciliation.** Store-then-
+   reconcile. Interim measure ONLY: batch-level dedup within a single
+   write's candidate set (the prototype's duplicates were largely
+   cross-write, which is reconciliation's job by definition). Do NOT
+   build an ad-hoc cross-write dedup here — that is the fourth-path
+   trap.
+5. **Fallback (client lacks sampling support):** the background dreaming
+   path IS the fallback — same prompt, same output shape, same
+   downstream, minutes later instead of seconds. Capability-detect at
+   session registration; SDK exposes `extract_facts` as
+   `eager | background | off`.
+
+## 5. Schema and provenance
+
+- Facts: `branch_type="fact"` children via `parent_id` (joins chunk /
+  rationale / insight). Independently embedded. `is_current` semantics
+  identical to other memories — facts are first-class, versionable,
+  reconcilable.
+- Provenance: every fact carries the extraction run ID (model — as
+  reported by the client, prompt version, timestamp, trigger=eager|
+  background) per #348's rollback-unit design. A bad extraction batch
+  must be rollback-able exactly like a dreaming run.
+- Weight default: inherit a configurable default (0.7 suggested);
+  reconciliation and curation adjust after.
+
+## 6. Retrieval interplay (must be decided BEFORE facts ship to a shared tenant)
+
+The recall pool now potentially contains parents, chunks, AND facts.
+Lessons already paid for: chunks competing with parents caused the
+#344 regression; `return_chunks` filtering post-RRF still lets parents
+influence ranking. Design:
+
+- Introduce an explicit `retrieval_unit` preference on search
+  (`facts | chunks | parents | auto`), sibling to `content_mode`.
+  Default `auto` = facts-first with parent expansion available via
+  flags/read_memory (the proven facts + hydration pattern).
+- Pool discipline: a single search draws candidates from ONE unit class
+  plus its expansion targets — units never compete head-to-head in RRF
+  within one query. (The prototype avoided this with a separate
+  project; production gets it by design, not by isolation.)
+
+## 7. Cost model
+
+Eager extraction cost is borne by the CLIENT's model at write time —
+zero marginal server LLM cost. For the caller: one extraction call per
+oversized write (prototype: ~34 facts/doc avg from 195 PersonaMem docs;
+typical agent session summaries will produce far fewer). Background
+fallback uses the server's existing dreaming budget (see
+memory-extraction-pipeline.md Section 4).
+
+## 8. Open questions
+
+1. Extraction model sensitivity — does a stronger client model move the
+   63.3%? (Next session Part 1 tests exactly this before the pipeline
+   is built.)
+2. `retrieval_unit=auto` policy — facts-first is right for the measured
+   synthesis categories; the -7.6pp on suggest_new_ideas argues for
+   category- or query-adaptive delivery eventually. Needs its own
+   design pass; do not improvise in the implementation session.
+3. Sampling trust: the client's model produces content the server
+   stores — a new write channel. Curation gates apply, but the
+   poisoning-resistance work (#334) should add "sampling-supplied
+   facts" to its threat model.
+4. Fact granularity vs PersonaMem bias: facts are tuned here against
+   one benchmark's question mix. The platform benchmark (D1 temporal
+   consistency) is the truer target — facts are what reconciliation
+   versions, which is what the cheese test exercises.

--- a/strategy/client-supplied-intelligence.md
+++ b/strategy/client-supplied-intelligence.md
@@ -1,0 +1,88 @@
+# Client-Supplied Intelligence: Extraction Without Server-Side Models
+
+**Date:** 2026-07-16
+**Status:** Positioning note (technical basis: `planning/eager-fact-extraction.md`)
+
+## The one-sentence version
+
+MemoryHub performs LLM-powered memory extraction using the *calling
+agent's own model* via MCP sampling — the server needs no model
+credentials, no GPU inference capacity, and no egress to a model
+provider to turn raw content into structured, reconcilable memories.
+
+## Why this matters to our customers
+
+Memory products that do LLM extraction require the memory layer itself
+to be provisioned with model access — a provider API key or a
+co-deployed inference stack (verified 2026-07-16 against primary
+sources): Hindsight's server takes `HINDSIGHT_API_LLM_API_KEY` /
+`HINDSIGHT_API_LLM_PROVIDER` as deployment configuration and its README
+states the retain operation "uses an LLM to extract key facts"
+(github.com/vectorize-io/hindsight); Mem0's memory layer makes its own
+LLM calls with `OPENAI_API_KEY` as the default, or a locally-hosted
+endpoint such as Ollama (docs.mem0.ai). To be precise and fair: these
+products DO support local/self-hosted models, so restricted environments
+are not impossible for them — but the memory system remains a second
+model surface to provision, govern, and pay for. With MCP sampling,
+MemoryHub's extraction requires none of that: no key, no co-deployed
+inference, no second surface. For our customer
+base that is not a detail — it is often the blocking question:
+
+1. **Air-gapped and restricted-egress environments.** A memory server
+   that must call out to a model provider is a non-starter in
+   disconnected deployments. With sampling, the extraction call rides
+   the already-established client connection — no new egress path, no
+   new firewall conversation.
+2. **Model governance stays where it already lives.** Enterprises
+   approve models per-team, per-workload, through existing processes.
+   Sampling means extraction runs under the *caller's* approved model —
+   whatever the agent is already using (a MaaS endpoint, a local vLLM,
+   a hosted frontier model). MemoryHub never introduces a second model
+   to govern, and never makes a model choice on the customer's behalf.
+   (This also composes with early customer preferences on model
+   selection: the customer's choice IS the extraction model.)
+3. **Cost attribution is native.** Extraction cost lands on the caller
+   who wrote the memory, on their existing model billing — not pooled
+   into a platform bill nobody can allocate. Chargeback works without
+   building chargeback.
+4. **FIPS posture stays clean.** No bundled inference runtime on the
+   server side means no additional crypto-validation surface for
+   extraction. The server remains what it is: UBI-based services,
+   PostgreSQL, MinIO, Valkey.
+5. **Graceful capability ladder.** Clients that support MCP sampling
+   get eager extraction (facts appear seconds after write). Clients
+   that don't fall back to the server's background dreaming pipeline —
+   which CAN use a server-configured model where the customer wants
+   one. Both entry points feed the same governed pipeline
+   (reconciliation, provenance, versioning, rollback).
+
+## The demo sentence
+
+"Write a meeting transcript into MemoryHub from Claude Code, and watch
+it come back as queryable facts — extracted by *your* model, on *your*
+bill, with the server never having touched an LLM." (Scope honestly when
+asked: this is the eager/sampling path; the background fallback path can
+use a server-configured model where the customer wants one.)
+
+## Evidence to cite (as of 2026-07-16)
+
+- Fact-based retrieval: 63.3% PersonaMem at 1,256 context tokens vs
+  70.8% at ~28,000 tokens for full-context stuffing — 22x token
+  efficiency for 7.5 points, and the best score of any budgeted mode
+  (`benchmarks/results/`, 2026-07-15 sweep).
+- Category signature: facts win the personalization-synthesis
+  categories (+15.8pp generalizing to new scenarios, +8.1pp recalling
+  reasons behind updates) — the "know me" core.
+- Honest caveat for external use: single extraction model, single run
+  so far; extraction-model sensitivity test scheduled. Numbers are
+  Flash Lite answer-model, budget-pinned per our comparability rules.
+
+## Positioning care
+
+- Frame as capability ("bring-your-own-intelligence extraction"), never
+  as a critique of specific competitors' architectures.
+- Model-selection rationale in public materials: "early customer
+  preference" + technical merits, per standing wording rule.
+- Do not cite the competitive scorecard externally until context-budget
+  parity is documented alongside it (frontier framing: accuracy AND
+  tokens-per-query, both axes, always).


### PR DESCRIPTION
## Summary

- `planning/eager-fact-extraction.md` -- design for write-time fact extraction via MCP sampling, the second entry point to the dreaming pipeline
- `strategy/client-supplied-intelligence.md` -- strategy doc for client-supplied intelligence integration
- `planning/d5-readiness-audit.md` -- readiness audit for the d5 milestone

These docs are referenced by upcoming issues for the facts pipeline work.

## Test plan

- [x] Docs-only change, no code impact