### PR TITLE
fix: MCP test key name + container prompt path

### DIFF
--- a/memory-hub-mcp/src/tools/write_memory.py
+++ b/memory-hub-mcp/src/tools/write_memory.py
@@ -51,7 +51,7 @@ logger = logging.getLogger(__name__)
 FACT_EXTRACTION_TIMEOUT = 15.0
 _PROMPT_DIR = Path(__file__).resolve().parents[3] / "prompts"
 # Fallback for container deployments where the prompt is co-located
-_PROMPT_DIR_CONTAINER = Path("/opt/app-root/src/prompts")
+_PROMPT_DIR_CONTAINER = Path("/opt/app-root/src/memoryhub_core/prompts")
 
 
 class ExtractedFact(BaseModel):

--- a/memory-hub-mcp/tests/tools/test_search_memory.py
+++ b/memory-hub-mcp/tests/tools/test_search_memory.py
@@ -933,7 +933,7 @@ async def test_search_memory_no_focus_routes_to_plain_path():
 
     assert "pivot_suggested" not in result
     assert "pivot_reason" not in result
-    assert "focus_fallback_reason" not in result
+    assert "reranker_fallback_reason" not in result
 
 
 @pytest.mark.asyncio
@@ -957,7 +957,7 @@ async def test_search_memory_focus_routes_to_focused_path():
     assert len(result["results"]) == 1
     assert result["pivot_suggested"] is False
     assert result["pivot_reason"] is None
-    assert "focus_fallback_reason" not in result
+    assert "reranker_fallback_reason" not in result
 
 
 @pytest.mark.asyncio
@@ -1004,7 +1004,7 @@ async def test_search_memory_focus_fallback_reason_surfaces():
         focus="some focus",
     )
 
-    assert result["focus_fallback_reason"].startswith("reranker call failed")
+    assert result["reranker_fallback_reason"].startswith("reranker call failed")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Fix `test_search_memory_focus_fallback_reason_surfaces` test failure: key was `focus_fallback_reason` but implementation uses `reranker_fallback_reason`
- Fix container fallback path for fact extraction prompt: `memoryhub_core/prompts/` not `prompts/` (matches build-context.sh staging)

## Test plan

- [x] 561 MCP server tests pass (0 failures)