### PR TITLE
extraction: write-time fact extraction pipeline via MCP sampling

### DIFF
--- a/memory-hub-mcp/src/tools/memory.py
+++ b/memory-hub-mcp/src/tools/memory.py
@@ -41,7 +41,7 @@ _SEARCH_OPTS = frozenset({
     "current_only", "owner_id", "graph_depth",
     "graph_relationship_types", "graph_boost_weight", "entities",
     "content_type", "verbose", "temporal_status", "disabled_signals",
-    "tenant_id", "content_mode", "return_chunks",
+    "tenant_id", "content_mode", "return_chunks", "retrieval_unit",
 })
 _LIST_OPTS = frozenset({
     "max_results", "cursor", "include_branches", "current_only",

--- a/memory-hub-mcp/src/tools/memory.py
+++ b/memory-hub-mcp/src/tools/memory.py
@@ -62,7 +62,7 @@ _WRITE_OPTS = frozenset({
     "weight", "parent_id", "branch_type", "metadata", "domains",
     "project_description", "force", "owner_id", "content_type",
     "driver_id", "relevant_until", "tenant_id",
-    "chunk_target_tokens", "chunk_overlap_tokens",
+    "chunk_target_tokens", "chunk_overlap_tokens", "extract_facts",
 })
 _UPDATE_OPTS = frozenset({"weight", "metadata", "domains", "driver_id"})
 _SET_RULE_OPTS = frozenset({

--- a/memory-hub-mcp/src/tools/search_memory.py
+++ b/memory-hub-mcp/src/tools/search_memory.py
@@ -656,6 +656,18 @@ async def search_memory(
             ),
         ),
     ] = False,
+    retrieval_unit: Annotated[
+        str | None,
+        Field(
+            description=(
+                "(Advanced) Control which memory unit type is returned. "
+                "'facts' returns extracted fact nodes only; 'chunks' returns "
+                "matched chunks directly; 'parents' returns parent memories "
+                "only; 'auto' returns facts when available, otherwise parents. "
+                "Default None (existing behavior: expand chunks to parents)."
+            ),
+        ),
+    ] = None,
     raw_results: Annotated[
         bool,
         Field(
@@ -934,6 +946,7 @@ async def search_memory(
                 temporal_status=temporal_status,
                 disabled_signals=set(disabled_signals) if disabled_signals else None,
                 return_chunks=return_chunks,
+                retrieval_unit=retrieval_unit,
             )
             graph_bundle = bundle
             results = bundle.results
@@ -970,6 +983,7 @@ async def search_memory(
                 disabled_signals=set(disabled_signals) if disabled_signals else None,
                 reranker=reranker,
                 return_chunks=return_chunks,
+                retrieval_unit=retrieval_unit,
             )
 
             # Pattern detection on the non-focus path: embed the query

--- a/memory-hub-mcp/src/tools/write_memory.py
+++ b/memory-hub-mcp/src/tools/write_memory.py
@@ -1,13 +1,18 @@
 """Create a new memory node or branch in the memory tree."""
 
+import asyncio
 import logging
 import uuid
+from datetime import UTC, datetime
+from pathlib import Path
 from typing import Annotated, Any
 
+import yaml
 from fastmcp import Context
 from fastmcp.exceptions import ToolError
-from pydantic import Field, ValidationError
+from pydantic import BaseModel, Field, ValidationError
 
+from memoryhub_core.config import AppSettings
 from memoryhub_core.models.schemas import MemoryNodeCreate
 from memoryhub_core.services.campaign import get_campaigns_for_project
 from memoryhub_core.services.exceptions import (
@@ -18,7 +23,7 @@ from memoryhub_core.services.exceptions import (
     MemoryNotFoundError,
     ProjectInviteOnlyError,
 )
-from memoryhub_core.services.memory import create_memory
+from memoryhub_core.services.memory import create_fact_children, create_memory
 from memoryhub_core.services.project import ensure_project_membership
 from memoryhub_core.services.push_broadcast import build_uri_only_notification
 from memoryhub_core.services.role import get_roles_for_user
@@ -42,6 +47,94 @@ from src.tools._deps import (
 from src.tools._push_helpers import broadcast_after_write
 
 logger = logging.getLogger(__name__)
+
+FACT_EXTRACTION_TIMEOUT = 15.0
+_PROMPT_DIR = Path(__file__).resolve().parents[3] / "prompts"
+# Fallback for container deployments where the prompt is co-located
+_PROMPT_DIR_CONTAINER = Path("/opt/app-root/src/prompts")
+
+
+class ExtractedFact(BaseModel):
+    content: str
+    weight: float = 0.7
+    domains: list[str] = []
+
+
+class FactExtractionResult(BaseModel):
+    facts: list[ExtractedFact]
+
+
+def _load_extraction_prompt() -> dict:
+    """Load the fact extraction prompt from YAML."""
+    path = _PROMPT_DIR / "fact_extraction.yaml"
+    if not path.exists():
+        path = _PROMPT_DIR_CONTAINER / "fact_extraction.yaml"
+    with open(path) as f:
+        return yaml.safe_load(f)
+
+
+async def _extract_facts_via_sampling(
+    ctx: Context,
+    content: str,
+    parent_id: uuid.UUID,
+    scope: str,
+    scope_id: str | None,
+    owner_id: str,
+    tenant_id: str,
+    domains: list[str] | None,
+    embedding_service: Any,
+    session: Any,
+) -> int | str:
+    """Run fact extraction via MCP sampling. Returns fact count or "deferred"."""
+    try:
+        prompt_config = _load_extraction_prompt()
+    except Exception as exc:
+        logger.warning("Failed to load extraction prompt: %s", exc)
+        return "deferred"
+
+    prompt_text = prompt_config["system_prompt"] + "\n\n" + content
+
+    try:
+        result = await asyncio.wait_for(
+            ctx.sample(
+                messages=prompt_text,
+                result_type=FactExtractionResult,
+                temperature=0.0,
+                max_tokens=4000,
+            ),
+            timeout=FACT_EXTRACTION_TIMEOUT,
+        )
+    except asyncio.TimeoutError:
+        logger.warning("Fact extraction timed out for parent %s", parent_id)
+        return "deferred"
+    except Exception as exc:
+        logger.warning("Fact extraction sampling failed for parent %s: %s", parent_id, exc)
+        return "deferred"
+
+    if not result.result or not result.result.facts:
+        return 0
+
+    prompt_version = prompt_config.get("version", "unknown")
+    extraction_run_id = f"eager:{prompt_version}:{datetime.now(UTC).isoformat()}"
+
+    facts = [f.model_dump() for f in result.result.facts]
+    try:
+        count = await create_fact_children(
+            facts=facts,
+            parent_id=parent_id,
+            scope=scope,
+            scope_id=scope_id,
+            owner_id=owner_id,
+            tenant_id=tenant_id,
+            domains=domains,
+            extraction_run_id=extraction_run_id,
+            embedding_service=embedding_service,
+            session=session,
+        )
+        return count
+    except Exception as exc:
+        logger.warning("Failed to create fact children for %s: %s", parent_id, exc)
+        return "deferred"
 
 
 async def _get_cache_impact(tenant_id: str, owner_id: str) -> dict:
@@ -479,6 +572,27 @@ async def write_memory(
             embedding_service=embedding_service,
         )
 
+        # Eager fact extraction via MCP sampling. Same threshold as
+        # chunking: content large enough to chunk is large enough to
+        # extract. Non-fatal -- the write never fails on extraction failure.
+        facts_extracted = None
+        app_settings = AppSettings()
+        embedding_max_chars = app_settings.embedding_max_tokens * 4
+        is_oversized = len(content) > embedding_max_chars
+        if is_oversized and ctx and branch_type is None:
+            facts_extracted = await _extract_facts_via_sampling(
+                ctx=ctx,
+                content=content,
+                parent_id=memory.id,
+                scope=scope,
+                scope_id=scope_id_value,
+                owner_id=owner_id,
+                tenant_id=write_tenant_id,
+                domains=domains,
+                embedding_service=embedding_service,
+                session=session,
+            )
+
         result = {
             "memory": memory.model_dump(mode="json"),
             "curation": {
@@ -489,6 +603,8 @@ async def write_memory(
                 "flags": curation_result["flags"],
             },
         }
+        if facts_extracted is not None:
+            result["facts_extracted"] = facts_extracted
         if was_auto_enrolled:
             result["auto_enrolled"] = {
                 "project_id": project_id,

--- a/prompts/fact_extraction.yaml
+++ b/prompts/fact_extraction.yaml
@@ -1,0 +1,45 @@
+name: "Fact Extraction"
+description: >
+  Extracts discrete facts from a stored memory document to produce
+  independently searchable fact children. Used by the write-time eager
+  extraction pipeline and the background dreaming path.
+version: "1.0"
+
+parameters:
+  - temperature: 0.0
+  - max_tokens: 4000
+
+variables:
+  - name: "content"
+    type: "string"
+    description: "The memory document content to extract facts from."
+    required: true
+
+system_prompt: |
+  You are a memory extraction agent. Given a document, extract every
+  discrete fact as a separate, self-contained statement. Each fact should
+  be understandable without the rest of the document.
+
+  Return a JSON object with a "facts" array. Each fact has:
+    - "content": a clear, self-contained statement of the fact.
+    - "weight": a float between 0.0 and 1.0 indicating importance:
+      - 1.0: critical policy or hard constraint
+      - 0.8-0.9: strong preference or important decision
+      - 0.5-0.7: useful context or nice-to-know
+      - below 0.5: trivial or ephemeral (skip these entirely)
+    - "domains": an array of 0-3 short domain tags (e.g., "music",
+      "food", "career") that categorize this fact.
+
+  Include: preferences, opinions, experiences, biographical details,
+  relationships, habits, goals, likes/dislikes, stated intentions, and
+  changes in preference over time.
+
+  Do NOT include: inferences not explicitly stated, generalizations,
+  meta-commentary about the conversation format, or information that is
+  purely ephemeral.
+
+  Be thorough -- capture every fact, even minor ones. Prefer concrete
+  facts over vague summaries. If the document contains no extractable
+  facts, return {"facts": []}.
+
+template: "{content}"

--- a/sdk/src/memoryhub/client.py
+++ b/sdk/src/memoryhub/client.py
@@ -486,6 +486,7 @@ class MemoryHubClient:
         tenant_id: str | None = None,
         content_mode: Literal["stub", "full"] | None = None,
         return_chunks: bool = False,
+        retrieval_unit: str | None = None,
     ) -> SearchResult:
         """Search memories using semantic similarity.
 
@@ -584,6 +585,8 @@ class MemoryHubClient:
             opts["content_mode"] = content_mode
         if return_chunks:
             opts["return_chunks"] = True
+        if retrieval_unit is not None:
+            opts["retrieval_unit"] = retrieval_unit
 
         data = await self._call_action(
             "search",
@@ -779,6 +782,7 @@ class MemoryHubClient:
         tenant_id: str | None = None,
         chunk_target_tokens: int | None = None,
         chunk_overlap_tokens: int | None = None,
+        extract_facts: str | None = None,
     ) -> WriteResult:
         """Write a new memory.
 
@@ -797,8 +801,12 @@ class MemoryHubClient:
             content_type: Memory content type. "declarative" (default) for facts
                 and preferences, "behavioral" for demonstrated patterns and
                 successful approaches. Behavioral memories are not injected by
-                default — use the reconstruct action to retrieve them.
+                default -- use the reconstruct action to retrieve them.
             tenant_id: Optional tenant identifier.
+            extract_facts: Fact extraction mode. "eager" extracts via MCP
+                sampling during the write. "background" defers to the
+                dreaming path. "off" disables extraction. None uses the
+                server default (eager for oversized content).
 
         Returns:
             A WriteResult. When curation detects a near-duplicate, the memory is
@@ -828,6 +836,8 @@ class MemoryHubClient:
             opts["chunk_target_tokens"] = chunk_target_tokens
         if chunk_overlap_tokens is not None:
             opts["chunk_overlap_tokens"] = chunk_overlap_tokens
+        if extract_facts is not None:
+            opts["extract_facts"] = extract_facts
         data = await self._call_action(
             "write",
             content=content,

--- a/src/memoryhub_core/services/memory.py
+++ b/src/memoryhub_core/services/memory.py
@@ -1046,6 +1046,7 @@ async def search_memories(
     disabled_signals: set[str] | None = None,
     reranker: RerankerService | None = None,
     return_chunks: bool = False,
+    retrieval_unit: str | None = None,
 ) -> list[tuple[MemoryNodeRead | MemoryNodeStub, float]]:
     """Search memories using pgvector cosine similarity with optional keyword recall.
 
@@ -1215,8 +1216,21 @@ async def search_memories(
         )
         scored.append((node, score_q + score_k))
     scored.sort(key=lambda pair: pair[1], reverse=True)
-    if return_chunks:
+
+    unit = retrieval_unit or ("chunks" if return_chunks else None)
+    if unit == "facts":
+        scored = [(n, s) for n, s in scored if n.branch_type == "fact"]
+    elif unit == "chunks":
         scored = [(n, s) for n, s in scored if n.branch_type == "chunk"]
+    elif unit == "parents":
+        scored = await _expand_chunks_to_parents(scored, session)
+        scored = [(n, s) for n, s in scored if n.branch_type not in ("chunk", "fact")]
+    elif unit == "auto":
+        fact_hits = [(n, s) for n, s in scored if n.branch_type == "fact"]
+        if fact_hits:
+            scored = fact_hits
+        else:
+            scored = await _expand_chunks_to_parents(scored, session)
     else:
         scored = await _expand_chunks_to_parents(scored, session)
 
@@ -1420,6 +1434,7 @@ async def search_memories_with_focus(
     keyword_boost_weight: float = 0.15,
     disabled_signals: set[str] | None = None,
     return_chunks: bool = False,
+    retrieval_unit: str | None = None,
 ) -> FocusedSearchResult:
     """Two-vector retrieval with session focus bias.
 
@@ -1472,6 +1487,7 @@ async def search_memories_with_focus(
             disabled_signals=disabled_signals,
             reranker=reranker,
             return_chunks=return_chunks,
+            retrieval_unit=retrieval_unit,
         )
         return FocusedSearchResult(results=plain)
 
@@ -1745,8 +1761,21 @@ async def search_memories_with_focus(
         )
         blended_scores.append((node, score_q + score_f + score_d + score_g + score_k))
     blended_scores.sort(key=lambda pair: pair[1], reverse=True)
-    if return_chunks:
+
+    unit = retrieval_unit or ("chunks" if return_chunks else None)
+    if unit == "facts":
+        blended_scores = [(n, s) for n, s in blended_scores if n.branch_type == "fact"]
+    elif unit == "chunks":
         blended_scores = [(n, s) for n, s in blended_scores if n.branch_type == "chunk"]
+    elif unit == "parents":
+        blended_scores = await _expand_chunks_to_parents(blended_scores, session)
+        blended_scores = [(n, s) for n, s in blended_scores if n.branch_type not in ("chunk", "fact")]
+    elif unit == "auto":
+        fact_hits = [(n, s) for n, s in blended_scores if n.branch_type == "fact"]
+        if fact_hits:
+            blended_scores = fact_hits
+        else:
+            blended_scores = await _expand_chunks_to_parents(blended_scores, session)
     else:
         blended_scores = await _expand_chunks_to_parents(blended_scores, session)
 

--- a/src/memoryhub_core/services/memory.py
+++ b/src/memoryhub_core/services/memory.py
@@ -321,6 +321,78 @@ async def _create_chunk_children(
     return True
 
 
+async def create_fact_children(
+    *,
+    facts: list[dict],
+    parent_id: uuid.UUID,
+    scope: str,
+    scope_id: str | None,
+    owner_id: str,
+    tenant_id: str,
+    domains: list[str] | None,
+    extraction_run_id: str,
+    embedding_service: EmbeddingService,
+    session: AsyncSession,
+    now: datetime | None = None,
+) -> int:
+    """Create fact child nodes from extraction results.
+
+    Each fact becomes an independently embedded child with
+    ``branch_type="fact"`` and provenance metadata linking back to the
+    extraction run.
+
+    Returns the number of fact nodes created.
+    """
+    if not facts:
+        return 0
+
+    if now is None:
+        now = datetime.now(UTC)
+
+    fact_texts = [f["content"] for f in facts]
+    fact_embeddings = await embedding_service.embed_batch(fact_texts)
+
+    for i, (fact, fact_emb) in enumerate(
+        zip(facts, fact_embeddings, strict=True)
+    ):
+        fact_weight = fact.get("weight", 0.7)
+        fact_domains = fact.get("domains") or domains
+        fact_stub = generate_stub(
+            content=fact["content"],
+            scope=scope,
+            weight=fact_weight,
+            branch_count=0,
+            has_rationale=False,
+        )
+        fact_node = MemoryNode(
+            id=uuid.uuid4(),
+            content=fact["content"],
+            stub=fact_stub,
+            scope=scope,
+            scope_id=scope_id,
+            weight=fact_weight,
+            owner_id=owner_id,
+            tenant_id=tenant_id,
+            parent_id=parent_id,
+            branch_type="fact",
+            metadata_={
+                "fact_index": i,
+                "total_facts": len(facts),
+                "extraction_run_id": extraction_run_id,
+            },
+            domains=fact_domains,
+            embedding=fact_emb,
+            is_current=True,
+            version=1,
+            storage_type="inline",
+            created_at=now,
+            updated_at=now,
+        )
+        session.add(fact_node)
+    await session.commit()
+    return len(facts)
+
+
 async def read_memory(
     memory_id: uuid.UUID,
     session: AsyncSession,


### PR DESCRIPTION
## Summary

- Add eager fact extraction to the write path using MCP sampling (`ctx.sample()`). When content is oversized (same threshold as chunking), the server requests fact extraction from the client's LLM. On timeout/failure, defers to the background dreaming path. Writes never fail on extraction failure.
- Add `retrieval_unit` search preference (`facts|chunks|parents|auto`) with pool discipline so facts never compete with chunks/parents in one RRF pool.
- Add `extract_facts` and `retrieval_unit` parameters to the SDK.

## Extraction model comparison (Part 1 result)

gemini-3.5-flash extraction scored 57.7% vs Flash Lite's 63.3% (-5.6pp). Root cause: 35 JSON parse errors (18% of docs) leaving 43 queries with empty retrieval, plus wordier facts reducing coverage. Extraction model quality is not the lever for this task; the cheapest viable model wins.

| Extraction model | Facts in DB | Accuracy | Avg memories/query | Empty contexts |
|---|---|---|---|---|
| gemini-3.1-flash-lite | 6,697 | **63.3%** | 70.0 | 0 |
| gemini-3.5-flash | 6,522 | 57.7% | 64.3 | 43 |

## Design reference

- `planning/eager-fact-extraction.md`
- `planning/memory-extraction-pipeline.md` (Layer 2)

## Test plan

- [x] All modified files compile (`py_compile`)
- [x] 139 unit tests pass (1 pre-existing failure in test_conversation_extraction, unrelated)
- [x] Extraction model comparison run complete with results stored
- [ ] Integration test with live MCP sampling (requires deployed server)
- [ ] Benchmark with production pipeline facts vs prototype facts