### PR TITLE
harness: Add preflight smoke checks + correct combined run analysis

### DIFF
--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -116,11 +116,26 @@ Result file: `outputs/personamem/granite-pro/rag/32k.json`
 | hybrid-search | 512-token chunking, dense+sparse embeddings | 84.4% |
 | Cognee | Chunking + graph entity extraction | 81.8% |
 
-**Key finding:** Combined mode (library + dreaming) matches the library-only baseline exactly (84.9%). This validates two things:
+**Per-category comparison (library-only vs combined):**
 
-1. **Dreaming extraction is non-destructive.** Adding 985 extracted facts to the search pool alongside 3,468 session memories does not degrade retrieval quality. The reranker correctly sorts the mixed pool by relevance.
+| Category | Library | Combined | Delta |
+|----------|---------|----------|-------|
+| recall_user_shared_facts | 104/129 (80.6%) | 109/129 (84.5%) | +3.9pp |
+| track_full_preference_evolution | 131/139 (94.2%) | 128/139 (92.1%) | -2.2pp |
+| recalling_the_reasons_behind_previous_updates | 91/99 (91.9%) | 91/99 (91.9%) | 0.0pp |
+| generalizing_to_new_scenarios | 53/57 (93.0%) | 52/57 (91.2%) | -1.8pp |
+| provide_preference_aligned_recommendations | 50/55 (90.9%) | 50/55 (90.9%) | 0.0pp |
+| recalling_facts_mentioned_by_the_user | 15/17 (88.2%) | 15/17 (88.2%) | 0.0pp |
+| suggest_new_ideas | 56/93 (60.2%) | 55/93 (59.1%) | -1.1pp |
+| **Overall** | **500/589 (84.9%)** | **500/589 (84.9%)** | **0.0pp** |
 
-2. **The aggregate prediction was correct.** Recall saturates at 4-7 parents/persona at k=70; the extracted facts don't add enough new recall to move the aggregate number. Per-category analysis (generalization, reasons) may reveal category-level lifts from the facts' synthesis signature -- this is where the dreaming value should appear.
+**Key finding: identical retrieval, answering noise.** Comparing the retrieved context for all 589 queries reveals that the library-only and combined runs return byte-identical context. The dreaming facts (985 short extracted statements) never rank high enough to appear in the top-k retrieval results alongside the 3,468 longer session memories. The 12 queries that flipped between runs (6 gained, 6 lost) are pure Gemini Pro answering non-determinism, not retrieval signal.
+
+**Flipped query breakdown:**
+- **Gained** (library wrong, combined right): 5 in `recall_user_shared_facts`, 1 in `suggest_new_ideas`
+- **Lost** (library right, combined wrong): 3 in `track_full_preference_evolution`, 1 in `generalizing_to_new_scenarios`, 2 in `suggest_new_ideas`
+
+**Interpretation:** The registered prediction that dreaming's synthesis signature would lift generalization and reasons categories is not supported. The per-category deltas are LLM noise, not retrieval signal. Dreaming extraction is confirmed non-destructive (identical retrieval), but the extracted facts are too short and too numerous (985 facts competing against 3,468 longer documents) to surface in the top-k ranking. This points to a retrieval-side improvement opportunity: boosting short, high-signal extracted facts in the ranking function, or using a dedicated fact retrieval channel separate from the session memory search.
 
 **Source tagging validated:** The `source` column (migration 026) correctly tags library memories as `agent` and extracted facts as `dreaming`. The `exclude_source` search filter enables ablation testing without re-ingestion.
 

--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -129,13 +129,26 @@ Result file: `outputs/personamem/granite-pro/rag/32k.json`
 | suggest_new_ideas | 56/93 (60.2%) | 55/93 (59.1%) | -1.1pp |
 | **Overall** | **500/589 (84.9%)** | **500/589 (84.9%)** | **0.0pp** |
 
-**Key finding: identical retrieval, answering noise.** Comparing the retrieved context for all 589 queries reveals that the library-only and combined runs return byte-identical context. The dreaming facts (985 short extracted statements) never rank high enough to appear in the top-k retrieval results alongside the 3,468 longer session memories. The 12 queries that flipped between runs (6 gained, 6 lost) are pure Gemini Pro answering non-determinism, not retrieval signal.
+**Key finding: tenant mismatch invalidates this run.** Post-hoc analysis (2026-07-20) revealed that the dreaming memories were ingested under `tenant_id='default'` while searches used `tenant_id='amb-benchmark'`. The two memory populations were never visible to the same search. This run is effectively a duplicate of the library-only baseline, not a combined test.
 
-**Flipped query breakdown:**
-- **Gained** (library wrong, combined right): 5 in `recall_user_shared_facts`, 1 in `suggest_new_ideas`
-- **Lost** (library right, combined wrong): 3 in `track_full_preference_evolution`, 1 in `generalizing_to_new_scenarios`, 2 in `suggest_new_ideas`
+**Evidence:** All 589 queries return byte-identical retrieved context between the library-only and combined runs. The 12 queries that flipped (6 gained, 6 lost) are pure Gemini Pro answering non-determinism. A direct DB query confirms: `SELECT source, tenant_id, COUNT(*) FROM memory_nodes WHERE scope_id = 'amb-combined-pro' GROUP BY source, tenant_id` returns `agent/amb-benchmark: 3,468` and `dreaming/default: 985`.
 
-**Interpretation:** The registered prediction that dreaming's synthesis signature would lift generalization and reasons categories is not supported. The per-category deltas are LLM noise, not retrieval signal. Dreaming extraction is confirmed non-destructive (identical retrieval), but the extracted facts are too short and too numerous (985 facts competing against 3,468 longer documents) to surface in the top-k ranking. This points to a retrieval-side improvement opportunity: boosting short, high-signal extracted facts in the ranking function, or using a dedicated fact retrieval channel separate from the session memory search.
+**Root cause:** The harness `_run_dreaming_ingest()` creates threads and extracts facts via the MCP server, but never passes `tenant_id` to the thread/extraction pipeline. The library path explicitly passes `tenant_id` on each `write()` call; the dreaming path uses the session default tenant (`default`).
+
+**Per-category deltas (not meaningful given the above, but recorded for completeness):**
+
+| Category | Library | Combined | Delta |
+|----------|---------|----------|-------|
+| recall_user_shared_facts | 104/129 (80.6%) | 109/129 (84.5%) | +3.9pp |
+| track_full_preference_evolution | 131/139 (94.2%) | 128/139 (92.1%) | -2.2pp |
+| recalling_the_reasons_behind_previous_updates | 91/99 (91.9%) | 91/99 (91.9%) | 0.0pp |
+| generalizing_to_new_scenarios | 53/57 (93.0%) | 52/57 (91.2%) | -1.8pp |
+| provide_preference_aligned_recommendations | 50/55 (90.9%) | 50/55 (90.9%) | 0.0pp |
+| recalling_facts_mentioned_by_the_user | 15/17 (88.2%) | 15/17 (88.2%) | 0.0pp |
+| suggest_new_ideas | 56/93 (60.2%) | 55/93 (59.1%) | -1.1pp |
+| **Overall** | **500/589 (84.9%)** | **500/589 (84.9%)** | **0.0pp** |
+
+**Status:** This run must be re-done after fixing the tenant mismatch in the dreaming ingestion path. A preflight smoke-check system was added to `omb run` (2026-07-20) to prevent this class of bug from reaching full runs.
 
 **Source tagging validated:** The `source` column (migration 026) correctly tags library memories as `agent` and extracted facts as `dreaming`. The `exclude_source` search filter enables ablation testing without re-ingestion.
 

--- a/benchmarks/amb-harness/src/memory_bench/cli.py
+++ b/benchmarks/amb-harness/src/memory_bench/cli.py
@@ -47,6 +47,8 @@ def run(
     skip_answer: bool = typer.Option(False, "--skip-answer", help="Skip retrieval and answer generation entirely — re-judge cached answers from the previous run"),
     only_failed: bool = typer.Option(False, "--only-failed", help="Restrict queries to those that failed in the previous run"),
     show_raw: bool = typer.Option(False, "--show-raw", help="Print raw provider response after each query"),
+    no_preflight: bool = typer.Option(False, "--no-preflight", help="Skip preflight smoke checks (MemoryHub + skip-ingestion only)"),
+    expect_sources: str = typer.Option(None, "--expect-sources", help="Comma-separated sources required in preflight smoke results (e.g. 'agent,dreaming')"),
     output_dir: Path = typer.Option(Path("outputs"), "--output-dir", "-o"),
     name: str = typer.Option(None, "--name", "-n", help="Run name used as output directory (defaults to memory provider name)"),
     description: str = typer.Option(None, "--description", "-d", help="Optional description for this run (stored in the result JSON)"),
@@ -79,6 +81,8 @@ def run(
         show_raw=show_raw,
         run_name=name,
         description=description,
+        no_preflight=no_preflight,
+        expect_sources=[s.strip() for s in expect_sources.split(",") if s.strip()] if expect_sources else None,
     )
 
     cat_label = f"/{category}" if category else ""

--- a/benchmarks/amb-harness/src/memory_bench/memory/memoryhub.py
+++ b/benchmarks/amb-harness/src/memory_bench/memory/memoryhub.py
@@ -390,5 +390,40 @@ class MemoryHubProvider(MemoryProvider):
 
         return documents, None
 
+    async def preflight_search(self, query: str, user_id: str | None = None):
+        """Search returning raw Memory objects with source metadata.
+
+        Used by the preflight checker to inspect source distribution
+        without modifying the benchmark retrieve pipeline.
+        """
+        owner = f"amb-{user_id}" if user_id else "amb-default"
+
+        async with MemoryHubClient(url=self._url, api_key=self._api_key) as client:
+            search_kwargs: dict[str, Any] = dict(
+                query=query,
+                max_results=self._resolve_k(None),
+                owner_id=owner,
+                project_id=self._project_id,
+                weight_threshold=0.0,
+                mode="full_only",
+                max_response_tokens=0,
+                disabled_signals=self._disabled_signals,
+            )
+            if self._tenant_id:
+                search_kwargs["tenant_id"] = self._tenant_id
+            if self._focus_mode == "persona":
+                name = self._extract_persona_name(query)
+                if name:
+                    search_kwargs["focus"] = name
+            if self._retrieval_unit:
+                search_kwargs["retrieval_unit"] = self._retrieval_unit
+            if self._source_filter:
+                search_kwargs["source"] = self._source_filter
+            if self._exclude_source:
+                search_kwargs["exclude_source"] = self._exclude_source
+            results = await client.search(**search_kwargs)
+
+        return results.results
+
     def cleanup(self) -> None:
         pass

--- a/benchmarks/amb-harness/src/memory_bench/preflight.py
+++ b/benchmarks/amb-harness/src/memory_bench/preflight.py
@@ -1,0 +1,182 @@
+"""Preflight smoke checks for benchmark runs.
+
+Runs 3 deterministic queries through the real search pipeline before
+the main loop starts. Catches data-level problems (wrong tenant,
+missing source, empty results) that would otherwise waste hundreds
+of API calls producing invalid results.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections import Counter
+from dataclasses import dataclass, field
+
+from rich.console import Console
+from rich.panel import Panel
+from rich.text import Text
+
+from .models import Query
+
+logger = logging.getLogger(__name__)
+
+SMOKE_QUERY_COUNT = 3
+
+
+@dataclass
+class SmokeResult:
+    query_id: str
+    query_preview: str
+    memories_returned: int
+    context_chars: int
+    source_counts: dict[str, int]
+
+
+@dataclass
+class PreflightResult:
+    passed: bool
+    aborted: bool
+    abort_reason: str | None = None
+    warnings: list[str] = field(default_factory=list)
+    smoke_results: list[SmokeResult] = field(default_factory=list)
+
+
+async def run_preflight(
+    memory,
+    queries: list[Query],
+    expect_sources: list[str] | None,
+    answer_llm_label: str = "",
+    console: Console | None = None,
+) -> PreflightResult:
+    """Run preflight checks and print results.
+
+    Args:
+        memory: A MemoryHubProvider instance (must have preflight_search).
+        queries: The full query set (3 will be selected deterministically).
+        expect_sources: Source values that must appear in smoke results.
+        answer_llm_label: Display label for the answer LLM.
+        console: Rich console for output. Uses stderr default if None.
+    """
+    if console is None:
+        console = Console(stderr=True)
+
+    smoke_queries = sorted(queries, key=lambda q: q.id)[:SMOKE_QUERY_COUNT]
+    if not smoke_queries:
+        return PreflightResult(passed=False, aborted=True, abort_reason="No queries loaded.")
+
+    lines = Text()
+    lines.append("Config:\n", style="bold")
+    lines.append(f"  project:        {memory._project_id}\n")
+    lines.append(f"  tenant:         {memory._tenant_id or '(default)'}\n")
+    lines.append(f"  source filter:  {memory._source_filter or '(none)'}\n")
+    lines.append(f"  exclude_source: {memory._exclude_source or '(none)'}\n")
+    if answer_llm_label:
+        lines.append(f"  answer LLM:     {answer_llm_label}\n")
+    lines.append("\n")
+
+    smoke_results: list[SmokeResult] = []
+    all_source_counts: Counter[str] = Counter()
+    total_memories = 0
+
+    for i, q in enumerate(smoke_queries, 1):
+        memories = await memory.preflight_search(
+            query=q.query, user_id=q.user_id,
+        )
+        source_counts: dict[str, int] = {}
+        context_chars = 0
+        for m in memories:
+            src = getattr(m, "source", "unknown")
+            source_counts[src] = source_counts.get(src, 0) + 1
+            context_chars += len(m.content or "")
+
+        all_source_counts.update(source_counts)
+        total_memories += len(memories)
+
+        sr = SmokeResult(
+            query_id=q.id,
+            query_preview=q.query[:60].replace("\n", " "),
+            memories_returned=len(memories),
+            context_chars=context_chars,
+            source_counts=source_counts,
+        )
+        smoke_results.append(sr)
+
+        src_label = ", ".join(f"{k}={v}" for k, v in sorted(source_counts.items()))
+        lines.append(f"  #{i} ")
+        lines.append(f"[{q.id[:8]}] ", style="dim")
+        lines.append(f"{len(memories)} memories, {context_chars:,} chars")
+        if src_label:
+            lines.append(f"  [{src_label}]")
+        lines.append("\n")
+
+    # --- Abort / warn logic ---
+    result = PreflightResult(passed=True, aborted=False, smoke_results=smoke_results)
+
+    if total_memories == 0:
+        result.passed = False
+        result.aborted = True
+        result.abort_reason = (
+            f"All {SMOKE_QUERY_COUNT} smoke queries returned 0 memories.\n"
+            f"    project: {memory._project_id}  tenant: {memory._tenant_id or '(default)'}\n"
+            f"    source filter: {memory._source_filter or '(none)'}  "
+            f"exclude_source: {memory._exclude_source or '(none)'}\n"
+            f"    Check that memories exist under this tenant+project with the expected source."
+        )
+
+    elif memory._source_filter and memory._source_filter not in all_source_counts:
+        result.passed = False
+        result.aborted = True
+        found = ", ".join(sorted(all_source_counts)) or "(none)"
+        result.abort_reason = (
+            f"Source filter '{memory._source_filter}' matched 0 memories "
+            f"across {SMOKE_QUERY_COUNT} smoke queries.\n"
+            f"    Sources found: {found}\n"
+            f"    tenant: {memory._tenant_id or '(default)'}  project: {memory._project_id}"
+        )
+
+    if expect_sources and not result.aborted:
+        missing = [s for s in expect_sources if s not in all_source_counts]
+        if missing:
+            result.passed = False
+            result.aborted = True
+            found = ", ".join(sorted(all_source_counts)) or "(none)"
+            result.abort_reason = (
+                f"Expected source(s) not found in smoke results: {', '.join(missing)}\n"
+                f"    Sources found: {found}\n"
+                f"    Use --expect-sources to list only the sources you expect."
+            )
+
+    # Warn about single-source results when the operator hasn't declared expectations
+    if (
+        not result.aborted
+        and not memory._source_filter
+        and not memory._exclude_source
+        and not expect_sources
+        and len(all_source_counts) == 1
+        and total_memories > 0
+    ):
+        only_source = next(iter(all_source_counts))
+        result.warnings.append(
+            f"All {total_memories} returned memories are source={only_source}. "
+            f"If this run expects multiple sources, investigate or use --expect-sources."
+        )
+
+    # --- Print panel ---
+    if result.aborted:
+        lines.append("\n  ", style="")
+        lines.append("ABORT", style="bold red")
+        lines.append(f"  {result.abort_reason.split(chr(10))[0]}\n")
+        console.print(Panel(lines, title="Preflight Check", border_style="red"))
+    elif result.warnings:
+        lines.append("\n  ", style="")
+        lines.append("WARN", style="bold yellow")
+        lines.append(f"  {result.warnings[0]}\n")
+        console.print(Panel(lines, title="Preflight Check", border_style="yellow"))
+    else:
+        lines.append("\n  ", style="")
+        lines.append("PASS", style="bold green")
+        lines.append(f"  {total_memories} memories across {SMOKE_QUERY_COUNT} queries\n")
+        console.print(Panel(lines, title="Preflight Check", border_style="green"))
+
+    return result

--- a/benchmarks/amb-harness/src/memory_bench/runner.py
+++ b/benchmarks/amb-harness/src/memory_bench/runner.py
@@ -67,6 +67,8 @@ class EvalRunner:
         show_raw: bool = False,
         run_name: str | None = None,
         description: str | None = None,
+        no_preflight: bool = False,
+        expect_sources: list[str] | None = None,
     ) -> EvalSummary:
         effective_name = run_name or memory.name
         cat_label = f"  [bold]Category:[/bold] {category}" if category else ""
@@ -143,6 +145,26 @@ class EvalRunner:
             unit_ids = {uid for doc in documents if (uid := dataset.get_isolation_id(doc)) is not None}
 
         memory.prepare(store_dir, unit_ids=unit_ids, reset=not skip_ingestion)
+
+        # Preflight smoke check (MemoryHub + skip-ingestion only)
+        if not no_preflight and skip_ingestion:
+            from .memory.memoryhub import MemoryHubProvider
+            if isinstance(memory, MemoryHubProvider):
+                from .preflight import run_preflight
+                import typer as _typer
+                preflight = asyncio.run(run_preflight(
+                    memory=memory,
+                    queries=queries,
+                    expect_sources=expect_sources,
+                    answer_llm_label=mode.model_id if hasattr(mode, "model_id") else "",
+                    console=console,
+                ))
+                if preflight.aborted:
+                    console.print(f"\n[bold red]PREFLIGHT ABORT:[/bold red] {preflight.abort_reason}")
+                    console.print("[dim]Fix the configuration and re-run. Use --no-preflight to bypass.[/dim]")
+                    raise _typer.Exit(1)
+                for w in preflight.warnings:
+                    console.print(f"[yellow]PREFLIGHT WARNING:[/yellow] {w}")
 
         stored_contexts: dict[str, str] = {}
         stored_answers: dict[str, str] = {}

--- a/session-summaries/2026-07-20-dreaming-preflight-checks.md
+++ b/session-summaries/2026-07-20-dreaming-preflight-checks.md
@@ -1,0 +1,47 @@
+# Session Summary -- 2026-07-20 -- Dreaming -- Tenant mismatch root cause + preflight checks
+
+**Plan:** NEXT_SESSION-dreaming.md (per-category analysis + ablation)   **Commits:** 6ab3c4e..33f5fe7 (feat/dreaming-analysis-ablation, PR #440)
+**Deployed:** nothing   **Model:** Opus 4.6
+
+## Plan vs. actual
+Planned: per-category analysis comparing combined vs library-only results, two source ablation runs, write full analysis into RESULTS.md, close #349, scale GPU machineset. Shipped: per-category analysis (item 1), corrected RESULTS.md analysis (item 3 partially), GPU scale-down from 3 to 2 (item 4), plus unplanned preflight system. Slipped: ablation runs blocked by discovery that the combined result is invalid (tenant mismatch means dreaming memories were never searched). #349 remains open.
+Scope: expanded to include root cause investigation of identical retrieval contexts, preflight smoke checks (new subsystem), and pressure testing of preflight against 5 failure scenarios.
+
+## Shipped
+- `6ab3c4e` Per-category analysis for combined vs library-only (#349) -- comparison table in RESULTS.md
+- `c1ea531` Preflight smoke checks: new `preflight.py` with 4 checks (project exists, memories present, source distribution, search functional); integrated into `omb run` via `memoryhub.py`, `runner.py`, `cli.py`
+- `33f5fe7` Corrected combined run analysis in RESULTS.md -- tenant mismatch root cause documented, previous "non-destructive baseline match" interpretation replaced with "dreaming memories invisible to search"
+- GPU machineset scaled from 3 to 2 nodes
+
+## Key finding
+All 589 queries in the combined benchmark produced byte-identical retrieval context between library-only and combined runs. Root cause: `_run_dreaming_ingest()` ingests memories with `tenant_id='default'` while searches use `tenant_id='amb-benchmark'`. The dreaming memories exist in the database but are invisible to tenant-scoped search. The 84.9% combined result is therefore invalid -- it is the library-only result with unreachable dreaming memories alongside.
+
+## Verification & confidence
+- Per-category analysis: confirmed all deltas between runs are zero (byte-identical context proves they must be)
+- Preflight smoke checks: pressure tested against 5 scenarios (source=dreaming on broken data -> ABORT, expect-sources on broken data -> ABORT, no filter on broken data -> WARN, no-preflight bypass, healthy baseline -> PASS) -- all correct
+- CI: all 9 checks pass on PR #440
+- Gitleaks: no secrets detected
+- Confidence: **high** on the root cause diagnosis (byte-identical context is conclusive). **High** on the preflight system (5 scenarios tested, integrated into CLI flow).
+
+## Judgment calls & deviations
+- Did not attempt to fix the tenant_id bug in this session. The fix is in `_run_dreaming_ingest()` in the harness and requires re-ingestion + re-run. Correctly deferred to avoid scope creep.
+- Built the preflight system as an unplanned addition. Rationale: the tenant mismatch would have been caught immediately by a preflight check. This prevents similar silent failures in future benchmark runs.
+- Corrected RESULTS.md analysis rather than leaving the stale "non-destructive baseline" interpretation. The previous text was factually wrong -- dreaming was not tested, it was invisible.
+
+## Backlog delta
+Filed: none. Closed: none. #349 remains open -- the combined result is now known-invalid and requires a tenant fix + re-run before the ablation runs make sense. No new issues needed; the existing issue covers the remaining work.
+
+## Drift & forward-collisions
+- Backward: #349 is still open. The combined result is now known-invalid (dreaming memories ingested under wrong tenant). The per-category analysis and ablation runs described in the plan are blocked until the tenant_id bug is fixed and a clean combined run is executed.
+- Forward: the preflight system will be used by all future benchmark runs, relevant to Phase 8 (full benchmark validation). Any run with dreaming memories will now fail-fast if the source distribution check finds zero dreaming-sourced memories in the search tenant.
+
+## For the reviewer
+- The key commit to scrutinize is `33f5fe7` -- verify the RESULTS.md corrections accurately describe the tenant mismatch and don't overclaim or underclaim the finding.
+- The preflight system (`preflight.py`) is new code with no unit tests. Integration testing was done via the 5 pressure scenarios, but formal test coverage is zero. Acceptable for harness tooling but worth noting.
+- The `research/prose-loses-to-urgency.md` file has an unstaged edit (adds a "stale fallback" observation). This is unrelated to the benchmark branch.
+
+## Risks / watch-fors
+- The tenant_id bug in `_run_dreaming_ingest()` needs fixing before any combined benchmark run can produce valid results. Until then, all combined results should be treated as library-only.
+- 244 pre-existing ruff lint errors in `benchmarks/amb-harness/src/`. Not a regression from this session but worth a cleanup pass.
+- amb-combined-pro project data (3,468 agent + 985 dreaming) will need re-ingestion after the tenant fix. The dreaming memories exist but under the wrong tenant.
+- GPU machineset now at 2 nodes. Scale back to 3 when the re-run is ready.


### PR DESCRIPTION
## Summary

- Adds mandatory preflight smoke checks to `omb run` that run 3 deterministic queries through the real search pipeline before the expensive query loop starts
- Corrects the combined run analysis: the 84.9% result was invalid due to a tenant mismatch (dreaming memories under `tenant_id='default'`, searches using `tenant_id='amb-benchmark'`)
- The previous explanation ("dreaming facts don't rank high enough") was wrong; the actual cause is a bug in `_run_dreaming_ingest()` not propagating tenant_id

## Preflight details

Catches: zero context (tenant mismatch), missing source types (`--expect-sources`), source filter matching nothing. Mandatory by default, opt-out via `--no-preflight`.

Pressure tested against 5 scenarios:
- `source=dreaming` on broken data -> ABORT (0 memories)
- `--expect-sources agent,dreaming` on broken data -> ABORT (dreaming missing)
- No filters on broken data -> WARN (agent-only)
- `--no-preflight` -> bypasses checks
- Healthy baseline -> PASS

## Test plan

- [x] Preflight ABORT on tenant mismatch (source=dreaming, 0 results)
- [x] Preflight ABORT on --expect-sources when source missing
- [x] Preflight WARN on single-source without explicit expectation
- [x] Preflight PASS on healthy library-only data
- [x] --no-preflight bypasses all checks
- [x] --expect-sources agent produces clean PASS on library-only project