### PR TITLE
dreaming: Fix persona isolation and circuit breaker

### DIFF
--- a/benchmarks/amb-harness/src/memory_bench/memory/memoryhub.py
+++ b/benchmarks/amb-harness/src/memory_bench/memory/memoryhub.py
@@ -211,9 +211,11 @@ class MemoryHubProvider(MemoryProvider):
             for p_idx, (persona_id, sessions) in enumerate(
                 sorted(persona_sessions.items()), 1
             ):
+                owner = f"amb-{persona_id}" if persona_id else "amb-default"
                 thread = await client.create_thread(
                     scope="project",
                     scope_id=self._project_id,
+                    owner_id=owner,
                     title=f"PersonaMem {persona_id}",
                     metadata={
                         "persona_id": persona_id,

--- a/memory-hub-mcp/src/tools/thread.py
+++ b/memory-hub-mcp/src/tools/thread.py
@@ -22,7 +22,7 @@ _VALID_ACTIONS = frozenset({
 
 _CREATE_OPTS = frozenset({
     "title", "participant_ids", "participant_access",
-    "a2a_context_id", "scope_id", "metadata",
+    "a2a_context_id", "scope_id", "owner_id", "metadata",
 })
 _APPEND_OPTS = frozenset({"actor_id", "tool_call_id", "metadata", "a2a_context_id"})
 _GET_OPTS = frozenset({"limit", "before_sequence", "include_messages"})
@@ -189,7 +189,9 @@ async def _dispatch_create(scope, opts, ctx):
     ):
         raise ToolError(f"Not authorized to create threads in scope '{scope}'.")
 
+    effective_owner = opts.get("owner_id") or caller_id
     create_opts = _forward(opts, _CREATE_OPTS)
+    create_opts.pop("owner_id", None)
     data = ConversationThreadCreate(scope=scope, **create_opts)
 
     session, gen = await get_db_session()
@@ -198,7 +200,7 @@ async def _dispatch_create(scope, opts, ctx):
             session,
             tenant_id=tenant,
             data=data,
-            owner_id=caller_id,
+            owner_id=effective_owner,
             actor_id=caller_id,
             driver_id=claims.get("driver_id"),
         )

--- a/sdk/src/memoryhub/client.py
+++ b/sdk/src/memoryhub/client.py
@@ -1551,6 +1551,7 @@ class MemoryHubClient:
         scope: str,
         *,
         scope_id: str | None = None,
+        owner_id: str | None = None,
         title: str | None = None,
         participant_ids: list[str] | None = None,
         participant_access: dict[str, str] | None = None,
@@ -1561,6 +1562,8 @@ class MemoryHubClient:
         opts: dict[str, Any] = {}
         if scope_id is not None:
             opts["scope_id"] = scope_id
+        if owner_id is not None:
+            opts["owner_id"] = owner_id
         if title is not None:
             opts["title"] = title
         if participant_ids is not None:


### PR DESCRIPTION
## Summary

- Thread creation always used caller_id as owner_id, breaking per-persona isolation in dreaming mode benchmarks
- Added owner_id override to thread creation (tool, SDK, harness)
- Extracted memories now correctly scoped to amb-{persona_id}

## Test plan

- [x] 40 thread tool tests pass
- [x] 28 extraction tests pass
- [x] Lint clean