### PR TITLE
dreaming: Fix 0% accuracy caused by return_chunks + stale env vars

### DIFF
--- a/benchmarks/evalhub-adapter/config/dreaming-pro.yaml
+++ b/benchmarks/evalhub-adapter/config/dreaming-pro.yaml
@@ -19,7 +19,6 @@ benchmarks:
       project_id: amb-granite-pro-dreaming
       disabled_signals: domain,graph
       focus_mode: persona
-      return_chunks: "true"
       k: 10
       query_limit: 589
 experiment:

--- a/benchmarks/evalhub-adapter/config/dreaming-tiny.yaml
+++ b/benchmarks/evalhub-adapter/config/dreaming-tiny.yaml
@@ -2,7 +2,7 @@ name: dreaming-tiny
 description: 5-query micro-test for rapid iteration on dreaming pipeline
 model:
   url: https://generativelanguage.googleapis.com
-  name: gemini-3.1-flash-lite
+  name: gemini-3.1-pro-preview
   auth:
     secret_ref: gemini-api-key
 benchmarks:
@@ -16,7 +16,6 @@ benchmarks:
       project_id: amb-dreaming-tiny
       disabled_signals: domain,graph
       focus_mode: persona
-      return_chunks: "true"
       k: 10
       query_limit: 5
 experiment:

--- a/benchmarks/evalhub-adapter/config/dreaming-validate.yaml
+++ b/benchmarks/evalhub-adapter/config/dreaming-validate.yaml
@@ -1,5 +1,8 @@
-name: dreaming-smoke
-description: 20-query dreaming-mode smoke test to verify pipeline wiring
+name: dreaming-validate
+description: >
+  10-query pipeline validation run. Pro answerer against existing
+  amb-dreaming-tiny extracted memories (skip_ingestion). Validates the
+  end-to-end EvalHub machinery before committing to a full 589-query run.
 model:
   url: https://generativelanguage.googleapis.com
   name: gemini-3.1-pro-preview
@@ -13,10 +16,11 @@ benchmarks:
       dataset_variant: "32k"
       memory_provider: memoryhub
       ingestion_mode: dreaming
-      project_id: amb-granite-pro-dreaming-smoke
+      project_id: amb-dreaming-tiny
       disabled_signals: domain,graph
       focus_mode: persona
       k: 10
-      query_limit: 20
+      query_limit: 10
+      skip_ingestion: true
 experiment:
-  name: memoryhub/personamem-mcq/32k/dreaming-smoke
+  name: memoryhub/personamem-mcq/32k/dreaming-validate

--- a/benchmarks/evalhub-adapter/src/memoryhub_evalhub/adapter.py
+++ b/benchmarks/evalhub-adapter/src/memoryhub_evalhub/adapter.py
@@ -113,7 +113,7 @@ class AMBAdapter(FrameworkAdapter):
             val = params.get(param_key)
             if val is not None:
                 os.environ[env_key] = str(val)
-            elif env_key in os.environ and param_key == "disabled_signals":
+            elif env_key in os.environ:
                 del os.environ[env_key]
 
         # Wire DB connection for memoryhub provider (params override env vars)


### PR DESCRIPTION
## Summary

- Root cause of the 0% dreaming accuracy: `return_chunks: "true"` in eval configs caused empty search results at the SDK layer, making the harness short-circuit every query to `correct=False`
- Secondary: adapter's env-var wiring only cleared stale values for `disabled_signals`, letting a stale `MEMORYHUB_TENANT_ID` filter searches to the wrong tenant
- Switched dreaming-smoke/tiny answerer from Flash Lite to Pro (Flash Lite is for extraction, not MCQ answering)
- Added `dreaming-validate.yaml` config for 10-query pipeline validation with skip_ingestion

## Test plan

- [x] Local validation: 2/2 correct (100%) with Pro answerer against `amb-dreaming-tiny` with return_chunks removed
- [x] Confirmed 0% reproduces locally with return_chunks=true
- [ ] EvalHub validation job with updated config (after adapter rebuild)