### PR TITLE
deploy: Default to current oc context when MEMORYHUB_CONTEXT unset

### DIFF
--- a/memory-hub-mcp/deploy/deploy.sh
+++ b/memory-hub-mcp/deploy/deploy.sh
@@ -23,7 +23,7 @@ set -euo pipefail
 
 NAMESPACE="memory-hub-mcp"
 DEPLOYMENT="memory-hub-mcp"
-CONTEXT="${MEMORYHUB_CONTEXT:-mcp-rhoai}"
+CONTEXT="${MEMORYHUB_CONTEXT:-$(oc config current-context 2>/dev/null)}"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 

--- a/memoryhub-auth/deploy.sh
+++ b/memoryhub-auth/deploy.sh
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 PROJECT="${1:-memoryhub-auth}"
-CONTEXT="${MEMORYHUB_CONTEXT:-mcp-rhoai}"
+CONTEXT="${MEMORYHUB_CONTEXT:-$(oc config current-context 2>/dev/null)}"
 
 # Manifest is rewritten through sed to embed cluster-specific URLs.
 # The image reference stays as the short imagestream tag (auth-server:latest)

--- a/scripts/check-prereqs.sh
+++ b/scripts/check-prereqs.sh
@@ -6,7 +6,7 @@
 SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}")"
 QUIET=false
 
-CONTEXT="${MEMORYHUB_CONTEXT:-mcp-rhoai}"
+CONTEXT="${MEMORYHUB_CONTEXT:-$(oc config current-context 2>/dev/null)}"
 TARGET_NAMESPACES=(memory-hub-mcp memoryhub-auth memoryhub-db memoryhub-ui)
 
 # ---------------------------------------------------------------------------

--- a/scripts/deploy-full.sh
+++ b/scripts/deploy-full.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}")"
-CONTEXT="${MEMORYHUB_CONTEXT:-mcp-rhoai}"
+CONTEXT="${MEMORYHUB_CONTEXT:-$(oc config current-context 2>/dev/null)}"
 export MEMORYHUB_CONTEXT="$CONTEXT"
 
 DB_NAMESPACE="memoryhub-db"

--- a/scripts/run-migrations.sh
+++ b/scripts/run-migrations.sh
@@ -13,7 +13,7 @@
 set -euo pipefail
 
 DB_NAMESPACE="${1:-memoryhub-db}"
-CONTEXT="${MEMORYHUB_CONTEXT:-mcp-rhoai}"
+CONTEXT="${MEMORYHUB_CONTEXT:-$(oc config current-context 2>/dev/null)}"
 LOCAL_PORT=15432
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 VENV="${REPO_ROOT}/.venv"

--- a/scripts/run-seed-oauth-clients.sh
+++ b/scripts/run-seed-oauth-clients.sh
@@ -12,7 +12,7 @@
 set -euo pipefail
 
 DB_NAMESPACE="${1:-memoryhub-db}"
-CONTEXT="${MEMORYHUB_CONTEXT:-mcp-rhoai}"
+CONTEXT="${MEMORYHUB_CONTEXT:-$(oc config current-context 2>/dev/null)}"
 LOCAL_PORT=15432
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 VENV="${REPO_ROOT}/.venv"

--- a/scripts/uninstall-full.sh
+++ b/scripts/uninstall-full.sh
@@ -16,7 +16,7 @@
 set -euo pipefail
 
 SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}")"
-CONTEXT="${MEMORYHUB_CONTEXT:-mcp-rhoai}"
+CONTEXT="${MEMORYHUB_CONTEXT:-$(oc config current-context 2>/dev/null)}"
 
 DB_NAMESPACE="memoryhub-db"
 MCP_PROJECT="memory-hub-mcp"


### PR DESCRIPTION
## Summary

- All 7 deploy/utility scripts defaulted `MEMORYHUB_CONTEXT` to `mcp-rhoai`, a named context that only exists on the maintainers' machines. A fresh user doing `oc login` + `make install` would immediately fail.
- Changed the default to `$(oc config current-context)` so the scripts use whatever cluster the user just logged into.
- `MEMORYHUB_CONTEXT=my-cluster make install` still works for multi-cluster workflows.

## Test plan

- [x] `bash -n` passes on all 7 modified scripts
- [x] No behavioral change when `MEMORYHUB_CONTEXT` is set (our existing workflow)
- [x] Quick start path (`oc login` + `make install`) now has no implicit dependency on a specific named context