### PR TITLE
dreaming: EvalHub infrastructure for dreaming-mode benchmark

### DIFF
--- a/benchmarks/evalhub-adapter/config/dreaming-pro.yaml
+++ b/benchmarks/evalhub-adapter/config/dreaming-pro.yaml
@@ -1,0 +1,26 @@
+name: dreaming-pro-full
+description: >
+  Full 589-query PersonaMem in dreaming mode with Granite embeddings,
+  reranker, and gemini-3.1-pro-preview answerer. Threads + extraction
+  per session, search over extracted memories only.
+model:
+  url: https://generativelanguage.googleapis.com
+  name: gemini-3.1-pro-preview
+  auth:
+    secret_ref: gemini-api-key
+benchmarks:
+  - id: personamem-mcq
+    provider_id: 9b72673c-c757-434e-909f-e2f21a616de5
+    parameters:
+      dataset: personamem
+      dataset_variant: "32k"
+      memory_provider: memoryhub
+      ingestion_mode: dreaming
+      project_id: amb-granite-pro-dreaming
+      disabled_signals: domain,graph
+      focus_mode: persona
+      return_chunks: "true"
+      k: 10
+      query_limit: 589
+experiment:
+  name: memoryhub/personamem-mcq/32k/dreaming-pro

--- a/benchmarks/evalhub-adapter/config/dreaming-smoke.yaml
+++ b/benchmarks/evalhub-adapter/config/dreaming-smoke.yaml
@@ -1,0 +1,23 @@
+name: dreaming-smoke
+description: 20-query dreaming-mode smoke test to verify pipeline wiring
+model:
+  url: https://generativelanguage.googleapis.com
+  name: gemini-3.1-flash-lite
+  auth:
+    secret_ref: gemini-api-key
+benchmarks:
+  - id: personamem-mcq
+    provider_id: 9b72673c-c757-434e-909f-e2f21a616de5
+    parameters:
+      dataset: personamem
+      dataset_variant: "32k"
+      memory_provider: memoryhub
+      ingestion_mode: dreaming
+      project_id: amb-granite-pro-dreaming-smoke
+      disabled_signals: domain,graph
+      focus_mode: persona
+      return_chunks: "true"
+      k: 10
+      query_limit: 20
+experiment:
+  name: memoryhub/personamem-mcq/32k/dreaming-smoke

--- a/benchmarks/evalhub-adapter/src/memoryhub_evalhub/adapter.py
+++ b/benchmarks/evalhub-adapter/src/memoryhub_evalhub/adapter.py
@@ -31,7 +31,6 @@ class AMBAdapter(FrameworkAdapter):
       - parameters: {
             mode:            "library" | "dreaming"  (harness ingestion mode)
             answer_model:    model name override (optional, defaults to model.name)
-            k:               top-k for retrieval (optional)
             dataset:         dataset name (default "personamem")
             dataset_variant: split name (default "32k")
             pipeline_sha:    git SHA of the MemoryHub pipeline code
@@ -39,6 +38,13 @@ class AMBAdapter(FrameworkAdapter):
             memoryhub_url:   MemoryHub server URL (optional)
             memoryhub_api_key: MemoryHub API key (optional)
             disabled_signals: comma-separated signal names to disable (optional)
+            ingestion_mode:  "library" or "dreaming" (default: library)
+            project_id:      MemoryHub project ID (default: amb-benchmark)
+            focus_mode:      "persona" for 2-vector retrieval (optional)
+            return_chunks:   "true" to return chunks (optional)
+            k:               retrieval depth (optional)
+            extract_facts:   eager/background/off (optional)
+            tenant_id:       tenant ID override (optional)
             skip_ingestion:  if true, skip data ingestion (reuse existing data)
             query_limit:     max queries (optional, None = all)
             category:        category filter (optional)
@@ -54,7 +60,7 @@ class AMBAdapter(FrameworkAdapter):
         load_dotenv(override=True)
 
         from memory_bench.dataset import get_dataset
-        from memory_bench.llm import get_llm, get_answer_llm
+        from memory_bench.llm import get_answer_llm
         from memory_bench.memory import get_memory_provider
         from memory_bench.modes import get_mode
         from memory_bench.runner import EvalRunner
@@ -92,11 +98,23 @@ class AMBAdapter(FrameworkAdapter):
         if params.get("memoryhub_api_key"):
             os.environ["MEMORYHUB_API_KEY"] = params["memoryhub_api_key"]
 
-        # Wire disabled signals for ablation testing
-        if params.get("disabled_signals"):
-            os.environ["MEMORYHUB_DISABLED_SIGNALS"] = params["disabled_signals"]
-        elif "MEMORYHUB_DISABLED_SIGNALS" in os.environ:
-            del os.environ["MEMORYHUB_DISABLED_SIGNALS"]
+        # Wire harness configuration from job parameters
+        param_to_env = {
+            "disabled_signals": "MEMORYHUB_DISABLED_SIGNALS",
+            "project_id": "MEMORYHUB_PROJECT_ID",
+            "ingestion_mode": "MEMORYHUB_INGESTION_MODE",
+            "focus_mode": "MEMORYHUB_FOCUS_MODE",
+            "return_chunks": "MEMORYHUB_RETURN_CHUNKS",
+            "k": "MEMORYHUB_K",
+            "extract_facts": "MEMORYHUB_EXTRACT_FACTS",
+            "tenant_id": "MEMORYHUB_TENANT_ID",
+        }
+        for param_key, env_key in param_to_env.items():
+            val = params.get(param_key)
+            if val is not None:
+                os.environ[env_key] = str(val)
+            elif env_key in os.environ and param_key == "disabled_signals":
+                del os.environ[env_key]
 
         # Wire DB connection for memoryhub provider (params override env vars)
         for db_key in ("MEMORYHUB_DB_HOST", "MEMORYHUB_DB_PORT", "MEMORYHUB_DB_USER",
@@ -106,7 +124,7 @@ class AMBAdapter(FrameworkAdapter):
                 os.environ[db_key] = str(params[param_key])
 
         # -- Preflight: probe deployment and enforce expectations --------
-        from memoryhub_evalhub.preflight import run_preflight, enforce_manifest
+        from memoryhub_evalhub.preflight import enforce_manifest, run_preflight
 
         db_url = (
             f"postgresql://{os.environ.get('MEMORYHUB_DB_USER', 'memoryhub')}"

--- a/memory-hub-mcp/src/tools/thread.py
+++ b/memory-hub-mcp/src/tools/thread.py
@@ -152,6 +152,7 @@ async def _dispatch_create(scope, opts, ctx):
     from memoryhub_core.models.schemas import ConversationThreadCreate
     from memoryhub_core.services.conversation import create_thread
     from src.core.authz import (
+        PROJECT_ISOLATION_ENABLED,
         AuthenticationError,
         authorize_write,
         get_claims_from_context,
@@ -169,7 +170,23 @@ async def _dispatch_create(scope, opts, ctx):
     tenant = get_tenant_filter(claims)
     caller_id = claims["sub"]
 
-    if not authorize_write(claims, scope, owner_id=caller_id, tenant_id=tenant):
+    project_ids: set[str] | None = None
+    scope_id_value = opts.get("scope_id")
+    if scope == "project" and PROJECT_ISOLATION_ENABLED and scope_id_value:
+        from src.tools.write_memory import ensure_project_membership
+        session_proj, gen_proj = await get_db_session()
+        try:
+            project_ids, _ = await ensure_project_membership(
+                session_proj, scope_id_value, caller_id, tenant,
+            )
+            await session_proj.commit()
+        finally:
+            await release_db_session(gen_proj)
+
+    if not authorize_write(
+        claims, scope, owner_id=caller_id, tenant_id=tenant,
+        project_ids=project_ids, scope_id=scope_id_value,
+    ):
         raise ToolError(f"Not authorized to create threads in scope '{scope}'.")
 
     create_opts = _forward(opts, _CREATE_OPTS)

--- a/src/memoryhub_core/config.py
+++ b/src/memoryhub_core/config.py
@@ -80,6 +80,7 @@ class AppSettings(BaseSettings):
     # Dreaming pipeline (#168 Phase 3)
     conv_extraction_model: str = ""
     conv_extraction_model_url: str = ""
+    conv_extraction_api_key: str = ""
     conv_extraction_window_size: int = 4
     conv_extraction_timeout: int = 60
 

--- a/src/memoryhub_core/services/dreaming.py
+++ b/src/memoryhub_core/services/dreaming.py
@@ -146,7 +146,7 @@ async def _call_extraction_llm(
     for attempt in range(_MAX_RETRIES):
         try:
             response = await client.post(
-                f"{url.rstrip('/')}/v1/chat/completions",
+                f"{url.rstrip('/')}/chat/completions",
                 json={
                     "model": model,
                     "messages": messages,
@@ -457,8 +457,12 @@ async def extract_from_thread(
     circuit_breaker_reason: str | None = None
     windows_completed = 0
 
+    headers = {}
+    if settings.conv_extraction_api_key:
+        headers["Authorization"] = f"Bearer {settings.conv_extraction_api_key}"
+
     async with httpx.AsyncClient(
-        timeout=settings.conv_extraction_timeout, verify=False,
+        timeout=settings.conv_extraction_timeout, verify=False, headers=headers,
     ) as client:
         for window in windows:
             window_start = window[0].sequence_number


### PR DESCRIPTION
## Summary

- Fix project-scope authorization for thread creation (thread tool was missing `ensure_project_membership` call, causing all project-scope thread ops to be rejected)
- Add extraction API key support to dreaming pipeline (`MEMORYHUB_CONV_EXTRACTION_API_KEY` env var, Bearer auth on httpx client)
- Fix URL construction in extraction client (remove hardcoded `/v1/` prefix for Gemini compat)
- Wire harness configuration parameters (ingestion_mode, project_id, focus_mode, k, etc.) through EvalHub adapter
- Add dreaming-mode eval configs (smoke + full Pro)

## Test plan

- [x] 40 thread tool tests pass
- [x] 28 extraction service tests pass
- [x] All server unit tests pass (727)
- [x] Lint clean on all modified files
- [x] Local `create_thread(scope="project", scope_id=...)` verified against live cluster
- [x] EvalHub smoke test submitted and extraction pipeline running on cluster (76+ extraction events)

Closes #416