### PR TITLE
memory: Add source column for provenance tracking

### DIFF
--- a/alembic/versions/026_add_source_column.py
+++ b/alembic/versions/026_add_source_column.py
@@ -1,0 +1,35 @@
+"""Add source column to memory_nodes for provenance tracking.
+
+Tracks what produced a memory: agent-written, dreaming extraction, or
+import. Enables search filtering for ablation testing and operator audit.
+
+Part of #349 (Layer 2 benchmark).
+
+Revision ID: 026_add_source_column
+Revises: 025_add_reconciliation_decisions
+Create Date: 2026-07-17
+"""
+
+from alembic import op
+
+revision = "026_add_source_column"
+down_revision = "025_add_reconciliation_decisions"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "ALTER TABLE memory_nodes ADD COLUMN source VARCHAR(20) NOT NULL DEFAULT 'agent'"
+    )
+    op.execute(
+        """ALTER TABLE memory_nodes ADD CONSTRAINT ck_memory_nodes_source
+           CHECK (source IN ('agent', 'dreaming', 'import'))"""
+    )
+    op.execute("CREATE INDEX ix_memory_nodes_source ON memory_nodes(source)")
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS ix_memory_nodes_source")
+    op.execute("ALTER TABLE memory_nodes DROP CONSTRAINT IF EXISTS ck_memory_nodes_source")
+    op.execute("ALTER TABLE memory_nodes DROP COLUMN IF EXISTS source")

--- a/benchmarks/amb-harness/extract_facts.py
+++ b/benchmarks/amb-harness/extract_facts.py
@@ -29,7 +29,7 @@ from pathlib import Path
 
 from dotenv import load_dotenv
 
-load_dotenv(dotenv_path=Path(__file__).parent / ".env", override=True)
+load_dotenv(dotenv_path=Path(__file__).parent / ".env", override=False)
 
 from memoryhub import MemoryHubClient
 from sqlalchemy import text

--- a/benchmarks/amb-harness/src/memory_bench/cli.py
+++ b/benchmarks/amb-harness/src/memory_bench/cli.py
@@ -9,7 +9,7 @@ from dotenv import load_dotenv
 from rich.console import Console
 from rich.table import Table
 
-load_dotenv(dotenv_path=Path(__file__).parents[2] / ".env", override=True)
+load_dotenv(dotenv_path=Path(__file__).parents[2] / ".env", override=False)
 
 from .dataset import REGISTRY as DATASET_REGISTRY, get_dataset
 from .llm import REGISTRY as LLM_REGISTRY, get_llm, get_answer_llm

--- a/memory-hub-mcp/src/tools/memory.py
+++ b/memory-hub-mcp/src/tools/memory.py
@@ -42,6 +42,7 @@ _SEARCH_OPTS = frozenset({
     "graph_relationship_types", "graph_boost_weight", "entities",
     "content_type", "verbose", "temporal_status", "disabled_signals",
     "tenant_id", "content_mode", "return_chunks", "retrieval_unit",
+    "source", "exclude_source",
 })
 _LIST_OPTS = frozenset({
     "max_results", "cursor", "include_branches", "current_only",

--- a/memory-hub-mcp/src/tools/search_memory.py
+++ b/memory-hub-mcp/src/tools/search_memory.py
@@ -697,6 +697,26 @@ async def search_memory(
             ),
         ),
     ] = None,
+    source: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Filter by memory source. 'agent' for agent-written memories, "
+                "'dreaming' for memories extracted by the dreaming pipeline, "
+                "'import' for bulk-imported memories. Omit to include all sources."
+            ),
+        ),
+    ] = None,
+    exclude_source: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Exclude memories from a specific source. Useful for ablation "
+                "testing: exclude_source='dreaming' reproduces the library-only "
+                "baseline by filtering out extracted memories."
+            ),
+        ),
+    ] = None,
     temporal_status: Annotated[
         str | None,
         Field(
@@ -947,6 +967,8 @@ async def search_memory(
                 disabled_signals=set(disabled_signals) if disabled_signals else None,
                 return_chunks=return_chunks,
                 retrieval_unit=retrieval_unit,
+                source=source,
+                exclude_source=exclude_source,
             )
             graph_bundle = bundle
             results = bundle.results
@@ -984,6 +1006,8 @@ async def search_memory(
                 reranker=reranker,
                 return_chunks=return_chunks,
                 retrieval_unit=retrieval_unit,
+                source=source,
+                exclude_source=exclude_source,
             )
 
             # Pattern detection on the non-focus path: embed the query

--- a/memory-hub-mcp/tests/test_source_tagging.py
+++ b/memory-hub-mcp/tests/test_source_tagging.py
@@ -1,0 +1,411 @@
+"""Tests for source tagging: default values, filtering, and reconciliation."""
+
+import inspect
+import uuid as _uuid
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+import src.tools.auth as auth_mod
+from memoryhub_core.models.schemas import (
+    MemoryNodeCreate,
+    MemoryNodeRead,
+    MemoryNodeStub,
+    MemoryScope,
+    StorageType,
+)
+from src.tools.search_memory import search_memory
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_read_node(
+    content: str = "test content",
+    source: str = "agent",
+    weight: float = 0.7,
+    owner_id: str = "wjackson",
+    tenant_id: str = "default",
+) -> MemoryNodeRead:
+    """Build a MemoryNodeRead with a configurable source field."""
+    return MemoryNodeRead(
+        id=_uuid.uuid4(),
+        parent_id=None,
+        content=content,
+        stub=content[:80],
+        storage_type=StorageType.INLINE,
+        content_ref=None,
+        weight=weight,
+        scope=MemoryScope.USER,
+        branch_type=None,
+        owner_id=owner_id,
+        tenant_id=tenant_id,
+        is_current=True,
+        version=1,
+        previous_version_id=None,
+        metadata=None,
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
+        expires_at=None,
+        has_children=False,
+        has_rationale=False,
+        branch_count=0,
+        source=source,
+    )
+
+
+def _make_stub_node(
+    stub: str = "stub text",
+    source: str = "agent",
+    weight: float = 0.5,
+) -> MemoryNodeStub:
+    """Build a MemoryNodeStub with a configurable source field."""
+    return MemoryNodeStub(
+        id=_uuid.uuid4(),
+        stub=stub,
+        scope=MemoryScope.USER,
+        weight=weight,
+        branch_type=None,
+        has_children=False,
+        has_rationale=False,
+        source=source,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Schema-level tests
+# ---------------------------------------------------------------------------
+
+
+def test_create_memory_default_source():
+    """Creating a MemoryNodeCreate without specifying source defaults to None,
+    which the service layer interprets as 'agent'."""
+    data = MemoryNodeCreate(
+        content="remember this",
+        scope="user",
+        weight=0.7,
+        owner_id="wjackson",
+    )
+    assert data.source is None
+
+
+def test_create_memory_explicit_source():
+    """Setting source='dreaming' on MemoryNodeCreate persists correctly."""
+    data = MemoryNodeCreate(
+        content="extracted from conversation",
+        scope="user",
+        weight=0.7,
+        owner_id="wjackson",
+        source="dreaming",
+    )
+    assert data.source == "dreaming"
+
+
+# ---------------------------------------------------------------------------
+# Search source filter tests
+# ---------------------------------------------------------------------------
+
+
+async def _run_search_with_source_filter(**call_kwargs):
+    """Helper that patches all dependencies and runs search_memory.
+
+    Returns the search_memories mock alongside the tool result so callers
+    can inspect forwarded kwargs.
+    """
+    mock_session = AsyncMock()
+    mock_gen = AsyncMock()
+    fake_embedding_service = AsyncMock()
+    mock_valkey = AsyncMock()
+    mock_valkey.read_compilation = AsyncMock(return_value=None)
+    mock_valkey.write_compilation = AsyncMock()
+
+    auth_mod._current_session = {
+        "user_id": "wjackson",
+        "scopes": ["user"],
+        "identity_type": "user",
+    }
+    try:
+        with (
+            patch(
+                "src.tools.search_memory.get_db_session",
+                return_value=(mock_session, mock_gen),
+            ),
+            patch(
+                "src.tools.search_memory.release_db_session",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "src.tools.search_memory.get_embedding_service",
+                return_value=fake_embedding_service,
+            ),
+            patch(
+                "src.tools.search_memory.search_memories",
+                new_callable=AsyncMock,
+                return_value=[],
+            ) as mock_search,
+            patch(
+                "src.tools.search_memory.count_search_matches",
+                new_callable=AsyncMock,
+                return_value=0,
+            ) as mock_count,
+            patch(
+                "src.tools.search_memory.get_valkey_client",
+                return_value=mock_valkey,
+            ),
+            patch(
+                "src.tools.search_memory.ROLE_ISOLATION_ENABLED",
+                False,
+            ),
+            patch(
+                "src.tools.search_memory.PROJECT_ISOLATION_ENABLED",
+                False,
+            ),
+            patch(
+                "src.tools.search_memory.detect_patterns",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+        ):
+            result = await search_memory(query="test query", **call_kwargs)
+            return result, mock_search, mock_count
+    finally:
+        auth_mod._current_session = None
+
+
+@pytest.mark.asyncio
+async def test_search_source_filter():
+    """source='dreaming' is forwarded to search_memories."""
+    result, mock_search, mock_count = await _run_search_with_source_filter(
+        source="dreaming",
+    )
+
+    _, search_kwargs = mock_search.call_args
+    assert search_kwargs.get("source") == "dreaming", (
+        f"Expected source='dreaming' forwarded to search_memories, got {search_kwargs}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_search_exclude_source():
+    """exclude_source='dreaming' is forwarded to search_memories."""
+    result, mock_search, mock_count = await _run_search_with_source_filter(
+        exclude_source="dreaming",
+    )
+
+    _, search_kwargs = mock_search.call_args
+    assert search_kwargs.get("exclude_source") == "dreaming", (
+        f"Expected exclude_source='dreaming' forwarded to search_memories, got {search_kwargs}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Search tool parameter defaults
+# ---------------------------------------------------------------------------
+
+
+def test_search_memory_source_params_have_defaults():
+    """Verify source and exclude_source parameters exist and default to None."""
+    sig = inspect.signature(search_memory)
+    params = sig.parameters
+
+    assert "source" in params
+    assert params["source"].default is None
+    assert "exclude_source" in params
+    assert params["exclude_source"].default is None
+
+
+# ---------------------------------------------------------------------------
+# Reconciliation sets source='dreaming'
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reconciliation_sets_dreaming_source():
+    """reconcile_candidate creates memories with source='dreaming'."""
+    from memoryhub_core.services.reconciliation import (
+        ExtractionCandidate,
+        reconcile_candidate,
+    )
+
+    candidate = ExtractionCandidate(
+        content="Paris is the capital of France",
+        weight=0.8,
+        content_type="experiential",
+    )
+
+    fake_node = _make_read_node(
+        content=candidate.content,
+        source="dreaming",
+    )
+    fake_curation = {
+        "blocked": False,
+        "reason": None,
+        "detail": None,
+        "similar_count": 0,
+        "nearest_id": None,
+        "nearest_score": None,
+        "flags": [],
+    }
+
+    captured_data: list[MemoryNodeCreate] = []
+
+    async def fake_create_memory(data, session, embedding_service, **kwargs):
+        captured_data.append(data)
+        return fake_node, fake_curation
+
+    with (
+        patch(
+            "memoryhub_core.services.reconciliation.create_memory",
+            new_callable=AsyncMock,
+            side_effect=fake_create_memory,
+        ),
+        patch(
+            "memoryhub_core.services.reconciliation.check_similarity",
+            new_callable=AsyncMock,
+            return_value=SimpleNamespace(
+                blocked=False,
+                similar_count=0,
+                nearest_id=None,
+                nearest_score=None,
+                flags=[],
+            ),
+        ),
+    ):
+        result = await reconcile_candidate(
+            candidate=candidate,
+            owner_id="wjackson",
+            scope="user",
+            scope_id=None,
+            session=AsyncMock(),
+            embedding_service=AsyncMock(),
+            tenant_id="default",
+            extraction_run_id="test-run-001",
+        )
+
+    assert result.action == "create"
+    assert len(captured_data) == 1
+    assert captured_data[0].source == "dreaming"
+
+
+# ---------------------------------------------------------------------------
+# Source in read response
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_source_in_read_response():
+    """read_memory returns the source field in its model_dump output."""
+    from src.tools.read_memory import read_memory
+
+    fake_node = _make_read_node(source="dreaming")
+    mock_session = AsyncMock()
+    mock_gen = AsyncMock()
+
+    auth_mod._current_session = {
+        "user_id": "wjackson",
+        "scopes": ["user"],
+        "identity_type": "user",
+    }
+    try:
+        with (
+            patch(
+                "src.tools.read_memory.get_db_session",
+                return_value=(mock_session, mock_gen),
+            ),
+            patch(
+                "src.tools.read_memory.release_db_session",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "src.tools.read_memory._read_memory",
+                new_callable=AsyncMock,
+                return_value=fake_node,
+            ),
+        ):
+            result = await read_memory(memory_id=str(fake_node.id))
+    finally:
+        auth_mod._current_session = None
+
+    assert result["source"] == "dreaming"
+
+
+# ---------------------------------------------------------------------------
+# Source in stub response
+# ---------------------------------------------------------------------------
+
+
+def test_source_in_stub_response():
+    """MemoryNodeStub includes the source field."""
+    stub = _make_stub_node(source="dreaming")
+    dumped = stub.model_dump(mode="json")
+    assert dumped["source"] == "dreaming"
+
+
+def test_stub_default_source_is_agent():
+    """MemoryNodeStub defaults source to 'agent' when not specified."""
+    stub = MemoryNodeStub(
+        id=_uuid.uuid4(),
+        stub="a stub",
+        scope=MemoryScope.USER,
+        weight=0.5,
+    )
+    assert stub.source == "agent"
+
+
+# ---------------------------------------------------------------------------
+# _build_search_filters respects source / exclude_source
+# ---------------------------------------------------------------------------
+
+
+def test_build_search_filters_source_filter():
+    """_build_search_filters adds a source == 'dreaming' clause when
+    source='dreaming' is passed."""
+    from memoryhub_core.services.memory import _build_search_filters
+
+    filters = _build_search_filters(
+        scope=None,
+        owner_id=None,
+        current_only=True,
+        authorized_scopes=None,
+        tenant_id="default",
+        source="dreaming",
+    )
+
+    assert filters is not None
+    has_source_match = False
+    for f in filters:
+        clause_str = str(f.compile(compile_kwargs={"literal_binds": True}))
+        if "source" in clause_str.lower() and "dreaming" in clause_str.lower() and "!=" not in clause_str:
+            has_source_match = True
+            break
+
+    assert has_source_match, f"Expected source='dreaming' filter in: {filters}"
+
+
+def test_build_search_filters_exclude_source():
+    """_build_search_filters adds a source != 'dreaming' clause when
+    exclude_source='dreaming' is passed."""
+    from memoryhub_core.services.memory import _build_search_filters
+
+    filters = _build_search_filters(
+        scope=None,
+        owner_id=None,
+        current_only=True,
+        authorized_scopes=None,
+        tenant_id="default",
+        exclude_source="dreaming",
+    )
+
+    assert filters is not None
+    has_exclusion = False
+    for f in filters:
+        clause_str = str(f.compile(compile_kwargs={"literal_binds": True}))
+        if "source" in clause_str.lower() and "dreaming" in clause_str.lower() and "!=" in clause_str:
+            has_exclusion = True
+            break
+
+    assert has_exclusion, f"Expected source != 'dreaming' filter in: {filters}"

--- a/memoryhub-cli/src/memoryhub_cli/main.py
+++ b/memoryhub-cli/src/memoryhub_cli/main.py
@@ -297,6 +297,12 @@ def search(
     content_type: str | None = typer.Option(
         None, "--content-type", help="Filter by content type: declarative or behavioral",
     ),
+    source: str | None = typer.Option(
+        None, "--source", help="Filter by source: agent, dreaming, import",
+    ),
+    exclude_source: str | None = typer.Option(
+        None, "--exclude-source", help="Exclude memories from a source (e.g. dreaming)",
+    ),
     output: OutputFormat = typer.Option(
         OutputFormat.table, "--output", "-o",
         help="Output format: table, json, quiet, compact",
@@ -312,6 +318,7 @@ def search(
                 query, scope=scope, max_results=max_results,
                 project_id=_project_id, domains=domains or None,
                 content_type=content_type,
+                source=source, exclude_source=exclude_source,
             )
 
     result = _run_command(_do(), output)

--- a/planning/memory-source-tagging.md
+++ b/planning/memory-source-tagging.md
@@ -1,0 +1,115 @@
+# Memory Source Tagging
+
+Status: Design (Session A of dreaming combined-mode split)
+Issue: Part of #349 (Layer 2 benchmark run)
+
+## Problem
+
+The extraction pipeline stores provenance in two places:
+`metadata.extraction_source` (JSON blob on the memory node) and the
+`conversation_extractions` join table. Neither is queryable via a simple
+SQL filter. To distinguish "agent wrote this" from "dreaming extracted
+this," you need a JSON operator or a join. This blocks three production
+use cases:
+
+1. **Ablation testing.** The combined benchmark needs to exclude dreaming
+   memories to verify they don't hurt the library-only baseline. Without
+   a queryable field, the harness must post-filter results client-side.
+2. **Operator audit.** Production operators need to see how much of a
+   project's memory is agent-written vs extracted, without writing SQL.
+3. **Search filtering.** Agents may want "only show me what I wrote" or
+   "only show me extracted facts" in production.
+
+## Decision: Column, not metadata
+
+Add a `source` column to `memory_nodes` (VARCHAR(20), indexed, default
+`'agent'`). A `metadata.source` key would avoid a migration but requires
+`metadata->>'source'` in every query and can't use a btree index.
+
+The `source` column follows the same pattern as `content_type`: a
+top-level indexed string column with a check constraint for known values.
+
+## Source values
+
+Aligned with the existing producer taxonomy in the extraction pipeline:
+
+| Value      | Producer                                        | Set by                    |
+|------------|-------------------------------------------------|---------------------------|
+| `agent`    | Written directly by an agent via MCP/SDK/API    | Default on column         |
+| `dreaming` | Extracted by the background dreaming pipeline   | reconciliation.py create  |
+| `import`   | Bulk import / git-transport / membership promo  | Future: import service    |
+
+Why not a generic `extraction` value for all extraction triggers (eager,
+background, session-close)? Because the three-trigger design in
+eager-fact-extraction.md (Section 5) treats these as distinct producer
+identities with different quality characteristics. `dreaming` is the
+background pipeline. When eager extraction ships, it gets its own value
+(`eager`). The column is VARCHAR, not a Postgres enum, so adding values
+requires only a migration to update the check constraint.
+
+The extraction_run_id prefix (`dream:`) already discriminates trigger
+type at the run level. `source` is the coarse, indexable projection that
+search filters use.
+
+## Search filter
+
+Add two optional parameters to the search path:
+
+- `source: str | None` -- include only memories from this source.
+- `exclude_source: str | None` -- exclude memories from this source.
+
+`exclude_source` is the more useful variant for ablation: "give me
+everything except dreaming memories" reproduces the library-only
+baseline. Both follow the `content_type` filter pattern: simple equality
+(or inequality) check in `_build_search_filters`, threaded through all
+search entry points.
+
+Mutual exclusivity: if both are provided, `source` wins (the inclusive
+filter is more specific).
+
+## Migration
+
+Alembic migration `026_add_source_column`:
+
+1. Add `source` column (VARCHAR(20), NOT NULL, server_default `'agent'`).
+2. Add check constraint `ck_memory_nodes_source` for known values
+   (`agent`, `dreaming`, `import`).
+3. Add btree index `ix_memory_nodes_source`.
+
+Default `'agent'` handles existing rows correctly: all 3,516
+amb-granite-pro memories and all 3,620 amb-dreaming-tiny memories were
+created before source tagging existed. The amb-dreaming-tiny memories
+SHOULD be `dreaming` but backfilling is de-scoped from this session (the
+combined benchmark ingests fresh into a copy, so new extractions get the
+correct tag at write time). Backfill is a maintenance item.
+
+## Implementation surface
+
+| Layer          | File                                          | Change                                          |
+|----------------|-----------------------------------------------|--------------------------------------------------|
+| Model          | `models/memory.py`                            | Add `source` column                              |
+| Schema         | `models/schemas.py`                           | Add `source` to Create/Read/Stub schemas          |
+| Migration      | `alembic/versions/026_add_source_column.py`   | Column + constraint + index                      |
+| Reconciliation | `services/reconciliation.py`                  | Set `source='dreaming'` on MemoryNodeCreate       |
+| Search         | `services/memory.py`                          | Add source/exclude_source to _build_search_filters |
+| MCP tool       | `memory-hub-mcp/src/tools/search_memory.py`   | Add source/exclude_source parameters              |
+| MCP dispatch   | `memory-hub-mcp/src/tools/memory.py`          | Add to _SEARCH_OPTS                               |
+| SDK            | `sdk/src/memoryhub/client.py`                 | Add source/exclude_source to search()             |
+| CLI            | `sdk/src/memoryhub/cli.py`                    | Add --source/--exclude-source flags (if present)  |
+
+## Backfill (de-scoped)
+
+Existing amb-dreaming-tiny memories should eventually get
+`source='dreaming'` via a one-shot UPDATE joined on
+`conversation_extractions`. This is hygiene, not a prerequisite for the
+combined benchmark. Add to the Haiku maintenance list.
+
+## Testing
+
+- Migration: verify column exists, default works, constraint rejects
+  invalid values.
+- Reconciliation: verify `source='dreaming'` on memories created by the
+  extraction pipeline.
+- Search: verify `source` and `exclude_source` filters return correct
+  results.
+- MCP/SDK: verify parameters are accepted and forwarded correctly.

--- a/sdk/src/memoryhub/client.py
+++ b/sdk/src/memoryhub/client.py
@@ -487,6 +487,8 @@ class MemoryHubClient:
         content_mode: Literal["stub", "full"] | None = None,
         return_chunks: bool = False,
         retrieval_unit: str | None = None,
+        source: str | None = None,
+        exclude_source: str | None = None,
     ) -> SearchResult:
         """Search memories using semantic similarity.
 
@@ -587,6 +589,10 @@ class MemoryHubClient:
             opts["return_chunks"] = True
         if retrieval_unit is not None:
             opts["retrieval_unit"] = retrieval_unit
+        if source is not None:
+            opts["source"] = source
+        if exclude_source is not None:
+            opts["exclude_source"] = exclude_source
 
         data = await self._call_action(
             "search",

--- a/src/memoryhub_core/models/memory.py
+++ b/src/memoryhub_core/models/memory.py
@@ -84,6 +84,9 @@ class MemoryNode(TimestampMixin, Base):
         String(20), nullable=False, server_default="active",
     )
 
+    # Provenance: what produced this memory (#349)
+    source: Mapped[str] = mapped_column(String(20), nullable=False, server_default="agent")
+
     # Content-addressed entity IDs for deduplication (#247)
     content_hash: Mapped[str | None] = mapped_column(String(64), nullable=True)
 
@@ -167,6 +170,7 @@ class MemoryNode(TimestampMixin, Base):
         Index("ix_memory_nodes_scope_id", "scope_id"),
         Index("ix_memory_nodes_domains", "domains", postgresql_using="gin"),
         Index("ix_memory_nodes_search_vector", "search_vector", postgresql_using="gin"),
+        Index("ix_memory_nodes_source", "source"),
         Index(
             "ix_memory_nodes_expires_at",
             "expires_at",

--- a/src/memoryhub_core/models/schemas.py
+++ b/src/memoryhub_core/models/schemas.py
@@ -82,6 +82,7 @@ class MemoryNodeCreate(BaseModel):
         default=None, description="Crosscutting knowledge domain tags (e.g., 'React', 'Spring Boot')"
     )
     content_type: ContentType = Field(default=ContentType.EXPERIENTIAL, description="Memory classification type")
+    source: str | None = Field(default=None, description="Memory source: agent, dreaming, import")
     relevant_until: datetime | None = Field(
         default=None,
         description="Semantic expiry timestamp. NULL means evergreen or version-bound.",
@@ -140,6 +141,7 @@ class MemoryNodeRead(BaseModel):
     scope_id: str | None = None
     domains: list[str] | None = None
     content_type: ContentType = ContentType.EXPERIENTIAL
+    source: str = Field(default="agent", description="What produced this memory")
     content_hash: str | None = None
     is_current: bool
     version: int
@@ -177,6 +179,7 @@ class MemoryNodeStub(BaseModel):
     has_rationale: bool = False
     domains: list[str] | None = None
     content_type: ContentType | None = None
+    source: str = Field(default="agent", description="What produced this memory")
     created_at: datetime | None = None  # needed for cache-optimized sort ordering (#175)
     content_truncated: bool = True
     full_available: bool = True

--- a/src/memoryhub_core/services/memory.py
+++ b/src/memoryhub_core/services/memory.py
@@ -187,6 +187,7 @@ async def create_memory(
         metadata_=node_metadata,
         domains=data.domains,
         content_type=data.content_type,
+        source=data.source or "agent",
         relevant_until=data.relevant_until,
         embedding=embedding,
         is_current=True,
@@ -773,6 +774,8 @@ def _build_search_filters(
     content_type: str | None = None,
     temporal_status: str | None = None,
     include_statuses: list[str] | None = None,
+    source: str | None = None,
+    exclude_source: str | None = None,
 ) -> list | None:
     """Build the SQL filter list shared by search_memories and count_search_matches.
 
@@ -897,6 +900,11 @@ def _build_search_filters(
     if content_type is not None:
         filters.append(MemoryNode.content_type == content_type)
 
+    if source is not None:
+        filters.append(MemoryNode.source == source)
+    if exclude_source is not None:
+        filters.append(MemoryNode.source != exclude_source)
+
     # Temporal status filter: restrict results by relevant_until semantics.
     if temporal_status is not None and temporal_status != "all":
         now_expr = func.now()
@@ -942,6 +950,8 @@ async def count_search_matches(
     entity_names: list[str] | None = None,
     content_type: str | None = None,
     temporal_status: str | None = None,
+    source: str | None = None,
+    exclude_source: str | None = None,
 ) -> int:
     """Count memories matching the same filter set used by search_memories.
 
@@ -962,6 +972,8 @@ async def count_search_matches(
         entity_names=entity_names,
         content_type=content_type,
         temporal_status=temporal_status,
+        source=source,
+        exclude_source=exclude_source,
     )
     if filters is None:
         return 0
@@ -1047,6 +1059,8 @@ async def search_memories(
     reranker: RerankerService | None = None,
     return_chunks: bool = False,
     retrieval_unit: str | None = None,
+    source: str | None = None,
+    exclude_source: str | None = None,
 ) -> list[tuple[MemoryNodeRead | MemoryNodeStub, float]]:
     """Search memories using pgvector cosine similarity with optional keyword recall.
 
@@ -1087,6 +1101,8 @@ async def search_memories(
         entity_names=entity_names,
         content_type=content_type,
         temporal_status=temporal_status,
+        source=source,
+        exclude_source=exclude_source,
     )
     if filters is None:
         return []
@@ -1140,7 +1156,9 @@ async def search_memories(
                     scope=node.scope, weight=node.weight,
                     branch_type=node.branch_type, has_children=has_children,
                     has_rationale=has_rationale,
-                    content_type=node.content_type, created_at=node.created_at,
+                    content_type=node.content_type,
+                    source=getattr(node, 'source', 'agent'),
+                    created_at=node.created_at,
                 ), score))
         return results
 
@@ -1255,7 +1273,9 @@ async def search_memories(
                 scope=node.scope, weight=node.weight,
                 branch_type=node.branch_type, has_children=has_children,
                 has_rationale=has_rationale,
-                content_type=node.content_type, created_at=node.created_at,
+                content_type=node.content_type,
+                source=getattr(node, 'source', 'agent'),
+                created_at=node.created_at,
             ), rrf_score))
     used_reranker = (
         reranker is not None
@@ -1435,6 +1455,8 @@ async def search_memories_with_focus(
     disabled_signals: set[str] | None = None,
     return_chunks: bool = False,
     retrieval_unit: str | None = None,
+    source: str | None = None,
+    exclude_source: str | None = None,
 ) -> FocusedSearchResult:
     """Two-vector retrieval with session focus bias.
 
@@ -1488,6 +1510,8 @@ async def search_memories_with_focus(
             reranker=reranker,
             return_chunks=return_chunks,
             retrieval_unit=retrieval_unit,
+            source=source,
+            exclude_source=exclude_source,
         )
         return FocusedSearchResult(results=plain)
 
@@ -1511,6 +1535,8 @@ async def search_memories_with_focus(
         entity_names=entity_names,
         content_type=content_type,
         temporal_status=temporal_status,
+        source=source,
+        exclude_source=exclude_source,
     )
     if filters is None:
         return FocusedSearchResult(
@@ -1850,6 +1876,7 @@ async def search_memories_with_focus(
                         has_children=has_children,
                         has_rationale=has_rationale,
                         content_type=node.content_type,
+                        source=getattr(node, 'source', 'agent'),
                         created_at=node.created_at,
                     ),
                     relevance_score,
@@ -2205,6 +2232,7 @@ def node_to_read(
         tenant_id=node.tenant_id,
         domains=node.domains,
         content_type=node.content_type,
+        source=getattr(node, 'source', 'agent'),
         content_hash=getattr(node, 'content_hash', None),
         is_current=node.is_current,
         version=node.version,

--- a/src/memoryhub_core/services/reconciliation.py
+++ b/src/memoryhub_core/services/reconciliation.py
@@ -166,6 +166,7 @@ async def reconcile_candidate(
                 metadata=candidate.metadata,
                 domains=candidate.domains,
                 content_type=candidate.content_type,
+                source="dreaming",
             )
             if actor_id:
                 data.actor_id = actor_id


### PR DESCRIPTION
## Summary

- Add `source` column to `memory_nodes` (VARCHAR(20), default `agent`, values: agent/dreaming/import) with Alembic migration 026, check constraint, and btree index
- Set `source=dreaming` in reconciliation when creating memories from thread extraction
- Add `source`/`exclude_source` search filters through all layers: service, MCP tool, SDK client, CLI
- Fix dotenv `override=True` to `override=False` in amb-harness (two-strikes mechanize fix for the poisoned API key and false 90% validation incidents)

Design: `planning/memory-source-tagging.md`
Part of #349 (Layer 2 benchmark -- combined ingestion mode)

## Test plan

- [x] 11 new source tagging tests (schema defaults, search filter forwarding, reconciliation source, read/stub response, _build_search_filters)
- [x] 578 MCP server tests pass (zero regressions)
- [x] 262 SDK tests pass (zero regressions)
- [ ] Deploy migration 026 to cluster and verify column exists
- [ ] Rebuild MCP server and verify source/exclude_source parameters accepted
- [ ] Verify dreaming extraction sets source=dreaming on new memories