### PR TITLE
thread: Fix dreaming tenant propagation + source in compact response

### DIFF
--- a/benchmarks/amb-harness/src/memory_bench/memory/memoryhub.py
+++ b/benchmarks/amb-harness/src/memory_bench/memory/memoryhub.py
@@ -222,7 +222,7 @@ class MemoryHubProvider(MemoryProvider):
                 sorted(persona_sessions.items()), 1
             ):
                 owner = f"amb-{persona_id}" if persona_id else "amb-default"
-                thread = await client.create_thread(
+                create_kwargs: dict[str, Any] = dict(
                     scope="project",
                     scope_id=self._project_id,
                     owner_id=owner,
@@ -233,6 +233,9 @@ class MemoryHubProvider(MemoryProvider):
                         "session_count": len(sessions),
                     },
                 )
+                if self._tenant_id:
+                    create_kwargs["tenant_id"] = self._tenant_id
+                thread = await client.create_thread(**create_kwargs)
                 logger.info(
                     "Persona %d/%d (%s): thread %s, %d sessions",
                     p_idx, total_personas, persona_id, thread.id, len(sessions),
@@ -258,6 +261,8 @@ class MemoryHubProvider(MemoryProvider):
                         extract_kwargs["model"] = self._extraction_model
                     if self._extraction_model_url:
                         extract_kwargs["model_url"] = self._extraction_model_url
+                    if self._tenant_id:
+                        extract_kwargs["tenant_id"] = self._tenant_id
 
                     result = await client.extract_thread(thread.id, **extract_kwargs)
                     total_extractions += result.extracted_count

--- a/memory-hub-mcp/src/tools/search_memory.py
+++ b/memory-hub-mcp/src/tools/search_memory.py
@@ -142,6 +142,7 @@ def _compact_entry(
         entry["content"] = item.stub
     entry["content_truncated"] = item.content_truncated
     entry["full_available"] = item.full_available
+    entry["source"] = getattr(item, "source", "agent")
     if relevance_score is not None:
         entry["relevance_score"] = round(relevance_score, 4)
     return entry

--- a/memory-hub-mcp/src/tools/thread.py
+++ b/memory-hub-mcp/src/tools/thread.py
@@ -22,7 +22,7 @@ _VALID_ACTIONS = frozenset({
 
 _CREATE_OPTS = frozenset({
     "title", "participant_ids", "participant_access",
-    "a2a_context_id", "scope_id", "owner_id", "metadata",
+    "a2a_context_id", "scope_id", "owner_id", "metadata", "tenant_id",
 })
 _APPEND_OPTS = frozenset({"actor_id", "tool_call_id", "metadata", "a2a_context_id"})
 _GET_OPTS = frozenset({"limit", "before_sequence", "include_messages"})
@@ -30,7 +30,7 @@ _LIST_OPTS = frozenset({
     "scope_id", "status", "participant_id", "limit", "offset",
 })
 _ARCHIVE_OPTS = frozenset({"reason"})
-_EXTRACT_OPTS = frozenset({"turn_range", "model", "model_url"})
+_EXTRACT_OPTS = frozenset({"turn_range", "model", "model_url", "tenant_id"})
 _FORK_OPTS = frozenset({"from_sequence", "title"})
 _SHARE_OPTS = frozenset({"grantee_id", "access_level", "authorized_by"})
 _DELETE_OPTS = frozenset({"cascade"})
@@ -156,7 +156,7 @@ async def _dispatch_create(scope, opts, ctx):
         AuthenticationError,
         authorize_write,
         get_claims_from_context,
-        get_tenant_filter,
+        resolve_tenant,
     )
     from src.tools._deps import get_db_session, release_db_session
 
@@ -167,7 +167,7 @@ async def _dispatch_create(scope, opts, ctx):
     except AuthenticationError as exc:
         raise ToolError(str(exc)) from exc
 
-    tenant = get_tenant_filter(claims)
+    tenant = resolve_tenant(claims, opts.get("tenant_id"))
     caller_id = claims["sub"]
 
     project_ids: set[str] | None = None
@@ -471,7 +471,7 @@ async def _dispatch_extract(thread_id_str, opts, ctx):
         AuthenticationError,
         authorize_thread_read,
         get_claims_from_context,
-        get_tenant_filter,
+        resolve_tenant,
     )
     from src.tools._deps import get_db_session, get_embedding_service, get_s3_adapter, release_db_session
 
@@ -487,7 +487,7 @@ async def _dispatch_extract(thread_id_str, opts, ctx):
     except AuthenticationError as exc:
         raise ToolError(str(exc)) from exc
 
-    tenant = get_tenant_filter(claims)
+    tenant = resolve_tenant(claims, opts.get("tenant_id"))
     caller_id = claims["sub"]
     s3_adapter = get_s3_adapter()
     embedding_service = get_embedding_service()

--- a/sdk/src/memoryhub/client.py
+++ b/sdk/src/memoryhub/client.py
@@ -1563,6 +1563,7 @@ class MemoryHubClient:
         participant_access: dict[str, str] | None = None,
         a2a_context_id: str | None = None,
         metadata: dict[str, Any] | None = None,
+        tenant_id: str | None = None,
     ) -> ConversationThread:
         """Create a new conversation thread."""
         opts: dict[str, Any] = {}
@@ -1580,6 +1581,8 @@ class MemoryHubClient:
             opts["a2a_context_id"] = a2a_context_id
         if metadata is not None:
             opts["metadata"] = metadata
+        if tenant_id is not None:
+            opts["tenant_id"] = tenant_id
         data = await self._call_thread_action("create", scope=scope, options=opts or None)
         return ConversationThread.model_validate(data)
 
@@ -1653,6 +1656,7 @@ class MemoryHubClient:
         turn_range: tuple[int, int] | None = None,
         model: str | None = None,
         model_url: str | None = None,
+        tenant_id: str | None = None,
     ) -> ExtractionResult:
         """Trigger extraction pipeline on a thread."""
         opts: dict[str, Any] = {}
@@ -1662,6 +1666,8 @@ class MemoryHubClient:
             opts["model"] = model
         if model_url is not None:
             opts["model_url"] = model_url
+        if tenant_id is not None:
+            opts["tenant_id"] = tenant_id
         data = await self._call_thread_action("extract", thread_id=thread_id, options=opts or None)
         return ExtractionResult.model_validate(data)
 


### PR DESCRIPTION
## Summary

- Thread tool now accepts per-call `tenant_id` override for create and extract
  actions, using `resolve_tenant()` (same pattern as `write_memory`). SDK
  `create_thread()` and `extract_thread()` forward it. Harness
  `_run_dreaming_ingest()` passes `self._tenant_id` through the pipeline.
- Compact search response (`verbose=False`) now includes `source` field.
  Previously omitted, causing all results to report `source='agent'` regardless
  of actual provenance.

Fixes the root cause of the invalidated combined benchmark (PR #440): dreaming
memories were ingested under `tenant_id='default'` while searches used
`tenant_id='amb-benchmark'`. Also fixes the preflight checker's inability to
detect source distribution.

## Test plan

- [x] SQL update: 985 existing dreaming memories migrated to `amb-benchmark`
- [x] Preflight: `--expect-sources agent,dreaming` passes (`agent=5, dreaming=48`)
- [x] Smoke test: `create_thread(tenant_id='amb-benchmark')` correctly places
  thread under override tenant; extraction produces `source='dreaming'` memories
- [ ] Full 589-query combined benchmark running (in progress)