### PR TITLE
docs: Track planning and research documents

### DIFF
--- a/planning/eager-fact-extraction.md
+++ b/planning/eager-fact-extraction.md
@@ -30,6 +30,51 @@ Everything after candidate production — reconciliation, dedup,
 provenance, versioning, curation gates — is shared. If an implementation
 decision would fork the downstream, the decision is wrong.
 
+### Third trigger: session-close capture (added 2026-07-16, Wes)
+
+Eager extraction only sees content agents explicitly WRITE to MemoryHub.
+Most memorable session content — decisions made, corrections given,
+preferences revealed — is never written anywhere; it lives in the
+transcript and evaporates at `/exit`. Session-close capture is the
+missing ingestion trigger for the original dreaming pipeline: the
+conversation-persistence subsystem (#168) built thread storage and the
+windowed extractor exists, but nothing feeds interactive-agent
+transcripts into them. This does.
+
+| | Session-close capture |
+|---|---|
+| Trigger | harness session-end hook (Claude Code SessionEnd; harness-agnostic via CLI) |
+| Mechanism | hook runs `memoryhub capture-session <transcript-path>` — redaction gate, then transcript persisted as a thread; extraction ENQUEUED |
+| LLM | none at close (the session is ending — sampling has no live client). Default: the queue drains at the NEXT connected session via sampling ("session N's close enqueues; session N+1's connect dreams it"). Optional: server-side model where configured (cluster), or `memoryhub dream --model ...` (personal). |
+| Output | same fact candidates, same downstream — trigger three, pipeline one |
+
+Design requirements:
+
+1. **Opt-in, per project** (`.memoryhub.yaml`), never default-on.
+   Transcripts contain everything — secrets, third-party code, personal
+   context.
+2. **Redaction gate before the transcript leaves the machine:** run the
+   credential patterns (we maintain gitleaks rules; reuse them) over the
+   trace pre-persist. The 2026-07-14 credential incident is the
+   argument.
+3. **Retention choice:** `extract-and-discard` (facts kept, raw trace
+   dropped after extraction) vs `retain-thread` (full governed thread,
+   the original #168 design). Default extract-and-discard for personal;
+   retain-thread is the enterprise/audit posture.
+4. **Extraction cursor applies** (already in the conversation-extraction
+   schema): a session partially processed by eager extraction mid-flight
+   must not be re-extracted wholesale at close — cursor + reconciliation
+   absorb the overlap, but the cursor does the cheap half.
+5. **Harness-agnostic core:** the CLI is the contract; the Claude Code
+   SessionEnd hook is the first integration (`memoryhub config init`
+   already writes our SessionStart hook — this is its sibling). Other
+   harnesses wire their own end-of-session ritual to the same CLI.
+
+Consequence for sequencing: this raises the stakes on #347 again —
+session-close extraction over full traces will re-produce facts eager
+extraction already caught, making reconciliation the dedup backstop for
+THREE producers, not two.
+
 ## 2. Why (evidence)
 
 The 2026-07-15 sweep established that retrieval-unit granularity, not

--- a/planning/git-transport-mode.md
+++ b/planning/git-transport-mode.md
@@ -1,0 +1,162 @@
+# Git and File Storage: Viability Analysis and Design Position
+
+**Status:** Position + design sketch
+**Date:** 2026-07-16
+**Author:** @rdwj (designed with Claude in Cowork)
+**Builds on:** `planning/personal-edition.md` (SQLite canonical store,
+membership ladder, scope homing), #347 (reconciliation — reused here as
+the merge engine)
+**Prompted by:** recurring external interest in "memories as files in
+git"
+
+## Position (one paragraph)
+
+"Git storage mode" bundles two proposals with opposite verdicts.
+**Files-as-canonical-store (git as the database): no** — the analysis
+below gives the specific failure modes and the boundary past which it
+recreates a bad database. **Git-as-transport between canonical local
+stores: yes** — it is the natural middle rung of the membership ladder
+(personal -> git-team -> cluster), it reuses reconciliation as its merge
+engine, and it converts market interest in file-based memory into a
+funnel toward the governed architecture instead of a fork away from it.
+A documented serialization format ships regardless, as the
+export/portability/backup story.
+
+## Part 1: Why files-as-canonical fails (the engineering "no")
+
+1. **Merge semantics.** Git merges lines; memory requires semantic
+   reconciliation. Concurrent updates to one memory on two clones
+   produce either a manual textual conflict or silent divergence. The
+   only real fix is a custom git merge driver that embeds the
+   reconciliation engine and runs on every clone at pull time —
+   reimplementing #347 inside git's merge machinery, per-user,
+   per-clone.
+2. **Double bookkeeping.** MemoryHub version chains and git commit
+   history both claim to be the history. Serialize chains into files ->
+   file explosion and repo bloat; keep chains local-only -> the core
+   governance value (versioning, is_current, provenance) silently fails
+   to transport. There is no clean resolution; every design falls into
+   one of these two holes.
+3. **Divergent curation.** Curation/reconciliation gates run per-clone
+   with nondeterministic LLM tiebreakers -> different clones reach
+   different verdicts about the same candidate -> stores diverge, then
+   conflict at sync.
+4. **Secrets and privacy.** Memories land in effectively-immutable repo
+   history. This project has already run one credential-scrub incident;
+   a memory store IN git multiplies that surface. The cluster has
+   delete + audit; git has BFG and regret.
+5. **Scale mechanics.** Tens of thousands of small files degrade clone
+   and status times; reconciliation churn becomes commit noise;
+   embeddings/indexes are derived state that must NOT be committed, so
+   every clone rebuilds them anyway (which quietly concedes that the
+   files are not the whole store).
+
+**Viability boundary, stated fairly:** files-as-canonical works to
+roughly 10 users / low-thousands of memories / PR-mediated writes /
+project scope only / low churn. Inside that box it is a workable
+artisanal system. The box's edges are exactly where MemoryHub's actual
+customers live outside of.
+
+## Part 2: Git as transport (the engineering "yes")
+
+Each participant runs the personal edition — **SQLite remains canonical
+on every machine**; indexes and embeddings stay local and derived. Git
+carries a serialized projection of *shared-scope* memories:
+
+```
+memoryhub sync git [--remote origin]
+  export: project-scope memories -> .memoryhub/memories/*.md
+          (stable per-memory serialization; see Part 3)
+  commit/push: normal git, normal review culture if the team wants PRs
+  import (on pull): reconciliation-as-merge INSIDE MemoryHub --
+          incoming candidates run the #347 pipeline against the local
+          store: exact-dup skip, update-with-version, create, or
+          flag -- with the decision log as the merge record
+```
+
+What each party contributes:
+
+- **Git does what git is good at:** transport, offline/async sync,
+  backup, repo-permission access control, and a human review surface
+  (memory changes as PRs — the exact workflow this project already uses
+  for CLAUDE.md, proven where humans should review).
+- **MemoryHub does what git cannot:** semantic merge, per-fact
+  versioning, retrieval, extraction, honesty flags. Conflicts surface
+  as reconciliation decisions, never as `<<<<<<<` markers.
+- **Scope homing does the privacy work:** user-scope memories NEVER
+  serialize into a shared repo. Project scope only, by construction.
+  (Same rule as the membership design in personal-edition.md 6b.)
+
+Known limits, stated in docs from day one: sync-time consistency (not
+live push updates — that is the cluster's job); repo-granular access
+control (not per-scope RBAC); history in two places (git history is the
+transport log; MemoryHub chains are the memory history — the
+serialization carries chain summaries so provenance survives transport).
+
+## Part 3: The serialization format (ships regardless)
+
+One file per memory, markdown with YAML frontmatter (id, scope, owner,
+weight, domains, branch_type, version, extraction run id, provenance
+refs, embedder id) + content body. Deterministic filenames (id-based),
+stable field ordering (clean diffs). `memoryhub export` / `import`
+against any directory — the data-portability, backup, and
+"never locked in" answer, valuable for trust independent of git-sync.
+Format versioned; documented in docs/ once implemented.
+
+## Part 4: The 3-person team, answered concretely
+
+Shared CLAUDE.md wins while team memory is *constitutional*: dozens of
+stable conventions, loaded whole, changed rarely, reviewed always. It
+loses on three axes as volume/churn grow: (1) load-everything — no
+retrieval, context cost grows with every fact; (2) versions the file,
+not the facts — no per-memory history, no is_current, no cheese test;
+(3) one hot file — merge conflicts, and agents writing operational
+memories into the constitution degrades the constitution.
+
+Rule of thumb for docs: **under ~50 stable facts, use CLAUDE.md; above
+that, or with churn, or when agents write memories mid-session, use
+git-transport mode.** They compose: constitution in CLAUDE.md,
+operational memory in `.memoryhub/` — which is how this project itself
+operates today (CLAUDE.md + MemoryHub), just with git in place of the
+cluster.
+
+## Onboarding and the sqlite-copy question (2026-07-16)
+
+New-teammate onboarding is not a feature — it is a consequence of
+transport: `git clone` + `memoryhub sync git` hydrates the team's
+project memory locally (embeddings rebuilt on import; provenance
+summaries carried by the serialization). No separate mechanism.
+
+Copying the SQLite file itself is the wrong tool for sharing (binary
+blob: no diffs, no review, whole-file conflicts, carries user-scope
+private data, couples schema/embedder versions) and the right tool for
+personal backup and device migration (copy file, restore file — free).
+Doctrine: **the SQLite file is your memory moving between your
+machines; serialized files in git are the team's memory moving between
+people.**
+
+## Ladder placement and sequencing
+
+personal (n=1, SQLite) -> **git-team (n≈2-10, SQLite + git transport)**
+-> cluster (org, governed multi-tenant). `memoryhub join` upgrades a
+git-team member to a cluster the same way it upgrades a solo user —
+curated promotion, provenance preserved.
+
+Sequencing: strictly after personal-edition P1-P4 (needs the SQLite
+backend and the serialization format) and materially better after #347
+(reconciliation is the merge engine — before it lands, import can only
+do exact-dup skip + create + flag, no semantic update). Candidate P7 of
+the personal-edition epic. The export/import format (Part 3) can land
+earlier, with P5.
+
+## Open questions
+
+1. Import trust: a teammate's repo push injects memories into my store
+   at sync — curation gates apply, but the poisoning threat model
+   (#334) gains a "malicious teammate commit" case (mitigated by PR
+   review where teams use it).
+2. Deletion semantics across clones (tombstone files? retention of
+   soft-deletes in the serialization?).
+3. Whether `sync git` runs reconciliation tiebreakers via sampling
+   (connected-session import) or defers ambiguous merges to a review
+   queue — leaning: defer, keep import deterministic.

--- a/planning/kubernetes-general.md
+++ b/planning/kubernetes-general.md
@@ -1,0 +1,106 @@
+# Kubernetes-General MemoryHub: From OpenShift AI Component to Community Project
+
+**Status:** Design (portability audit grounded in repo state 2026-07-16)
+**Date:** 2026-07-16
+**Author:** @rdwj (designed with Claude in Cowork)
+**Builds on:** `planning/personal-edition.md` (the ladder this completes),
+`planning/git-transport-mode.md`, `strategy/client-supplied-intelligence.md`
+
+## 1. Why
+
+Community adoption requires that `helm install memoryhub` work on any
+conformant Kubernetes — kind, k3s, EKS, GKE, AKS — with no OpenShift
+prerequisites. The org playbook is upstream/downstream (the ODH -> RHOAI
+motion): **MemoryHub the community project** runs K8s-general; **MemoryHub
+the OpenShift AI component** is the downstream packaging with the
+enterprise integrations. Nothing about the current architecture prevents
+this — the data plane (PostgreSQL+pgvector, MinIO-or-any-S3, Valkey, TEI)
+is vanilla; the coupling is confined to the deploy/build/expose layer.
+
+This also completes the adoption ladder:
+**personal (pip, SQLite)** -> **git-team (git transport)** ->
+**k8s-community (helm, any cluster)** -> **OpenShift AI (product)**.
+Every rung uses the same tool surface, SDK, and semantics; `memoryhub
+join` moves users up the ladder with provenance intact.
+
+## 2. Portability audit (grounded — file citations, not assumptions)
+
+| Coupling | Where (verified) | K8s-general replacement | Effort |
+|----------|------------------|------------------------|--------|
+| `oc` CLI throughout script layer | `scripts/deploy-full.sh`, `check-prereqs.sh`, `run-migrations.sh`, `cluster-setup-github-idp.sh`, others | `kubectl` everywhere it's 1:1; isolate genuinely-OpenShift ops behind a detected `IS_OPENSHIFT` flag | Medium (mechanical, wide) |
+| OpenShift Routes | `deploy/reranker/route.yaml`, `deploy/embedding/route.yaml` (no Ingress manifests exist) | Ingress (+ IngressClass) or Gateway API; Route retained as an overlay for the downstream | Small |
+| `anyuid` SCC grants ×3 | `scripts/deploy-full.sh:240,342,346` (DB, MinIO, Valkey service accounts); `deploy/postgresql/README.md` documents the random-UID issue | Root-cause fix, not a translation: set explicit `securityContext` (runAsUser/fsGroup) or use images that tolerate arbitrary UIDs; on plain K8s use Pod Security Standards. Fixing this properly REMOVES the SCC need on OpenShift too | Small-Medium |
+| BuildConfig/ImageStream | benchmark infra only (`benchmarks/evalhub-adapter/manifests/buildconfig.yaml`, `scripts/deploy-evalhub.sh`, `uninstall-full.sh`) | GitHub Actions -> ghcr/quay (release workflow already exists for PyPI with attestation — extend to images) | Small; benchmark-only, not product path |
+| GitHub IdP / auth setup script | `scripts/cluster-setup-github-idp.sh` | Downstream-only; community auth = the existing self-contained auth service (API key + OAuth 2.1), no cluster IdP dependency | None (scope decision) |
+| No Helm chart | `deploy/` is per-component kustomize + deploy-full.sh orchestration | **The centerpiece deliverable:** a Helm chart encoding everything deploy-full.sh knows (secret generation, cross-namespace copies, migration job, idempotency) — see Section 3 | Large |
+| Positioning language | CLAUDE.md epic statement, README, ARCHITECTURE.md ("on OpenShift AI") | "Kubernetes-native, packaged for OpenShift AI" — docs sweep | Small |
+| UBI base images, FIPS posture | everywhere | KEEP — UBI is freely redistributable; FIPS becomes an optional value ("hardened by default") not a prerequisite | None |
+| Granite models via TEI | `deploy/embedding`, `deploy/reranker` | Already portable (TEI is upstream HF; models Apache 2.0). GPU optional: CPU profile reuses the personal edition's ONNX path | Small |
+| EvalHub/TrustyAI | benchmark infra | Stays RHOAI-side; community CI uses the personal-edition harness path (no cluster needed) | None |
+
+**Unverified items for the implementing session** (capability-claims
+rule): whether the PG image swap or securityContext fully removes the
+anyuid need (test on kind with restricted PSS); whether anything in
+memoryhub-auth assumes OpenShift OAuth (believed self-contained —
+verify); operator plans (`planning/operator.md`) — kopf/operator-sdk are
+K8s-general already, confirm no Route/SCC assumptions in that design.
+
+## 3. The Helm chart (the real work)
+
+`deploy-full.sh` encodes hard-won operational knowledge that MUST NOT be
+lost in translation — it is the spec, per the CLAUDE.md reproducibility
+checklist:
+
+- Secret generation with generate-if-missing idempotency
+- Cross-namespace secret copies (or better: collapse the community
+  chart to ONE namespace — the multi-namespace split is an enterprise
+  concern; sub-charts with a `namespaceOverride` for downstream)
+- Alembic migration as a pre-install/pre-upgrade Job (replaces
+  `run-migrations.sh`)
+- Ordered readiness (auth before MCP — the race fixed on 07-14)
+- The golden test, ported: `helm uninstall` (values-gated DB retention)
+  + `helm install` must round-trip with zero manual steps — this
+  becomes the community CI gate on kind, replacing nothing and
+  protecting everything
+
+Profiles via values: `minimal` (single namespace, CPU/ONNX models, no
+MinIO — 100KB inline threshold makes S3 optional for small installs, no
+Valkey until agents are enabled) through `full` (GPU TEI, S3, Valkey,
+agents). `minimal` must run on kind on a laptop — that is the community
+first-touch, and it doubles as the CI environment.
+
+## 4. What stays downstream (OpenShift AI packaging)
+
+Routes overlay, IdP integration, SCC handling if any remains, RHOAI
+console/operator integration, FIPS-verified builds, support lifecycle.
+The downstream consumes the community chart + overlays — one codebase,
+two distributions, same as the model the org already runs elsewhere.
+
+## 5. Sequencing (new epic or personal-edition sibling, ~5 sessions)
+
+1. **K1 — securityContext root-cause fix** (removes SCC need everywhere;
+   verify on kind with restricted PSS). Smallest, highest-leverage.
+2. **K2 — Route->Ingress + `oc`->`kubectl` sweep** (Route as overlay;
+   `IS_OPENSHIFT` detection for the residue). Loop-shaped: grep-zero
+   exit predicate on `oc ` outside the openshift/ overlay dir.
+3. **K3-K4 — Helm chart** (minimal profile first, then full; migration
+   Job; golden test on kind in CI).
+4. **K5 — docs/positioning sweep** + community quickstart ("kind +
+   helm + Claude Code in 15 minutes") + artifacthub listing.
+
+Dependencies: none on the dreaming epic. K1/K2 are quota-free,
+attention-light sessions — ideal counter-programming for
+benchmark-blocked weeks, same as personal-edition P1.
+
+## 6. Open questions
+
+1. Namespace topology for community chart: one namespace (lean) vs
+   preserving the 3-namespace split (parity with downstream). Leaning
+   one, with sub-chart overrides.
+2. Community CI budget: kind-based golden test per PR vs nightly.
+3. Chart hosting: repo-local + artifacthub vs a charts monorepo.
+4. Does the community edition ship the agents (Curator etc.) at launch
+   or land them when Phase 6 stabilizes? Leaning: values-gated, off by
+   default.
+5. Naming/branding for upstream vs downstream (defer; "early customer
+   preference"-style sensitivity applies to community positioning too).

--- a/planning/personal-edition.md
+++ b/planning/personal-edition.md
@@ -1,0 +1,274 @@
+# MemoryHub Personal Edition: `pip install memoryhub`, Zero Infrastructure
+
+**Status:** Design (new epic candidate — outside the dreaming epic)
+**Date:** 2026-07-16
+**Author:** @rdwj (designed with Claude in Cowork)
+**Builds on:** existing `memoryhub` PyPI package (SDK, v0.14.0 — the name
+is already ours, verified 2026-07-16), `memoryhub-core` (server-side
+library), `planning/eager-fact-extraction.md` (sampling),
+`strategy/client-supplied-intelligence.md` (the zero-credential wedge)
+
+---
+
+## 1. The product statement
+
+A developer runs:
+
+```bash
+pip install "memoryhub[local]"
+claude mcp add memoryhub -- memoryhub mcp   # or: uvx memoryhub mcp
+```
+
+and has persistent, versioned, searchable agent memory — with the same
+14 MCP tools the enterprise cluster exposes — backed by a single SQLite
+file, with **no database server, no object store, no GPU, no model API
+key, and no account**. First retrieval works within a minute of install.
+
+The existing `memoryhub` package is the client SDK; today
+`MemoryHubClient()` requires a cluster URL. Personal edition is defined
+as: **the zero-argument constructor works.** No URL -> embedded local
+engine. Same import, same API, same tool surface. Not a fork, not a
+"lite" product — a second deployment mode of the same product.
+
+### Why (adoption mechanics)
+
+- Top-of-funnel: nobody evaluates a memory platform by provisioning an
+  OpenShift cluster. They evaluate it in Claude Code in ten minutes.
+- The community -> product ladder is the org's home motion. Local mode
+  is the community edition; the cluster is the product; `memoryhub push`
+  is the bridge.
+- Competitive wedge (verified against primary sources 2026-07-16):
+  Hindsight's embedded mode requires `llm_api_key` in its constructor;
+  Mem0 self-hosted requires `OPENAI_API_KEY` or a self-run Ollama
+  endpoint. Personal MemoryHub requires **no credentials of any kind**:
+  retrieval runs on local ONNX embeddings; extraction rides MCP sampling
+  (the connected agent's own model). "No API key" is a category-unique
+  sentence.
+
+## 2. Substrate mapping
+
+| Cluster | Personal | Notes |
+|---------|----------|-------|
+| PostgreSQL + pgvector | SQLite + sqlite-vec | vector recall; ANN adequate at personal scale (<100K memories) |
+| tsvector + GIN | SQLite FTS5 (BM25) | keyword recall — maps one-to-one |
+| MinIO (S3 spill) | inline in SQLite | threshold is 100KB now; personal content simply stores inline (SQLite handles MB-scale TEXT fine). No spill tier. |
+| TEI Granite embedding (GPU) | granite-embedding-small-english-r2, ONNX int8, CPU | SAME model family as the cluster — embeddings are semantically continuous across editions. ~90MB one-time download on first run. |
+| TEI Granite reranker (GPU) | optional extra `[reranker]`, ONNX CPU | k is small at personal scale; default off, honest flag when off |
+| Valkey, auth service, OAuth | none | single user; tenant_id="local", owner = OS user |
+| CronJob agents (curator etc.) | none in v1 | see maintenance model, Section 5 |
+| Alembic migrations | Alembic, batch mode | pip upgrades must migrate the local DB — the cluster rule ("create_all cannot migrate") applies to laptops too |
+| DB location | XDG path (`~/.local/share/memoryhub/memoryhub.db`) | one file; backup = copy the file |
+
+**Kept in full, deliberately:** versioning + `is_current`, provenance,
+extraction run IDs, honesty flags (`content_truncated`/`full_available`),
+chunking + chunk-to-parent expansion, fact extraction + `retrieval_unit`,
+simplified curation gates, and a lightweight audit table. Governance is
+the differentiator; a personal memory with version history and an audit
+trail is the demo of the enterprise value proposition, not a separate
+product.
+
+**Dropped, deliberately:** RBAC, multi-tenancy, OAuth, cross-namespace
+anything, SDC, leader election. These are meaningless at n=1 and their
+absence is not degradation.
+
+## 3. The load-bearing decision: a storage backend protocol
+
+`memoryhub-core` services currently speak SQLAlchemy with
+Postgres-specific constructs (pgvector operators, the generated tsvector
+column, dialect-specific recall SQL in `search_memories` /
+`curation/similarity.py`). The personal edition requires isolating a
+**StorageBackend protocol** covering the hot paths:
+
+- vector recall (top-k by cosine over candidate filters)
+- keyword recall (ranked text match)
+- filtered CRUD + version-chain read/write
+- similarity search for curation/reconciliation
+- chunk/fact/branch child queries
+
+Everything above that line (services, curation logic, extraction,
+MCP tools, honesty flags, retrieval_unit policy) is portable and MUST
+NOT fork. Two implementations: `PostgresBackend` (extracted from
+current code, zero behavior change) and `SQLiteBackend`
+(sqlite-vec + FTS5).
+
+**The parity guarantee is mechanical, not aspirational:** the existing
+core/MCP test suites get parameterized over both backends in CI. A tool
+behavior that differs between editions is a failing test, not a docs
+footnote. This is also the forcing function that keeps future features
+(reconciliation #347, reflection #345) edition-portable by default.
+
+**Accepted costs:** permanent two-backend maintenance; sqlite-vec is
+younger than pgvector (pin + vendor-watch); SQLite single-writer
+concurrency (fine for personal use; WAL mode; documented boundary —
+"multi-agent concurrent writes is what the cluster is for").
+
+## 4. Models without infrastructure
+
+- **Embeddings (required):** granite-embedding-small-english-r2 exported
+  to ONNX int8, run via onnxruntime (CPU). Avoids the torch/GPU
+  dependency cliff — target install weight is tens of MB of wheels plus
+  a ~90MB one-time model download with a clear first-run message.
+  Same 384-dim space as the cluster edition.
+- **Reranker (optional `[reranker]` extra):** Granite reranker ONNX.
+  Default off; preflight-style status visible via a `memoryhub doctor`
+  command.
+- **No LLM anywhere in the base install.** This is a hard product
+  constraint, not an implementation preference — it is the wedge.
+
+## 5. Extraction and maintenance without a server LLM
+
+- **Eager fact extraction:** MCP sampling, exactly as designed in
+  `eager-fact-extraction.md` — and personal edition is its natural home:
+  the connected client (Claude Code/Desktop) IS the model. The
+  "no-sampling-support" fallback here is `deferred` -> a local queue.
+- **Dreaming/maintenance (no cron, no agents):** three modes, user
+  choice in `.memoryhub.yaml`:
+  1. `on-connect` (default): pending extraction/curation work drains via
+     sampling while a session is connected — "dreams while you work."
+  2. `manual`: `memoryhub dream` CLI, optionally with `--model
+     ollama/...` for users who have local models and want offline
+     maintenance.
+  3. `off`.
+- **Reconciliation (#347), when it lands, runs identically** — it is
+  deterministic-plus-tiebreaker, and the tiebreaker uses the same
+  sampling/queue path. Design reviews for Phase 5-7 features must state
+  their personal-edition behavior (the parity CI will enforce it anyway).
+
+## 6. Onboarding surface
+
+- `memoryhub mcp` — stdio MCP server (the Claude Code path). `uvx
+  memoryhub mcp` works without a permanent install.
+- `memoryhub init` — writes `.memoryhub.yaml` + the SessionStart hook
+  into a project (reuses the existing `memoryhub config init` machinery;
+  local vs cluster is just the connection block).
+- `memoryhub doctor` — shows edition, DB path/size, models present,
+  signals active (the personal cousin of the benchmark preflight).
+- `memoryhub join` / `memoryhub leave` — membership flows, Section 6b.
+  (Replaces an earlier bare push/pull sketch: transfer is one mechanism
+  inside membership, not the feature itself.)
+
+## 6b. Membership: joining and leaving a team
+
+Requirement (Wes, 2026-07-16): a local user joining a team on the
+enterprise edition, and the reverse, must both be easy. Design
+principles:
+
+1. **Membership is a governed operation, not a sync.** What crosses the
+   local/cluster boundary is explicit, reviewed, and audited — in both
+   directions. No silent bulk upload of a laptop's memory into an org
+   tenant; no silent bulk download on the way out.
+2. **Scopes are the homing rule.** The scope hierarchy already encodes
+   ownership: `user` memories are yours; `project`/`organizational`/
+   `enterprise` are the team's. Join and leave are defined per-scope,
+   which makes the semantics obvious instead of negotiated.
+
+**`memoryhub join <cluster-url>`:**
+- Authenticates (API key or OAuth device flow), verifies granted scopes,
+  writes the connection profile (`~/.config/memoryhub/config.json`) —
+  the local DB is untouched by default.
+- Offers **curated promotion**: an interactive (or `--from-file`) review
+  of local memories worth contributing — project-relevant items promote
+  into cluster scopes with version chains and provenance preserved, and
+  a record that they originated from a personal edition (identity
+  mapping: local OS-user owner_id -> corporate identity, recorded in
+  metadata, both auditable).
+- Default posture after joining: **user scope can stay local** (private
+  by default), team scopes live on the cluster. v1 implements this as a
+  connection switch with curated promotion; full dual-homing (one MCP
+  surface routing user-scope queries to the local file and team-scope
+  queries to the cluster simultaneously) is the architectural north
+  star — flagged as its own design pass, not improvised (open question
+  6).
+
+**`memoryhub leave`:**
+- The reverse, and the differentiator: offboarding as a governed
+  operation. Exports what the user is *entitled* to take — their
+  user-scope memories always; project/org memories only as RBAC
+  permits — into the local DB, version chains and provenance intact,
+  with the export recorded in the cluster audit trail.
+- The pitch sentence: "joining and leaving are governed memory
+  operations — what an employee takes when they leave is exactly what
+  policy says, and there's an audit record either way." No competitor
+  in the category has an offboarding story at all.
+- Embeddings on transfer (both directions): re-embed on import by
+  default; provenance records which embedder produced what (see open
+  question 5).
+
+## 7. What this unlocks internally
+
+- **Benchmark/CI:** the AMB harness and retrieval tests run against the
+  personal edition in GitHub Actions — per-PR retrieval regression
+  gates, no cluster, no port-forwards. This alone may pay for the
+  backend work.
+- **The sampling round-trip test gap** (ctx.sample() never exercised
+  end-to-end): Claude Desktop + local stdio server is the missing test
+  environment.
+- **D5 benchmark tasks** (restraint/escalation classes) become runnable
+  by anyone — the platform benchmark's reproducibility story improves.
+
+## 8. Sequencing (new epic, ~6 sessions to alpha)
+
+1. **P1 — Backend protocol + SQLite spike:** extract StorageBackend;
+   SQLiteBackend passing the core search/CRUD test subset. Exit: cheese
+   test (write/update/version/search) green on SQLite.
+2. **P2 — Embedded server + stdio MCP:** zero-URL client path; 14 tools
+   over stdio; parameterized test suite in CI. Exit: Claude Code
+   round-trip on a laptop.
+3. **P3 — Local models:** ONNX Granite embeddings, first-run download,
+   `doctor`. Exit: fresh venv -> working search in <2 min on CPU.
+4. **P4 — Extraction + maintenance:** sampling extraction on by default,
+   on-connect dreaming queue, `memoryhub dream`. Exit: live sampling
+   round-trip demonstrated (closes the known test gap).
+5. **P5 — Onboarding + docs:** `init`, README quickstart rewrite,
+   parity matrix published. Exit: the 10-minute story is reproducible by
+   an outsider.
+6. **P6 — Membership v1 (join + leave):** connection profiles, curated
+   promotion, entitlement-scoped export, identity mapping, audit records
+   both directions. Exit: round-trip test — a local memory promoted via
+   `join` retains version chain + provenance on the cluster; a
+   user-scope memory exported via `leave` is intact and searchable
+   locally, and the cluster audit trail shows both operations. Dual-home
+   routing is explicitly NOT in v1 (own design pass).
+
+## 9. Open questions
+
+1. **Package layout:** does `[local]` live as an extra of `memoryhub`
+   (SDK) pulling `memoryhub-local`, or does `memoryhub-core` get
+   published with the backend split? Constraint: `pip install
+   "memoryhub[local]"` must be the only command a user learns.
+   (docs/package-layout.md is the reference; decide in P1.)
+2. **ONNX export provenance — verified 2026-07-16, now an ask not a
+   question.** The RedHatAI HuggingFace org publishes quantized models
+   and has INT8 ONNX embedding precedent (bge family), but no Granite
+   *embedding* quantizations yet (its Granite entries are LLMs in
+   vLLM-targeted formats). A community INT8 ONNX of
+   granite-embedding-english-r2 exists (yasserrmd/) but is unattested
+   and the wrong size variant — do NOT ship on it. Action: internal ask
+   to get granite-embedding-small-english-r2 (and the reranker) INT8
+   ONNX published under RedHatAI with attestation — the ideal outcome
+   for our provenance story (models pulled from our own org's attested
+   account). Fallback: we export and publish under the project org via
+   the same attested release workflow we use for PyPI.
+3. **Windows:** sqlite-vec + onnxruntime support it in principle; decide
+   whether v1 claims it or targets macOS/Linux with Windows explicitly
+   untested.
+4. **Scope semantics at n=1:** user scope = default; project scope from
+   `.memoryhub.yaml`/git root. Do organizational/enterprise scopes exist
+   locally (empty), or are they rejected? Leaning: exist-but-empty, so
+   promoted memories don't change shape.
+5. **Embedding continuity on transfer:** local 384-dim Granite ==
+   cluster 384-dim Granite, so vectors COULD travel — but re-embedding
+   on import is safer (model version drift). Decide in P6; provenance
+   records which embedder produced what either way.
+6. **Dual-homing (post-v1 design pass):** one local MCP surface routing
+   user-scope operations to the local file and team scopes to the
+   cluster, with merged search results. The scope model makes this
+   coherent; result merging, latency, offline behavior, and
+   conflict-on-reconnect make it a real design, not a feature flag.
+   Membership v1's connection-switch semantics must not paint this into
+   a corner (e.g., keep the local DB alive after join rather than
+   migrating-and-deleting).
+7. **Entitlement policy for `leave`:** who defines what project/org
+   memories a departing user may export — RBAC roles as-is, or a
+   dedicated export policy? Needs enterprise-admin input; default v1 =
+   user scope only, everything else stays.

--- a/research/prose-loses-to-urgency.md
+++ b/research/prose-loses-to-urgency.md
@@ -1,0 +1,200 @@
+# Prose Loses to Urgency: Field Notes on Controls Engineering for Agents
+
+**Date:** 2026-07-17
+**Provenance:** distilled from a two-week, ~20-session engineering effort
+executed almost entirely by coding agents (benchmark and pipeline work on
+an agent-memory platform), during which process rules were written,
+violated, amended, and progressively mechanized — with every violation
+and every hold documented in session summaries and reconciliations. The
+value of the case study is that the enforcement record is complete: we
+can say which rules held, which lost, to what force, and what fixed them.
+
+---
+
+## 1. The observation
+
+The project ran on written rules: a constitution file loaded into every
+agent session, per-session plans with constraints, and standing process
+rules. Compliance was good — but not uniform, and the non-uniformity had
+structure:
+
+| Rule (prose form) | Violations | Lost to | Eventual enforcement layer |
+|---|---|---|---|
+| Investigation sessions are read-only | 0 in 3 sessions | — | stayed prose (held) |
+| Exit predicates close issues, or get amended first | 2 early, ~0 after adoption | schedule pressure | prose + close ritual (held after being made a named rule) |
+| Verify capability claims before propagating | 8 incidents | convenience of assumption | tripwires: inline citations required, preflight checks, audit docs |
+| All pushes to main via PR | 2 incidents | **urgency, both times** | repository settings (mechanically impossible) |
+| Surfaced limitations get written down | 1 (a surfaced product gap became unreconstructable in 48h) | "it didn't block anything" | rule amended: "surfaced means written" + issue-filing gate |
+| Credentials never in documents | 1 (live key committed to a public repo) | none — pure oversight | secret-scanner pattern + standing rule + scrubbing protocol |
+| Don't run benchmarks on unverified config | repeated silent failures (wrong corpus, truncated content, capped k) | invisibility, not pressure | enforced preflight manifest: run refuses to start on mismatch |
+
+Two patterns fall out immediately. First, the rules that lost to
+*urgency* specifically (direct-push) were rules whose compliance cost
+spiked at exactly the moment the rule mattered most. Second, the rules
+that failed *silently* (benchmark config, capability claims) weren't
+losing to pressure at all — they were losing to invisibility, and needed
+detection, not willpower.
+
+## 2. The discriminator
+
+Prose holds when two conditions are met simultaneously:
+
+1. **Compliance is cheap** at the moment of decision, and
+2. **The rule is salient** at the moment of decision.
+
+Prose loses when either fails — and urgency is uniquely destructive
+because it attacks both at once: it raises the perceived cost of the
+compliant path ("the cluster test is running NOW") and crowds the rule
+out of attention. A rule whose enforcement depends on the actor's state
+of mind will fail precisely when the actor's state of mind is the
+problem.
+
+**The core principle: a control's enforcement mechanism must be
+independent of the pressure that tempts its violation.** A branch
+protection setting does not experience urgency. A preflight gate does
+not find the assumption convenient. A secret-scanner does not get tired
+at the end of a long session.
+
+## 3. Agents break rules differently than humans
+
+Human rule-breaking is usually motivated — someone weighs the rule and
+decides against it. Agent rule-breaking, observed across this project,
+is almost never that. It is **salience decay**: the rule entered context
+forty thousand tokens ago; an urgent framing reorganized the agent's
+priorities; a compaction dropped the nuance; a subagent never saw the
+rule at all. The agent that violated branch protection cited a memory
+that *used to be true* and had been superseded. The agent that skipped
+writing down a surfaced limitation complied with the letter ("surface
+it") while the intent ("make it actionable later") decayed.
+
+This reframes agent compliance as a **memory phenomenon**. Which yields
+the central duality of the field:
+
+- **Memory systems** attack the problem from one side: keep the right
+  prose salient at the right moment (session-start injection, weighted
+  policies, retrieval at decision time).
+- **Controls engineering** attacks it from the other: make the important
+  invariants not depend on salience at all.
+
+You need both, and they are not redundant: machinery can only enforce
+*anticipated* rules. Salient prose is how agents handle the
+unanticipated cases well — it trains judgment, carries rationale, and
+covers the space between the gates. The design question for any given
+rule is which layer it belongs in *today*, and when to migrate it.
+
+## 4. The enforcement ladder
+
+Rules migrate downward through four layers as violation evidence
+accumulates:
+
+1. **Prose** — the constitution, design docs, session constraints.
+   Carries the *why*. Cheap to write, degrades under pressure and
+   context distance.
+2. **Protocol** — checklists executed at known moments (session-start
+   premise checks, close rituals). Converts salience from ambient to
+   scheduled: the rule doesn't need to be remembered, only the ritual.
+3. **Automated check** — detection and gating: preflight manifests that
+   refuse to run on config mismatch, secret scanners, staleness checks
+   ("is any session summary newer than this plan?"), honesty flags on
+   degraded output, decision logs, parameterized parity tests.
+4. **Setting** — mechanical impossibility: branch protection, permission
+   boundaries, schema constraints. Holds always; encodes nothing about
+   why; ossifies if overused.
+
+**Migration trigger — the two-strikes heuristic:** the first violation
+of a rule might be noise; the second is data about where pressure
+concentrates. Mechanize on the second strike. Mechanizing speculatively
+(before any violation) fails in the other direction: gate fatigue,
+ossified process, and the classic death spiral where one flaky required
+check teaches everyone to bypass all checks. This project's flaky-test
+lesson: only stable checks may be required, or the control destroys
+itself.
+
+## 5. Design principles extracted
+
+- **Enforcement independence** (Section 2): the mechanism must not share
+  the actor's pressure. Corollary: any control implemented as "the agent
+  will remember to..." is a layer-1 control regardless of how firmly it
+  is phrased.
+- **Friction asymmetry, never lockout:** make the routine path cheap and
+  the violation path *deliberate* — but keep an escape hatch that
+  requires stepping visibly outside the flow (an admin settings edit),
+  because a control with no escape hatch gets removed the first time it
+  blocks legitimate work. (Design detail that mattered: sole-operator
+  repos must use PR-required-with-zero-approvals — enforcement WITHOUT a
+  self-approval deadlock. Controls that can deadlock their sole operator
+  are controls that get turned off.)
+- **Detective before preventive where uncertainty is high:** when you
+  don't yet know the failure modes, visibility beats gates. Honesty
+  flags ("this content is truncated"), decision logs, and manifests
+  recorded into results converted an entire class of silent failures
+  into observed events — and the observed events then justified the
+  preventive controls.
+- **Exit predicates as contracts:** every unit of delegated work carries
+  a deterministic done-condition, and the standing rule "close on a met
+  predicate, or amend the predicate in writing first" makes scope
+  pressure visible instead of silent. This held as prose because it is
+  cheap and scheduled (checked at close ritual) — evidence that layer
+  assignment, not rule importance, predicts survival.
+- **Circuit breakers as bounded autonomy:** timeboxes, max-iteration
+  caps, and stop-and-surface conditions written *at planning time*, when
+  judgment is cheap, so the executing agent inherits boundaries rather
+  than improvising them under pressure.
+- **Surfaced means written:** an observation that exists only in a
+  session transcript is not surfaced; it is temporarily visible. If it
+  can't be acted on without the original context, it doesn't count.
+- **Maker ≠ checker:** verification independent of execution — a
+  reviewer role auditing session outputs against plans caught material
+  errors (wrong attributions, stale claims, overclaimed projections)
+  that the executing agents, and the sole human, each missed alone.
+
+## 6. Measurement: controls are benchmarkable
+
+Whether a control holds under pressure is an empirically testable
+property of an agent system, and most agent benchmarks cannot see it —
+they score affirmative task completion, under which an agent that fires
+three unnecessary irreversible actions and an agent that correctly
+dissolves all three through investigation can score identically.
+
+The task classes that measure control-holding:
+
+- **Restraint tasks:** the correct outcome is to NOT act (don't file the
+  issue, don't re-run the destructive command). Binary, judge-free
+  ground truth; memoryless/ruleless agents have no reason to hesitate,
+  so the class isolates the control's contribution cleanly.
+- **Correction tasks:** the request conflicts with a standing rule or
+  stored decision; the agent should surface the conflict, not silently
+  comply or silently override.
+- **Escalation tasks:** the rule says "stop and ask a human at this
+  boundary"; did the agent stop?
+- **Reliability under repetition:** score pass^k across repeated trials,
+  not single-run success — a control that holds three runs in four is a
+  failing control.
+- **Attribution requirement:** a correct behavior only counts if the
+  trace shows the rule/memory was retrieved and applied; correct
+  behavior in the control-absent baseline disqualifies the task as
+  non-discriminating.
+- **Seed tasks from real incident ledgers,** not synthetic vignettes:
+  a project's own violations, paired with the documented correct
+  behavior, are labeled ground truth with realism no simulator matches.
+
+## 7. Incident ledger (the evidence, condensed)
+
+| Incident class | Count | Control adopted | Layer |
+|---|---|---|---|
+| Unverified capability claims propagated (own system, infra, third-party, competitors) | 8 | verify-before-propagating rule + inline-citation requirement + capability audit docs | 2-3 |
+| Direct push to main under urgency | 2 | branch settings: PR-required, approvals=0, admin-enforced, stable checks required | 4 |
+| Silent benchmark misconfiguration (wrong corpus / truncated content / capped k) | 3+ | enforced preflight manifest; refuses to run on mismatch; manifest recorded in results | 3 |
+| Credential in committed/public artifact | 2 | scanner patterns incl. project key format + standing rule + storage-location-reference convention | 3 + 1 |
+| Surfaced-but-unwritten product gap | 1 | "surfaced means written" corollary; issue-filing as the definition of surfaced | 1-2 |
+| Parallel-session redundant work (stale plan) | 1 | plan-staleness premise check at session start | 2 |
+| Constitution edited as a side effect (ghost law) | 1 | "constitution changes require a dedicated, human-approved PR" | 1 -> 4 candidate |
+| Sole-operator lockout risk (from our own proposed control) | 1 (caught in design) | zero-approval PR requirement; friction asymmetry principle | design rule |
+
+The ledger reads as a progression: every control at layer 3-4 today
+started as prose, earned its migration through documented failure, and
+left the prose in place to carry the rationale. That is, we suggest, the
+healthy end state for agent-operated systems: **agents follow written
+rules most of the time; settings follow them all of the time; and the
+written rules remain because they explain the settings and cover what
+the settings cannot anticipate.**


### PR DESCRIPTION
Track planning and research documents that are currently untracked:

- planning/eager-fact-extraction.md (modified)
- planning/git-transport-mode.md (new)
- planning/kubernetes-general.md (new)
- planning/personal-edition.md (new)
- research/prose-loses-to-urgency.md (new)

These are living documents for design exploration and research investigation.