### PR TITLE
harness: Add combined ingestion mode + source search filters

### DIFF
--- a/benchmarks/amb-harness/src/memory_bench/memory/memoryhub.py
+++ b/benchmarks/amb-harness/src/memory_bench/memory/memoryhub.py
@@ -76,6 +76,9 @@ class MemoryHubProvider(MemoryProvider):
         self._ingestion_mode: str = "library"
         self._extraction_model: str | None = None
         self._extraction_model_url: str | None = None
+        self._retrieval_unit: str | None = None
+        self._source_filter: str | None = None
+        self._exclude_source: str | None = None
 
     def prepare(self, store_dir: Path, unit_ids: set[str] | None = None, reset: bool = True) -> None:
         self._url = os.environ.get("MEMORYHUB_URL")
@@ -114,13 +117,18 @@ class MemoryHubProvider(MemoryProvider):
         self._extract_facts = raw_extract if raw_extract in ("eager", "background", "off") else None
 
         raw_mode = os.environ.get("MEMORYHUB_INGESTION_MODE", "library").strip().lower()
-        if raw_mode not in ("library", "dreaming"):
+        if raw_mode not in ("library", "dreaming", "combined"):
             raise RuntimeError(
-                f"MEMORYHUB_INGESTION_MODE must be 'library' or 'dreaming', got '{raw_mode}'"
+                f"MEMORYHUB_INGESTION_MODE must be 'library', 'dreaming', or 'combined', got '{raw_mode}'"
             )
         self._ingestion_mode = raw_mode
         self._extraction_model = os.environ.get("MEMORYHUB_EXTRACTION_MODEL", "").strip() or None
         self._extraction_model_url = os.environ.get("MEMORYHUB_EXTRACTION_MODEL_URL", "").strip() or None
+
+        raw_ru = os.environ.get("MEMORYHUB_RETRIEVAL_UNIT", "").strip().lower()
+        self._retrieval_unit = raw_ru if raw_ru in ("facts", "chunks", "parents", "auto") else None
+        self._source_filter = os.environ.get("MEMORYHUB_SOURCE", "").strip() or None
+        self._exclude_source = os.environ.get("MEMORYHUB_EXCLUDE_SOURCE", "").strip() or None
 
         self._doc_to_memory_id.clear()
         self._memory_to_doc_id.clear()
@@ -136,6 +144,8 @@ class MemoryHubProvider(MemoryProvider):
 
         if self._ingestion_mode == "dreaming":
             await self._run_dreaming_ingest(documents)
+        elif self._ingestion_mode == "combined":
+            await self._run_combined_ingest(documents)
         else:
             await self._run_library_ingest(documents)
 
@@ -268,6 +278,14 @@ class MemoryHubProvider(MemoryProvider):
             total_personas, total_sessions, total_extractions, total_failures,
         )
 
+    async def _run_combined_ingest(self, documents: list[Document]) -> None:
+        """Combined mode: library ingest first, then dreaming extraction on top."""
+        logger.info("Combined mode: starting library ingest phase")
+        await self._run_library_ingest(documents)
+        logger.info("Combined mode: starting dreaming extraction phase")
+        await self._run_dreaming_ingest(documents)
+        logger.info("Combined mode: both phases complete")
+
     async def _reset_benchmark_data(self) -> None:
         """Delete previous benchmark data via raw SQL (test scaffolding)."""
         engine = create_async_engine(self._db_url, pool_size=2)
@@ -353,6 +371,12 @@ class MemoryHubProvider(MemoryProvider):
             if self._return_chunks:
                 search_kwargs["return_chunks"] = True
                 search_kwargs["raw_results"] = True
+            if self._retrieval_unit:
+                search_kwargs["retrieval_unit"] = self._retrieval_unit
+            if self._source_filter:
+                search_kwargs["source"] = self._source_filter
+            if self._exclude_source:
+                search_kwargs["exclude_source"] = self._exclude_source
             results = await client.search(**search_kwargs)
 
         documents = []

--- a/planning/combined-ingestion-mode.md
+++ b/planning/combined-ingestion-mode.md
@@ -1,0 +1,121 @@
+# Combined Ingestion Mode
+
+Status: Design (Session B of dreaming combined-mode split)
+Issue: Part of #349 (Layer 2 benchmark run)
+
+## Problem
+
+The dreaming benchmark tests extraction in isolation: extracted facts
+REPLACE original session transcripts instead of AUGMENTING them.
+In production, dreaming is additive -- agents write memories, the
+pipeline extracts facts asynchronously, and search returns both. A
+combined benchmark models this production behavior.
+
+## Design: library-first, then dreaming-on-top
+
+Combined mode runs two phases sequentially in the same project:
+
+1. **Library ingest** -- call `_run_library_ingest(documents)`. This
+   writes each session as a memory (parent + chunks) via `client.write()`.
+   All memories get `source=agent` (the default).
+
+2. **Dreaming ingest** -- call `_run_dreaming_ingest(documents)`. This
+   creates threads per persona, appends session messages, and calls
+   `extract_thread()`. Extracted facts get `source=dreaming` (set by
+   reconciliation).
+
+This models production: agents write memories during conversations,
+dreaming runs asynchronously afterward. Both coexist in the same
+project.
+
+## Pool discipline
+
+Combined mode puts transcripts (parents/chunks) AND extracted facts in
+one search pool. This is exactly the units-competing-in-RRF scenario
+that `retrieval_unit` (planning/eager-fact-extraction.md Section 6) was
+designed to govern.
+
+**Default search behavior**: no `retrieval_unit` set. Let facts,
+chunks, and parents compete in RRF. The reranker should sort by
+relevance. The registered prediction says combined ~ 84.9% +/- noise
+because transcripts already saturate recall at 4-7 parents/persona.
+
+**If accuracy drops below 84.9%**: that's a pool-discipline failure.
+Diagnose with `retrieval_unit=auto` (facts-first with parent fallback)
+to separate the units. This is a diagnostic step, not the default.
+
+**Ablation support via source filter**: `exclude_source=dreaming`
+reproduces the library-only baseline without re-ingesting.
+
+## Search parameters
+
+Add three env vars to the harness search path, following the existing
+`MEMORYHUB_DISABLED_SIGNALS` pattern:
+
+| Env var                    | Maps to              | Purpose                      |
+|----------------------------|----------------------|------------------------------|
+| `MEMORYHUB_RETRIEVAL_UNIT` | `retrieval_unit`     | Control unit class returned  |
+| `MEMORYHUB_SOURCE`         | `source`             | Include only this source     |
+| `MEMORYHUB_EXCLUDE_SOURCE` | `exclude_source`     | Exclude this source          |
+
+These are search-time filters, not ingestion-time. They compose with
+existing parameters (disabled_signals, focus, etc.).
+
+## Project isolation
+
+Fresh project for the combined run (e.g., `amb-combined-pro`).
+amb-granite-pro (84.9% baseline) must not be modified.
+
+## Skip-ingestion shortcut
+
+If a project already has library memories from a previous run, set
+`MEMORYHUB_INGESTION_MODE=combined` with `--skip-ingestion` to skip
+the library phase. The dreaming phase creates threads and extracts on
+top of existing data. But for the benchmark, always ingest fresh to
+ensure clean state.
+
+## Implementation
+
+All changes in one file:
+`benchmarks/amb-harness/src/memory_bench/memory/memoryhub.py`
+
+1. Add `"combined"` to the mode validation set (line 117).
+2. Add a third branch in `_run_ingest` for combined mode.
+3. New method `_run_combined_ingest(documents)`:
+   - Calls `_run_library_ingest(documents)` first.
+   - Then calls `_run_dreaming_ingest(documents)`.
+   - Both methods already handle project creation idempotently.
+4. Add `retrieval_unit`, `source`, `exclude_source` to `_run_retrieve`
+   search kwargs (conditional on env vars being set).
+
+## Running the benchmark
+
+```bash
+# Combined mode -- fresh ingest
+MEMORYHUB_INGESTION_MODE=combined \
+MEMORYHUB_PROJECT_ID=amb-combined-pro \
+MEMORYHUB_EXTRACTION_MODEL=gemini-3.1-flash-lite \
+MEMORYHUB_EXTRACTION_MODEL_URL=https://generativelanguage.googleapis.com/v1beta/openai \
+uv run omb run --name combined-pro --description "Combined library+dreaming"
+
+# Ablation: exclude dreaming
+MEMORYHUB_EXCLUDE_SOURCE=dreaming \
+MEMORYHUB_PROJECT_ID=amb-combined-pro \
+uv run omb run --name combined-no-dreaming --skip-ingestion
+
+# Ablation: dreaming-only
+MEMORYHUB_SOURCE=dreaming \
+MEMORYHUB_PROJECT_ID=amb-combined-pro \
+uv run omb run --name combined-dreaming-only --skip-ingestion
+```
+
+## Predictions (registered per standing practice)
+
+- **Aggregate**: combined ~ 84.9% +/- noise (transcripts saturate
+  recall). Upside is category-level, not aggregate.
+- **Category-level**: facts' synthesis signature may lift generalization
+  and reasons questions even alongside transcripts.
+- **Below 84.9%**: pool-discipline failure. Diagnose with
+  `MEMORYHUB_RETRIEVAL_UNIT=auto`.
+- **exclude_source=dreaming**: should reproduce library-only 84.9%.
+- **source=dreaming**: should approximate dreaming-only 70%.

--- a/sdk/src/memoryhub/models.py
+++ b/sdk/src/memoryhub/models.py
@@ -41,6 +41,7 @@ class Memory(BaseModel):
     result_type: str | None = None  # "full" or "stub"
     is_appendix: bool | None = None  # True when result is cache-stable appendix (#175)
     content_type: str | None = None  # "declarative" or "behavioral"
+    source: str = "agent"  # "agent", "dreaming", or "import"
     content_truncated: bool = False
     full_available: bool = False
 


### PR DESCRIPTION
## Summary

- Add `combined` as third `MEMORYHUB_INGESTION_MODE` value: runs library ingest first, then dreaming extraction on top (models production behavior)
- Add `MEMORYHUB_RETRIEVAL_UNIT`, `MEMORYHUB_SOURCE`, `MEMORYHUB_EXCLUDE_SOURCE` env vars to harness search path for ablation testing
- Add `source` field to SDK `Memory` model so consumers can see what produced each memory
- Design doc: `planning/combined-ingestion-mode.md`

Part of #349 (Layer 2 benchmark -- combined ingestion mode)

## Test plan

- [x] Source filters validated end-to-end against live MCP server (amb-granite-pro project)
- [x] `source=agent` returns all results, `source=dreaming` returns 0 (correct for pre-tagged data)
- [x] `exclude_source=dreaming` matches unfiltered results
- [x] SDK `Memory.source` field populates correctly from MCP response
- [x] Harness lints clean
- [ ] Full combined run (Session C, separate PR)