### PR TITLE
dreaming: Run provenance, dry-run mode, and rollback (#348)

### DIFF
--- a/src/memoryhub_core/services/dreaming.py
+++ b/src/memoryhub_core/services/dreaming.py
@@ -36,6 +36,7 @@ from memoryhub_core.models.conversation import (
 )
 from memoryhub_core.services.reconciliation import (
     ExtractionCandidate,
+    ReconciliationResult,
     reconcile_candidate,
 )
 
@@ -197,11 +198,13 @@ async def _extract_window(
     model: str,
     url: str,
     embedding_service: Any,
+    extraction_run_id: str,
     s3_adapter: Any | None = None,
-) -> list[uuid.UUID]:
+    dry_run: bool = False,
+) -> list[ReconciliationResult]:
     """Extract memories from a single window of messages.
 
-    Returns list of created memory_node_ids.
+    Returns list of ReconciliationResult decisions from this window.
     """
     system_prompt, prompt_hash = _load_prompt()
     formatted = _format_messages(messages)
@@ -215,7 +218,8 @@ async def _extract_window(
     )
 
     source_seqs = [m.sequence_number for m in messages]
-    created_ids: list[uuid.UUID] = []
+    decisions: list[ReconciliationResult] = []
+    committed_ids: list[uuid.UUID] = []
 
     for item in extractions:
         content = item.get("content", "").strip()
@@ -237,8 +241,6 @@ async def _extract_window(
                 "source_messages": source_seqs,
             },
         }
-
-        extraction_run_id = f"dream:{model}:{prompt_hash}:{datetime.now(UTC).isoformat()}"
 
         candidate = ExtractionCandidate(
             content=content,
@@ -263,7 +265,12 @@ async def _extract_window(
             extraction_run_id=extraction_run_id,
             actor_id=thread.actor_id,
             s3_adapter=s3_adapter,
+            dry_run=dry_run,
         )
+        decisions.append(decision)
+
+        if dry_run:
+            continue
 
         if decision.action == "skip":
             logger.info(
@@ -290,12 +297,12 @@ async def _extract_window(
             tenant_id=thread.tenant_id,
         )
         session.add(extraction_record)
-        created_ids.append(decision.memory_id)
+        committed_ids.append(decision.memory_id)
 
-    if created_ids:
+    if committed_ids:
         await session.commit()
 
-    return created_ids
+    return decisions
 
 
 async def _log_failure(
@@ -322,6 +329,29 @@ async def _log_failure(
     await session.commit()
 
 
+def _check_circuit_breaker(
+    decisions: list[ReconciliationResult],
+    *,
+    max_create_ratio: float = 20.0,
+    min_decisions: int = 5,
+) -> str | None:
+    """Return a reason string if the circuit breaker trips, else None.
+
+    Trips when the create:update ratio exceeds max_create_ratio after
+    at least min_decisions have been made.
+    """
+    if len(decisions) < min_decisions:
+        return None
+    creates = sum(1 for d in decisions if d.action == "create")
+    updates = sum(1 for d in decisions if d.action == "update")
+
+    if updates == 0 and creates >= min_decisions:
+        return f"all creates ({creates}), zero updates (threshold {max_create_ratio}:1)"
+    if updates > 0 and creates / updates > max_create_ratio:
+        return f"create:update ratio {creates}:{updates} exceeds threshold {max_create_ratio}:1"
+    return None
+
+
 async def extract_from_thread(
     session: AsyncSession,
     *,
@@ -333,6 +363,9 @@ async def extract_from_thread(
     model_override: str | None = None,
     url_override: str | None = None,
     turn_range: tuple[int, int] | None = None,
+    dry_run: bool = False,
+    circuit_breaker_ratio: float = 20.0,
+    circuit_breaker_min: int = 5,
 ) -> dict[str, Any]:
     """Extract memories from a conversation thread.
 
@@ -346,9 +379,12 @@ async def extract_from_thread(
         model_override: Override the configured extraction model.
         url_override: Override the configured extraction model URL.
         turn_range: Optional (start_seq, end_seq) to extract only a specific range.
+        dry_run: Produce decisions without committing writes.
+        circuit_breaker_ratio: Max create:update ratio before halting.
+        circuit_breaker_min: Minimum decisions before circuit breaker arms.
 
     Returns:
-        Dict with extracted_count, cursor, failures count.
+        Dict with extracted_count, cursor, failures count, extraction_run_id.
     """
     settings = AppSettings()
     model = model_override or settings.conv_extraction_model
@@ -360,6 +396,9 @@ async def extract_from_thread(
             "Set MEMORYHUB_CONV_EXTRACTION_MODEL and MEMORYHUB_CONV_EXTRACTION_MODEL_URL, "
             "or pass model/model_url in options."
         )
+
+    _, prompt_hash = _load_prompt()
+    extraction_run_id = f"dream:{model}:{prompt_hash}:{datetime.now(UTC).isoformat()}"
 
     # Load thread
     stmt = select(ConversationThread).where(
@@ -401,13 +440,22 @@ async def extract_from_thread(
     messages = list(msg_result.scalars().all())
 
     if not messages:
-        return {"extracted_count": 0, "cursor": thread.extraction_cursor, "failures": 0}
+        return {
+            "extracted_count": 0,
+            "cursor": thread.extraction_cursor,
+            "failures": 0,
+            "extraction_run_id": extraction_run_id,
+        }
 
     # Build windows
     windows = _compute_windows(messages, mode, settings.conv_extraction_window_size)
 
     total_extracted = 0
     total_failures = 0
+    all_decisions: list[ReconciliationResult] = []
+    circuit_breaker_tripped = False
+    circuit_breaker_reason: str | None = None
+    windows_completed = 0
 
     async with httpx.AsyncClient(
         timeout=settings.conv_extraction_timeout, verify=False,
@@ -417,7 +465,7 @@ async def extract_from_thread(
             window_end = window[-1].sequence_number
 
             try:
-                created_ids = await _extract_window(
+                window_decisions = await _extract_window(
                     session,
                     thread=thread,
                     messages=window,
@@ -425,9 +473,15 @@ async def extract_from_thread(
                     model=model,
                     url=url,
                     embedding_service=embedding_service,
+                    extraction_run_id=extraction_run_id,
                     s3_adapter=s3_adapter,
+                    dry_run=dry_run,
                 )
-                total_extracted += len(created_ids)
+                all_decisions.extend(window_decisions)
+                total_extracted += sum(
+                    1 for d in window_decisions
+                    if d.memory_id is not None and d.action != "skip"
+                )
             except Exception as exc:
                 logger.warning(
                     "Extraction failed for thread %s window [%d-%d]: %s",
@@ -443,15 +497,45 @@ async def extract_from_thread(
                 )
                 total_failures += 1
 
+            windows_completed += 1
+
             # Advance cursor past this window regardless of success/failure
             # (design doc: cursor advances past failed windows to avoid blocking)
-            if turn_range is None:
+            if turn_range is None and not dry_run:
                 thread.extraction_cursor = window_end
                 thread.last_extracted_at = datetime.now(UTC)
                 await session.commit()
 
-    return {
+            # Circuit breaker check
+            trip_reason = _check_circuit_breaker(
+                all_decisions,
+                max_create_ratio=circuit_breaker_ratio,
+                min_decisions=circuit_breaker_min,
+            )
+            if trip_reason is not None:
+                circuit_breaker_tripped = True
+                circuit_breaker_reason = trip_reason
+                logger.warning(
+                    "Circuit breaker tripped for run %s: %s",
+                    extraction_run_id, trip_reason,
+                )
+                break
+
+    response: dict[str, Any] = {
         "extracted_count": total_extracted,
         "cursor": thread.extraction_cursor,
         "failures": total_failures,
+        "extraction_run_id": extraction_run_id,
     }
+
+    if dry_run:
+        response["dry_run"] = True
+        response["decisions"] = [d.model_dump() for d in all_decisions]
+
+    if circuit_breaker_tripped:
+        response["circuit_breaker_tripped"] = True
+        response["circuit_breaker_reason"] = circuit_breaker_reason
+        response["windows_completed"] = windows_completed
+        response["windows_total"] = len(windows)
+
+    return response

--- a/src/memoryhub_core/services/reconciliation.py
+++ b/src/memoryhub_core/services/reconciliation.py
@@ -13,12 +13,14 @@ from __future__ import annotations
 
 import logging
 import uuid
+from datetime import UTC, datetime
 from typing import Any, Callable, Awaitable
 
 from pydantic import BaseModel
-from sqlalchemy import select
+from sqlalchemy import delete, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from memoryhub_core.models.conversation import ConversationExtraction
 from memoryhub_core.models.memory import MemoryNode
 from memoryhub_core.models.reconciliation import (
     ReconciliationDecision as ReconciliationDecisionRow,
@@ -264,3 +266,151 @@ async def _log_decision(
         scope_id=scope_id,
     )
     session.add(row)
+
+
+# ---------------------------------------------------------------------------
+# Rollback
+# ---------------------------------------------------------------------------
+
+async def rollback_extraction_run(
+    extraction_run_id: str,
+    session: AsyncSession,
+) -> dict[str, Any]:
+    """Rollback all creates and updates from an extraction run.
+
+    For creates: soft-delete the created memory and its children.
+    For updates: soft-delete the new version and restore the prior version.
+    Skips decisions where post-run modifications have occurred.
+    """
+    stmt = (
+        select(ReconciliationDecisionRow)
+        .where(ReconciliationDecisionRow.extraction_run_id == extraction_run_id)
+        .order_by(ReconciliationDecisionRow.created_at.desc())
+    )
+    result = await session.execute(stmt)
+    decisions = list(result.scalars().all())
+
+    if not decisions:
+        return {
+            "extraction_run_id": extraction_run_id,
+            "total_decisions": 0,
+            "rolled_back": {"creates": 0, "updates": 0, "skips": 0},
+            "skipped": {"post_run_modifications": 0, "already_deleted": 0},
+        }
+
+    now = datetime.now(UTC)
+    rolled_creates = 0
+    rolled_updates = 0
+    rolled_skips = 0
+    skipped_modified = 0
+    skipped_deleted = 0
+
+    for decision in decisions:
+        if decision.action == "skip":
+            rolled_skips += 1
+            continue
+
+        if decision.memory_id is None:
+            continue
+
+        memory = await session.get(MemoryNode, decision.memory_id)
+        if memory is None:
+            skipped_deleted += 1
+            continue
+
+        if memory.deleted_at is not None:
+            skipped_deleted += 1
+            continue
+
+        # Safety: check for post-run modifications (a newer version exists)
+        successor_stmt = select(MemoryNode.id).where(
+            MemoryNode.previous_version_id == decision.memory_id,
+        )
+        successor = await session.execute(successor_stmt)
+        if successor.scalar_one_or_none() is not None:
+            skipped_modified += 1
+            logger.warning(
+                "Skipping rollback of %s (action=%s): post-run modification exists",
+                decision.memory_id, decision.action,
+            )
+            continue
+
+        if decision.action == "create":
+            # Soft-delete the created memory and its children
+            memory.deleted_at = now
+            memory.is_current = False
+
+            children_stmt = select(MemoryNode).where(
+                MemoryNode.parent_id == decision.memory_id,
+                MemoryNode.deleted_at.is_(None),
+            )
+            children_result = await session.execute(children_stmt)
+            for child in children_result.scalars().all():
+                child.deleted_at = now
+                child.is_current = False
+
+            # Remove provenance records
+            await session.execute(
+                delete(ConversationExtraction).where(
+                    ConversationExtraction.memory_node_id == decision.memory_id,
+                )
+            )
+            rolled_creates += 1
+
+        elif decision.action == "update":
+            if decision.nearest_match_id is None:
+                skipped_modified += 1
+                continue
+
+            # Soft-delete the new version and its children
+            memory.deleted_at = now
+            memory.is_current = False
+
+            new_children_stmt = select(MemoryNode).where(
+                MemoryNode.parent_id == decision.memory_id,
+                MemoryNode.deleted_at.is_(None),
+            )
+            new_children_result = await session.execute(new_children_stmt)
+            for child in new_children_result.scalars().all():
+                child.deleted_at = now
+                child.is_current = False
+
+            # Restore the prior version
+            old_memory = await session.get(MemoryNode, decision.nearest_match_id)
+            if old_memory is not None:
+                old_memory.is_current = True
+                old_memory.expires_at = None
+
+                # Restore old version's children
+                old_children_stmt = select(MemoryNode).where(
+                    MemoryNode.parent_id == decision.nearest_match_id,
+                    MemoryNode.deleted_at.is_(None),
+                )
+                old_children_result = await session.execute(old_children_stmt)
+                for child in old_children_result.scalars().all():
+                    child.is_current = True
+                    child.expires_at = None
+
+            # Remove provenance records for the new version
+            await session.execute(
+                delete(ConversationExtraction).where(
+                    ConversationExtraction.memory_node_id == decision.memory_id,
+                )
+            )
+            rolled_updates += 1
+
+    await session.commit()
+
+    return {
+        "extraction_run_id": extraction_run_id,
+        "total_decisions": len(decisions),
+        "rolled_back": {
+            "creates": rolled_creates,
+            "updates": rolled_updates,
+            "skips": rolled_skips,
+        },
+        "skipped": {
+            "post_run_modifications": skipped_modified,
+            "already_deleted": skipped_deleted,
+        },
+    }

--- a/src/memoryhub_core/services/reconciliation.py
+++ b/src/memoryhub_core/services/reconciliation.py
@@ -85,6 +85,7 @@ async def reconcile_candidate(
     actor_id: str | None = None,
     s3_adapter: Any | None = None,
     tiebreaker_fn: TiebreakerFn | None = None,
+    dry_run: bool = False,
 ) -> ReconciliationResult:
     """Reconcile a single extraction candidate against existing memories.
 
@@ -93,7 +94,8 @@ async def reconcile_candidate(
       >= 0.80  LLM tiebreaker; if "same" AND content_type+domain match -> update
       <  0.80  create new memory
 
-    Returns a ReconciliationResult and logs the decision to the DB.
+    When dry_run=True, computes the full decision but skips memory writes
+    and decision logging. Returns ReconciliationResult with memory_id=None.
     """
     stub = candidate.content[:200]
     embedding = await embedding_service.embed(candidate.content)
@@ -149,54 +151,55 @@ async def reconcile_candidate(
         result.action = "create"
         result.reason = "below_threshold"
 
-    # Execute the decided action
-    if result.action == "create":
-        data = MemoryNodeCreate(
-            content=candidate.content,
-            scope=scope,
-            weight=candidate.weight,
-            owner_id=owner_id,
-            scope_id=scope_id,
-            metadata=candidate.metadata,
-            domains=candidate.domains,
-            content_type=candidate.content_type,
-        )
-        if actor_id:
-            data.actor_id = actor_id
-        memory_node, _ = await create_memory(
-            data, session, embedding_service,
-            tenant_id=tenant_id,
-            force=True,
-            s3_adapter=s3_adapter,
-        )
-        if memory_node:
-            result.memory_id = memory_node.id
+    if not dry_run:
+        # Execute the decided action
+        if result.action == "create":
+            data = MemoryNodeCreate(
+                content=candidate.content,
+                scope=scope,
+                weight=candidate.weight,
+                owner_id=owner_id,
+                scope_id=scope_id,
+                metadata=candidate.metadata,
+                domains=candidate.domains,
+                content_type=candidate.content_type,
+            )
+            if actor_id:
+                data.actor_id = actor_id
+            memory_node, _ = await create_memory(
+                data, session, embedding_service,
+                tenant_id=tenant_id,
+                force=True,
+                s3_adapter=s3_adapter,
+            )
+            if memory_node:
+                result.memory_id = memory_node.id
 
-    elif result.action == "update":
-        update_data = MemoryNodeUpdate(content=candidate.content)
-        if candidate.domains is not None:
-            update_data.domains = candidate.domains
-        updated = await update_memory(
-            result.nearest_match_id,
-            update_data,
+        elif result.action == "update":
+            update_data = MemoryNodeUpdate(content=candidate.content)
+            if candidate.domains is not None:
+                update_data.domains = candidate.domains
+            updated = await update_memory(
+                result.nearest_match_id,
+                update_data,
+                session,
+                embedding_service,
+                s3_adapter=s3_adapter,
+                actor_id=actor_id,
+            )
+            result.memory_id = updated.id
+
+        # Log the decision
+        await _log_decision(
             session,
-            embedding_service,
-            s3_adapter=s3_adapter,
-            actor_id=actor_id,
+            result=result,
+            candidate=candidate,
+            owner_id=owner_id,
+            tenant_id=tenant_id,
+            scope=scope,
+            scope_id=scope_id,
+            extraction_run_id=extraction_run_id,
         )
-        result.memory_id = updated.id
-
-    # Log the decision
-    await _log_decision(
-        session,
-        result=result,
-        candidate=candidate,
-        owner_id=owner_id,
-        tenant_id=tenant_id,
-        scope=scope,
-        scope_id=scope_id,
-        extraction_run_id=extraction_run_id,
-    )
 
     return result
 

--- a/src/memoryhub_core/services/reconciliation.py
+++ b/src/memoryhub_core/services/reconciliation.py
@@ -13,11 +13,12 @@ from __future__ import annotations
 
 import logging
 import uuid
+from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime
-from typing import Any, Callable, Awaitable
+from typing import Any
 
 from pydantic import BaseModel
-from sqlalchemy import delete, select, update
+from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from memoryhub_core.models.conversation import ConversationExtraction

--- a/tests/test_services/test_conversation_extraction.py
+++ b/tests/test_services/test_conversation_extraction.py
@@ -231,6 +231,7 @@ class TestExtractWindow:
                     url="http://test",
                     client=MagicMock(),
                     embedding_service=mock_embedding,
+                    extraction_run_id="test-run-001",
                 )
 
         # Verify reconcile_candidate was called
@@ -250,8 +251,10 @@ class TestExtractWindow:
         assert extraction_record.extraction_model == "test-model"
         assert len(extraction_record.extraction_prompt_hash) == 64  # SHA-256
 
-        # Verify result
-        assert result == [mock_memory_id]
+        # Verify result contains the decision
+        assert len(result) == 1
+        assert result[0].action == "create"
+        assert result[0].memory_id == mock_memory_id
         assert session.commit.called
 
     @pytest.mark.asyncio
@@ -284,11 +287,14 @@ class TestExtractWindow:
                     url="http://test",
                     client=MagicMock(),
                     embedding_service=mock_embedding,
+                    extraction_run_id="test-run-001",
                 )
 
         # No provenance record should be created for skipped items
         assert session.add.call_count == 0
-        assert result == []
+        # Result contains the skip decision, but no provenance was created
+        assert len(result) == 1
+        assert result[0].action == "skip"
 
     @pytest.mark.asyncio
     async def test_extract_window_filters_low_weight(self):
@@ -309,9 +315,10 @@ class TestExtractWindow:
                 url="http://test",
                 client=MagicMock(),
                 embedding_service=mock_embedding,
+                extraction_run_id="test-run-001",
             )
 
-        # Should skip the extraction
+        # Should skip the extraction (filtered before reconciliation)
         assert result == []
 
     @pytest.mark.asyncio
@@ -333,9 +340,10 @@ class TestExtractWindow:
                 url="http://test",
                 client=MagicMock(),
                 embedding_service=mock_embedding,
+                extraction_run_id="test-run-001",
             )
 
-        # Should skip the extraction
+        # Should skip the extraction (filtered before reconciliation)
         assert result == []
 
 
@@ -362,7 +370,13 @@ class TestExtractFromThread:
         ]
 
         with patch("memoryhub_core.services.dreaming._extract_window") as mock_extract:
-            mock_extract.return_value = [uuid.uuid4()]
+            from memoryhub_core.services.reconciliation import ReconciliationResult
+            mock_extract.return_value = [
+                ReconciliationResult(
+                    candidate_stub="test", action="create",
+                    memory_id=uuid.uuid4(), reason="no_similar_memory",
+                ),
+            ]
 
             mock_embedding = MagicMock()
             result = await extract_from_thread(
@@ -381,6 +395,7 @@ class TestExtractFromThread:
         assert isinstance(thread.last_extracted_at, datetime)
         assert result["extracted_count"] == 1
         assert result["cursor"] == 2
+        assert "extraction_run_id" in result
 
     @pytest.mark.asyncio
     async def test_extract_from_thread_no_messages(self):
@@ -438,7 +453,13 @@ class TestExtractFromThread:
         ]
 
         with patch("memoryhub_core.services.dreaming._extract_window") as mock_extract:
-            mock_extract.return_value = [uuid.uuid4()]
+            from memoryhub_core.services.reconciliation import ReconciliationResult
+            mock_extract.return_value = [
+                ReconciliationResult(
+                    candidate_stub="test", action="create",
+                    memory_id=uuid.uuid4(), reason="no_similar_memory",
+                ),
+            ]
 
             mock_embedding = MagicMock()
             result = await extract_from_thread(
@@ -454,7 +475,7 @@ class TestExtractFromThread:
 
         # With turn_range, cursor should NOT advance
         assert thread.extraction_cursor == 0
-        assert result["extracted_count"] == 2  # 2 windows
+        assert result["extracted_count"] == 2  # 2 windows, 1 create each
 
     @pytest.mark.asyncio
     async def test_extract_from_thread_logs_failure_to_db(self):

--- a/tests/test_services/test_rollback.py
+++ b/tests/test_services/test_rollback.py
@@ -1,0 +1,349 @@
+"""Tests for extraction run rollback, dry-run, and circuit breaker (#348).
+
+Exit predicates:
+- Rollback restores exact prior state
+- Dry-run produces full decision set with zero writes
+- Circuit breaker halts a synthetic anomalous run
+"""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from memoryhub_core.models.memory import MemoryNode
+from memoryhub_core.models.reconciliation import ReconciliationDecision as DecisionRow
+from memoryhub_core.models.schemas import MemoryNodeCreate
+from memoryhub_core.services.curation.similarity import SimilarityResult
+from memoryhub_core.services.dreaming import _check_circuit_breaker
+from memoryhub_core.services.memory import create_memory, update_memory
+from memoryhub_core.services.reconciliation import (
+    ExtractionCandidate,
+    ReconciliationResult,
+    reconcile_candidate,
+    rollback_extraction_run,
+)
+
+TENANT = "test-tenant"
+OWNER = "test-user"
+RUN_ID = "test-rollback-run-001"
+
+
+def _candidate(content: str, **kwargs) -> ExtractionCandidate:
+    return ExtractionCandidate(content=content, **kwargs)
+
+
+async def _tiebreaker_same(_cand: str, _exist: str) -> str:
+    return "same"
+
+
+# ---------------------------------------------------------------------------
+# Rollback
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_rollback_restores_prior_state(
+    async_session, embedding_service, monkeypatch,
+):
+    """Exit predicate: rollback a synthetic run and restore exact prior state.
+
+    Run produces 3 decisions:
+      1. Create (no match) -> new memory A
+      2. Update (matches "mozzarella") -> cheese becomes parmesan (v2)
+      3. Skip (exact dup of "blue cheese")
+    Rollback should:
+      - Soft-delete memory A
+      - Revert cheese to v1 (mozzarella, is_current=True, expires_at=None)
+      - Leave blue cheese untouched
+    """
+    # Pre-existing memories
+    mozzarella_data = MemoryNodeCreate(
+        content="User's favorite cheese is mozzarella",
+        scope="user", owner_id=OWNER, content_type="experiential",
+    )
+    mozzarella, _ = await create_memory(
+        mozzarella_data, async_session, embedding_service,
+        tenant_id=TENANT, force=True,
+    )
+
+    blue_data = MemoryNodeCreate(
+        content="User enjoys blue cheese on salads",
+        scope="user", owner_id=OWNER, content_type="experiential",
+    )
+    blue, _ = await create_memory(
+        blue_data, async_session, embedding_service,
+        tenant_id=TENANT, force=True,
+    )
+    await async_session.commit()
+
+    mozzarella_id = mozzarella.id
+    blue_id = blue.id
+
+    # Decision 1: create (no similar memory)
+    monkeypatch.setattr(
+        "memoryhub_core.services.reconciliation.check_similarity",
+        AsyncMock(return_value=SimilarityResult(0, None, None)),
+    )
+    result_a = await reconcile_candidate(
+        _candidate("User prefers dark mode for all IDEs"),
+        OWNER, "user", None, async_session, embedding_service,
+        tenant_id=TENANT, extraction_run_id=RUN_ID,
+    )
+    assert result_a.action == "create"
+    created_id = result_a.memory_id
+    assert created_id is not None
+
+    # Decision 2: update (matches mozzarella, tiebreaker=same)
+    monkeypatch.setattr(
+        "memoryhub_core.services.reconciliation.check_similarity",
+        AsyncMock(return_value=SimilarityResult(1, mozzarella_id, 0.92)),
+    )
+    result_b = await reconcile_candidate(
+        _candidate("User's favorite cheese is now parmesan", content_type="experiential"),
+        OWNER, "user", None, async_session, embedding_service,
+        tenant_id=TENANT, extraction_run_id=RUN_ID,
+        tiebreaker_fn=_tiebreaker_same,
+    )
+    assert result_b.action == "update"
+    parmesan_id = result_b.memory_id
+    assert parmesan_id is not None
+
+    # Decision 3: skip (exact dup)
+    monkeypatch.setattr(
+        "memoryhub_core.services.reconciliation.check_similarity",
+        AsyncMock(return_value=SimilarityResult(1, blue_id, 0.99)),
+    )
+    result_c = await reconcile_candidate(
+        _candidate("User enjoys blue cheese on salads"),
+        OWNER, "user", None, async_session, embedding_service,
+        tenant_id=TENANT, extraction_run_id=RUN_ID,
+    )
+    assert result_c.action == "skip"
+    await async_session.commit()
+
+    # Verify pre-rollback state
+    created_mem = await async_session.get(MemoryNode, created_id)
+    assert created_mem is not None
+    assert created_mem.is_current is True
+
+    old_mozz = await async_session.get(MemoryNode, mozzarella_id)
+    assert old_mozz.is_current is False  # retired by update
+
+    new_parm = await async_session.get(MemoryNode, parmesan_id)
+    assert new_parm.is_current is True
+    assert "parmesan" in new_parm.content
+
+    # ROLLBACK
+    summary = await rollback_extraction_run(RUN_ID, async_session)
+
+    assert summary["total_decisions"] == 3
+    assert summary["rolled_back"]["creates"] == 1
+    assert summary["rolled_back"]["updates"] == 1
+    assert summary["rolled_back"]["skips"] == 1
+
+    # Verify post-rollback state
+    # Created memory should be soft-deleted
+    await async_session.refresh(created_mem)
+    assert created_mem.deleted_at is not None
+    assert created_mem.is_current is False
+
+    # Mozzarella v1 should be restored
+    await async_session.refresh(old_mozz)
+    assert old_mozz.is_current is True
+    assert old_mozz.expires_at is None
+    assert "mozzarella" in old_mozz.content
+
+    # Parmesan v2 should be soft-deleted
+    await async_session.refresh(new_parm)
+    assert new_parm.deleted_at is not None
+    assert new_parm.is_current is False
+
+    # Blue cheese should be completely untouched
+    blue_mem = await async_session.get(MemoryNode, blue_id)
+    assert blue_mem.is_current is True
+    assert blue_mem.deleted_at is None
+
+
+@pytest.mark.asyncio
+async def test_rollback_skips_post_run_modifications(
+    async_session, embedding_service, monkeypatch,
+):
+    """Rollback skips memories that were modified after the run."""
+    # Create a memory via a synthetic run
+    monkeypatch.setattr(
+        "memoryhub_core.services.reconciliation.check_similarity",
+        AsyncMock(return_value=SimilarityResult(0, None, None)),
+    )
+    result = await reconcile_candidate(
+        _candidate("User likes Python"),
+        OWNER, "user", None, async_session, embedding_service,
+        tenant_id=TENANT, extraction_run_id=RUN_ID,
+    )
+    assert result.action == "create"
+    original_id = result.memory_id
+    await async_session.commit()
+
+    # Post-run modification: update the memory independently
+    from memoryhub_core.models.schemas import MemoryNodeUpdate
+    updated = await update_memory(
+        original_id,
+        MemoryNodeUpdate(content="User loves Python and Rust"),
+        async_session,
+        embedding_service,
+    )
+    post_run_id = updated.id
+
+    # Rollback should skip this decision
+    summary = await rollback_extraction_run(RUN_ID, async_session)
+
+    assert summary["skipped"]["post_run_modifications"] == 1
+    assert summary["rolled_back"]["creates"] == 0
+
+    # The post-run version should still be current
+    post_run_mem = await async_session.get(MemoryNode, post_run_id)
+    assert post_run_mem.is_current is True
+    assert post_run_mem.deleted_at is None
+
+
+@pytest.mark.asyncio
+async def test_rollback_nonexistent_run(async_session):
+    """Rollback of a run with no decisions returns empty summary."""
+    summary = await rollback_extraction_run("nonexistent-run-id", async_session)
+    assert summary["total_decisions"] == 0
+    assert summary["rolled_back"]["creates"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Dry-run
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_dry_run_produces_decisions_no_writes(
+    async_session, embedding_service, monkeypatch,
+):
+    """Exit predicate: dry-run produces full decision set with zero writes."""
+    monkeypatch.setattr(
+        "memoryhub_core.services.reconciliation.check_similarity",
+        AsyncMock(return_value=SimilarityResult(0, None, None)),
+    )
+
+    result = await reconcile_candidate(
+        _candidate("User prefers vim keybindings"),
+        OWNER, "user", None, async_session, embedding_service,
+        tenant_id=TENANT, extraction_run_id="dry-run-001",
+        dry_run=True,
+    )
+
+    # Decision is fully populated
+    assert result.action == "create"
+    assert result.reason == "no_similar_memory"
+
+    # But no memory was created
+    assert result.memory_id is None
+
+    # No decision log row written
+    from sqlalchemy import func, select
+    decision_count = await async_session.scalar(
+        select(func.count()).select_from(DecisionRow)
+    )
+    assert decision_count == 0
+
+    # No memory node created
+    memory_count = await async_session.scalar(
+        select(func.count()).select_from(MemoryNode)
+    )
+    assert memory_count == 0
+
+
+@pytest.mark.asyncio
+async def test_dry_run_with_update_decision(
+    async_session, embedding_service, monkeypatch,
+):
+    """Dry-run with update decision: decision logged but no version created."""
+    existing_data = MemoryNodeCreate(
+        content="User drinks coffee",
+        scope="user", owner_id=OWNER, content_type="experiential",
+    )
+    existing, _ = await create_memory(
+        existing_data, async_session, embedding_service,
+        tenant_id=TENANT, force=True,
+    )
+    await async_session.commit()
+
+    monkeypatch.setattr(
+        "memoryhub_core.services.reconciliation.check_similarity",
+        AsyncMock(return_value=SimilarityResult(1, existing.id, 0.92)),
+    )
+
+    result = await reconcile_candidate(
+        _candidate("User drinks tea now", content_type="experiential"),
+        OWNER, "user", None, async_session, embedding_service,
+        tenant_id=TENANT, extraction_run_id="dry-run-002",
+        dry_run=True,
+        tiebreaker_fn=_tiebreaker_same,
+    )
+
+    assert result.action == "update"
+    assert result.memory_id is None  # no actual update performed
+
+    # Original memory untouched
+    refreshed = await async_session.get(MemoryNode, existing.id)
+    assert refreshed.is_current is True
+    assert "coffee" in refreshed.content
+
+
+# ---------------------------------------------------------------------------
+# Circuit breaker
+# ---------------------------------------------------------------------------
+
+def test_circuit_breaker_halts_anomalous_run():
+    """Exit predicate: circuit breaker trips on all-creates anomaly."""
+    all_creates = [
+        ReconciliationResult(candidate_stub=f"fact {i}", action="create")
+        for i in range(20)
+    ]
+    reason = _check_circuit_breaker(all_creates, min_decisions=5)
+    assert reason is not None
+    assert "creates" in reason.lower() or "create" in reason.lower()
+
+
+def test_circuit_breaker_does_not_trip_on_balanced_mix():
+    """Balanced create:update ratio should not trip the breaker."""
+    balanced = [
+        ReconciliationResult(candidate_stub=f"c{i}", action="create")
+        for i in range(5)
+    ] + [
+        ReconciliationResult(candidate_stub=f"u{i}", action="update")
+        for i in range(5)
+    ] + [
+        ReconciliationResult(candidate_stub=f"s{i}", action="skip")
+        for i in range(5)
+    ]
+    reason = _check_circuit_breaker(balanced, min_decisions=5)
+    assert reason is None
+
+
+def test_circuit_breaker_does_not_arm_below_min():
+    """Below min_decisions, the breaker should not trip."""
+    few_creates = [
+        ReconciliationResult(candidate_stub=f"fact {i}", action="create")
+        for i in range(3)
+    ]
+    reason = _check_circuit_breaker(few_creates, min_decisions=5)
+    assert reason is None
+
+
+def test_circuit_breaker_custom_ratio():
+    """Custom ratio threshold is respected."""
+    decisions = [
+        ReconciliationResult(candidate_stub=f"c{i}", action="create")
+        for i in range(10)
+    ] + [
+        ReconciliationResult(candidate_stub="u0", action="update"),
+    ]
+    # 10:1 ratio, threshold is 5:1 -> should trip
+    reason = _check_circuit_breaker(decisions, max_create_ratio=5.0, min_decisions=5)
+    assert reason is not None
+
+    # Same data, threshold is 15:1 -> should not trip
+    reason = _check_circuit_breaker(decisions, max_create_ratio=15.0, min_decisions=5)
+    assert reason is None


### PR DESCRIPTION
## Summary

- Fix extraction_run_id bug: was generated per-candidate (different timestamps), now generated once per `extract_from_thread()` invocation so all candidates in a run share the same ID
- Add `rollback_extraction_run()`: given a run ID, reverses all creates (soft-delete) and updates (revert to prior version) using the reconciliation_decisions table as the manifest, with safety checks for post-run modifications
- Add dry-run mode to `reconcile_candidate()` and `extract_from_thread()`: computes full decisions (similarity search + thresholds) without writing memories or decision log rows
- Add circuit breaker to `extract_from_thread()`: halts extraction when create:update ratio exceeds configurable threshold (default 20:1) after minimum decisions (default 5)
- Change `_extract_window()` return type from `list[UUID]` to `list[ReconciliationResult]` to support decision collection for dry-run and circuit breaker

## Test plan

- [x] `test_rollback_restores_prior_state` -- exit predicate: rollback a synthetic run with create/update/skip decisions, verify exact prior state restoration
- [x] `test_rollback_skips_post_run_modifications` -- safety check: post-run version changes are preserved
- [x] `test_rollback_nonexistent_run` -- empty summary for unknown run ID
- [x] `test_dry_run_produces_decisions_no_writes` -- exit predicate: decision computed, zero DB writes
- [x] `test_dry_run_with_update_decision` -- dry-run with update: original memory untouched
- [x] `test_circuit_breaker_halts_anomalous_run` -- exit predicate: trips on all-creates anomaly
- [x] `test_circuit_breaker_does_not_trip_on_balanced_mix` -- balanced ratio does not trip
- [x] `test_circuit_breaker_does_not_arm_below_min` -- respects min_decisions
- [x] `test_circuit_breaker_custom_ratio` -- custom threshold works
- [x] All 8 existing reconciliation tests pass
- [x] All 30 existing extraction tests pass (mocks updated for new signature)

Closes #348