### PR TITLE
Dreaming ablation results, curation epic plan, deploy cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,7 @@ seed-clients.json
 .cache_ggshield
 .mcp.json
 
-NEXT_SESSION*.md
+# NEXT_SESSION*.md -- now tracked per global CLAUDE.md convention
 ISSUE-postsession-*.md
 planning/rfe_draft.md
 

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -8,6 +8,7 @@ regex = '''mh-(dev|prod)-[a-f0-9]{16}'''
     '''dev-users\.json$''',
     '''tests\/.*\.py$''',
     '''\.claude\/worktrees\/''',
+    '''users-configmap\.example\.yaml$''',
   ]
 
 [allowlist]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,15 +3,29 @@
 ## Project Overview
 MemoryHub is a Kubernetes-native agent memory component for OpenShift AI. See docs/ARCHITECTURE.md for the full architecture and docs/SYSTEMS.md for subsystem inventory.
 
-## Branch Protection
+## Branch Strategy
 
-Main is protected. Never push directly to main. All changes go through pull requests:
-- Create a feature branch (`git checkout -b feat/description`)
-- Commit to the branch
-- Push the branch and open a PR via `gh pr create`
-- Merge after review
+Main is protected. Never push directly to main.
 
-This applies to all changes including docs, config, and demo code. No exceptions.
+Most work targets **feature branches**, not main. PRs to main happen only when a feature branch is ready to land as a cohesive unit.
+
+**Branch hierarchy:**
+- `feat/<topic>` -- long-lived feature branches forked from main
+- `feat/<topic>/<subtask>` -- short-lived branches forked from a feature branch for incremental work
+- `fix/<description>` -- bugfix branches (target main or a feature branch, depending on scope)
+
+**Workflow:**
+1. Create or check out the feature branch (`git checkout -b feat/topic`)
+2. For sub-work, branch off the feature branch (`git checkout -b feat/topic/subtask`)
+3. PR sub-branches into the parent feature branch, not main
+4. When the feature is complete, PR the feature branch into main
+
+**PR targeting rules:**
+- Sub-branches PR into their parent feature branch
+- Feature branches PR into main only when the work is ready to ship
+- Hotfixes (`fix/`) may target main directly when urgency warrants it
+
+This applies to all changes including docs, config, and demo code.
 
 ## Issue Management
 Use the `/issue-tracker` skill for ALL issue operations. Never create issues manually without using the skill -- it enforces our conventions:

--- a/NEXT_SESSION-curation.md
+++ b/NEXT_SESSION-curation.md
@@ -1,0 +1,322 @@
+# Next Session -- Curation
+
+## Next: Curator scaffold -- AgentPlugin base class + no-op sweep (#350)
+
+Build the runtime infrastructure that all autonomous sweep agents use.
+No curation logic yet. The session produces a testable AgentPlugin base
+class and a concrete NoOpSweep that discovers candidate memories, logs
+skip decisions, and exits cleanly. Code and tests only; deployment is a
+follow-up session.
+
+Branch off `feat/dreaming-ablation-results` as
+`feat/curation/350-curator-scaffold`.
+
+1. **Read the design doc first**
+   `planning/autonomous-curation-agents.md` sections 4 (architecture),
+   5.2 (Curator Agent spec), 9 (deployment topology), 12 (phasing).
+   Also `planning/memory-extraction-pipeline.md` Layer 3 section for
+   the reflection sweep interface contract. The design is detailed;
+   don't re-derive decisions it already made.
+
+2. **AgentPlugin base class** (`src/memoryhub_core/agents/base.py`)
+   Abstract sweep lifecycle: `discover() -> list[Candidate]`,
+   `evaluate(candidate) -> Decision`, `act(decision) -> Result`,
+   `report(results) -> SweepReport`. Configuration via dataclass
+   (thresholds, batch size, dry-run flag). DB session management
+   via existing `get_session()`. Logging structured for CronJob
+   pod log inspection.
+
+3. **NoOpSweep implementation** (`src/memoryhub_core/agents/noop_sweep.py`)
+   Concrete subclass. `discover()` queries active memory_nodes (limit
+   configurable, default 100). `evaluate()` returns `Decision.SKIP` for
+   every candidate. `act()` is a no-op. `report()` logs candidate count,
+   skip count, elapsed time. This proves the lifecycle works end-to-end
+   against a real (or SQLite test) database.
+
+4. **CLI entry point** (`src/memoryhub_core/cli/curator.py`)
+   `python -m memoryhub_core.cli.curator --sweep noop --dry-run`
+   Same pattern as existing `retention_sweep.py`. This is what the
+   CronJob will invoke. Support `--sweep` arg to select sweep type
+   (noop for now, dedup/staleness/reflection later).
+
+5. **Tests** (`tests/agents/test_base.py`, `tests/agents/test_noop_sweep.py`)
+   - AgentPlugin lifecycle hooks called in order
+   - NoOpSweep discovers candidates from test DB
+   - NoOpSweep produces correct SweepReport (all skips, correct counts)
+   - Dry-run mode prevents `act()` from being called
+   - Configuration validation (bad thresholds, missing DB)
+
+6. **K8s manifests (templates only, not applied)**
+   CronJob + ServiceAccount + RBAC in `deploy/curator/` or alongside
+   existing manifests. `concurrencyPolicy: Forbid`. Schedule placeholder
+   (daily 02:00 UTC). These are committed but not deployed this session.
+
+**Sequencing.** Items 1-5 are the session. Item 6 is quick scaffolding
+at the end if time permits. The design doc read (item 1) informs
+everything else -- don't skip it.
+
+**Constraints for the session:**
+- Code only, no cluster deployment. Tests run locally against SQLite.
+- Branch from `feat/dreaming-ablation-results`, not main (PR #448 is
+  still open).
+- Follow existing patterns: `retention_sweep.py` for CLI entry point,
+  `services/dreaming.py` for service-layer async patterns.
+- `actor_id` column already exists on `memory_nodes` and
+  `conversation_messages` -- no migration needed for OBO writes.
+- Don't build dedup/staleness/reflection logic. The sweep types are
+  Phase 2 work. This session builds the harness they plug into.
+
+**Session start protocol:**
+- Premise checks: verify `feat/dreaming-ablation-results` is current
+  (`git log -1`); verify `actor_id` column exists in models
+  (`grep actor_id src/memoryhub_core/models/memory.py`); read
+  `planning/autonomous-curation-agents.md` sections 4, 5.2, 9
+- Rules with history: all pushes through PRs; MCP tool creation uses
+  fips-agents workflow (but this session is service-layer code, not
+  MCP tools)
+- Stop-and-ask before: adding new MCP tools (not planned, but if it
+  comes up, use `/plan-tools` workflow); changing existing model
+  schemas (shouldn't be needed)
+- Close ritual: session summary; PR targeting
+  `feat/dreaming-ablation-results`
+
+**Exit predicate:**
+- `AgentPlugin` base class with abstract lifecycle methods exists and
+  has tests
+- `NoOpSweep` runs against SQLite test DB, discovers candidates,
+  produces a `SweepReport` with all-skip decisions
+- CLI entry point works: `python -m memoryhub_core.cli.curator --sweep noop`
+- All new tests pass; no regressions in existing suite
+- PR opened targeting `feat/dreaming-ablation-results`
+
+## Remaining epic phases
+
+Autonomous curation: a Curator Agent running as a CronJob on the cluster
+that periodically deduplicates memories (with measured precision), detects
+staleness and cross-scope conflicts, and generates insight memories from
+version-churn patterns (Layer 3 reflection). The agent runs unattended and
+improves memory quality without user intervention.
+
+Design references: `planning/autonomous-curation-agents.md` (Curator Agent
+sections), `planning/memory-extraction-pipeline.md` (Layer 3 reflection).
+
+### Phase 0: Housekeeping (start of first session)
+
+Land `feat/dreaming-ablation-results` branch (tenant fix, source ablation
+results, retrieval-unit routing design doc). Close #349 (Layer 2
+validation) and #336 (extraction pipeline epic -- Layers 1-2 shipped,
+remaining work moves to this epic).
+
+**Work:**
+1. Merge current branch via PR
+2. Close #349 with final ablation summary
+3. Close #336 with note that Curator (#350-353) and reflection (#345) are
+   tracked under this epic
+
+**Definition of done:** #349 and #336 closed on GitHub. Current branch
+merged to main.
+
+**Dependencies:** None.
+
+**Parallel-ok:** Can bundle with Phase 1 in a single session.
+
+### Phase 1: Curator scaffold (#350)
+
+Build the runtime infrastructure for autonomous sweep agents. No
+curation logic yet -- the sweep runs, logs "no-op," and exits cleanly.
+
+**Work:**
+1. `AgentPlugin` base class: sweep lifecycle (init, discover candidates,
+   evaluate, act, report), configuration from env/ConfigMap
+2. Leader election or single-pod CronJob (design doc says either; CronJob
+   with `concurrencyPolicy: Forbid` is simpler)
+3. K8s manifests: CronJob, ServiceAccount, RBAC (scoped to memory read/write),
+   ConfigMap for sweep config
+4. No-op sweep implementation: queries memory_nodes, iterates candidates,
+   logs skip decisions, exits 0
+5. Deploy to cluster, verify CronJob triggers and completes
+
+**Definition of done:** `oc get cronjob curator-agent --context mcp-rhoai -n memory-hub-mcp`
+shows a CronJob that has run at least once with status Succeeded. Pod logs
+show the no-op sweep discovering candidate memories and completing without
+action. AgentPlugin base class has tests covering lifecycle hooks.
+
+**Dependencies:** Phase 0 (clean main branch).
+
+**Parallel-ok:** No (everything else depends on this).
+
+### Phase 2a: Dedup judge (#351)
+
+Build and measure the dedup detection capability before wiring it into
+production.
+
+**Work:**
+1. Build labeled pair set from real cluster data: ~50-100 pairs of
+   (memory_a, memory_b, is_duplicate: bool). Mix of obvious dupes,
+   near-dupes, and distinct-but-related memories
+2. Implement dedup judge: embedding similarity + LLM tiebreaker (same
+   pattern as reconciliation). Configurable thresholds
+3. Measure precision/recall against labeled set. Target: >= 90% precision
+   (false merges are destructive), >= 70% recall (missed dupes are
+   tolerable)
+4. Tests covering threshold bands, edge cases (same content different
+   owner, same fact different wording)
+
+**Definition of done:** Dedup judge passes precision >= 90% / recall >= 70%
+against labeled pair set. Precision/recall numbers committed in a test or
+results file. Judge is a callable module, not yet wired into a sweep.
+
+**Dependencies:** Phase 1 (needs AgentPlugin base class for interface contract).
+
+**Parallel-ok:** Yes -- runs in parallel with 2b and 2c. Needs worktree
+isolation.
+
+### Phase 2b: Staleness + cross-scope conflict (#353)
+
+Second sweep type. Detects memories that are stale (no reads, old, low
+weight) and memories that contradict each other across scopes.
+
+**Work:**
+1. Staleness sweep: query memories by last_accessed, age, weight. Flag
+   candidates for review (not auto-delete -- destructive actions need
+   the dedup judge's precision bar or human review)
+2. Cross-scope conflict detection: find memories with high embedding
+   similarity but different content across scopes/owners. Surface as
+   contradictions via `report_contradiction()`
+3. Wire both into AgentPlugin as sweep types in the CronJob
+4. Deploy and verify on cluster
+
+**Definition of done:** CronJob runs staleness + conflict sweeps. Pod logs
+show candidates discovered and flagged. At least one real staleness
+candidate and one real conflict surfaced from cluster data (not synthetic).
+`report_contradiction()` called for conflicts.
+
+**Dependencies:** Phase 1 (needs AgentPlugin scaffold + CronJob).
+
+**Parallel-ok:** Yes -- runs in parallel with 2a and 2c. Needs worktree
+isolation.
+
+### Phase 2c: Layer 3 reflection (#345)
+
+Third sweep type. Generates insight memories from version-churn patterns
+using the version history that Layer 2 reconciliation produces.
+
+**Work:**
+1. Schema: add `last_reflection_version` column to `memory_nodes`
+   (Alembic migration)
+2. Churn detection query: find memories where
+   `current_version - last_reflection_version >= threshold` within a
+   rolling time window. Apply semantic-delta filter (skip rephrasings
+   via embedding distance between consecutive versions)
+3. Reflection prompt: compact version list -> LLM -> insight memory.
+   Write insight as a new memory with `branch_type="reflection"` and
+   `parent_id` pointing to the source memory
+4. Wire into AgentPlugin as a sweep type
+5. Integration test: the cheese test from the design doc (mozzarella ->
+   parmesan -> gruyere -> brie -> "user frequently changes cheese
+   preference")
+
+**Definition of done:** Cheese test passes end-to-end: 4+ version updates
+to a memory trigger reflection, insight memory created with correct
+parent_id and branch_type. Churn detection filters out rephrasings
+(semantic-delta < epsilon). Sweep runs in CronJob on cluster.
+
+**Dependencies:** Phase 1 (needs AgentPlugin scaffold + CronJob).
+
+**Parallel-ok:** Yes -- runs in parallel with 2a and 2b. Needs worktree
+isolation.
+
+### Phase 3: Deep-dedup sweep (#352)
+
+Wire the measured judge from Phase 2a into production. This is the first
+sweep that takes destructive action (merging duplicate memories).
+
+**Work:**
+1. Wire dedup judge into a sweep type: discover candidate pairs
+   (embedding similarity above threshold), run judge, merge or flag
+2. Merge action: soft-delete the duplicate, add provenance link to the
+   surviving memory, preserve version history
+3. Flag action: for pairs below the precision threshold, surface for
+   human review (write a contradiction or admin notification)
+4. Deploy and run against real cluster data. Monitor merge decisions
+5. Verify merged memories are searchable and duplicates are gone
+
+**Definition of done:** Dedup sweep runs on cluster, merges at least one
+real duplicate pair, and the surviving memory has correct provenance.
+No false merges (verify manually). Flagged pairs surfaced for pairs
+below the auto-merge threshold.
+
+**Dependencies:** Phase 2a (#351 -- needs the measured judge).
+
+**Parallel-ok:** No (terminal phase).
+
+---
+
+## What this covers (and what it doesn't)
+
+**In scope:**
+- #350 Curator scaffold (AgentPlugin, CronJob, no-op sweep)
+- #351 Labeled dedup pair set + deep-dedup judge
+- #352 Deep-dedup sweep (merge/flag actions)
+- #353 Staleness + cross-scope conflict detection
+- #345 Layer 3 provenance-driven reflection
+- #285 Curator Agent tracker (closed when #350-353 are done)
+- #336 Extraction pipeline tracker (closed in Phase 0 -- Layers 1-2 done)
+
+**Out of scope (other epics own):**
+- #447 Retrieval-unit routing for dreaming facts (post-curation)
+- #370 Ablation matrix B (blocked by #349, not this epic)
+- #290 Five-stage promotion pipeline (follow-on to Curator, separate epic)
+- #291 Per-agent fine-tuning (follow-on, separate epic)
+- #289 Statistician agent (separate agent, separate epic)
+- #334 Adversarial write / poisoning resistance (needs Curator, separate epic)
+
+## What landed last session (2026-07-21)
+
+Epic bootstrapped from dreaming epic. No code yet. Planning only:
+`NEXT_SESSION-curation.md` created, `NEXT_SESSION-dreaming.md` updated
+to point here for Phases 6-7.
+
+**Context from dreaming epic:** Layers 1-2 shipped. Source ablation showed
+dreaming adds +0.1pp without retrieval-unit routing. Autonomous curation
+is the next quality lever. PR #448 (ablation results + tenant fix) is
+open on `feat/dreaming-ablation-results`.
+
+## Watch out for
+
+- **OBO ownership model.** Curator writes memories on behalf of users.
+  The `owner_id` / `actor_id` dual-field model is designed in
+  `planning/autonomous-curation-agents.md` section 3. `actor_id` column
+  already exists on `memory_nodes` and `conversation_messages` --
+  verified 2026-07-21.
+- **Existing `retention_sweep.py` is thread retention, not memory curation.**
+  Don't confuse the two. The retention sweep handles conversation thread
+  TTL; the Curator Agent handles memory quality. Different concerns,
+  different code paths. But the CLI entry point pattern is worth copying.
+- **Destructive actions need precision guarantees.** Merge (dedup) and
+  delete (staleness) are irreversible for the user even if soft-deleted
+  in the DB. The labeled pair set in Phase 2a is the quality gate.
+  Phase 1 (scaffold) has NO destructive actions -- the no-op sweep
+  only reads.
+- **Parallel phases need worktree isolation.** Phases 2a/2b/2c modify
+  different subsystems but share the same repo. Use
+  `isolation: "worktree"` when running parallel sub-agents.
+- **CronJob vs Deployment.** The design doc discusses both. CronJob with
+  `concurrencyPolicy: Forbid` is the simpler starting point. Move to a
+  long-running Deployment with leader election only if sweep duration
+  exceeds the cron interval.
+- **Branch topology.** This epic branches from
+  `feat/dreaming-ablation-results` (not main) until PR #448 merges.
+  Sub-branches target the parent feature branch per project convention.
+
+## If blocked
+
+- If PR #448 hasn't merged and you need main: the scaffold code is
+  independent of the ablation work. You could branch from main instead,
+  but the epic file assumes the feature branch. Check with the user.
+- If the design doc is unclear on a specific sweep interface: the
+  no-op sweep is intentionally minimal. Don't over-design the base
+  class for sweep types that don't exist yet. Keep the interface thin
+  and extend when Phase 2 work starts.
+- If cluster is unavailable: Phase 1 is entirely local (SQLite tests).
+  No cluster needed until deployment in a follow-up session.

--- a/NEXT_SESSION-dreaming.md
+++ b/NEXT_SESSION-dreaming.md
@@ -1,0 +1,213 @@
+# Next Session -- Dreaming
+
+## Next: Fix tenant bug, re-run combined benchmark, close #349
+
+The 2026-07-19 combined benchmark (84.9%) is invalid. Dreaming
+memories were ingested under `tenant_id='default'` while searches
+use `tenant_id='amb-benchmark'`. The two populations were never
+visible to the same search. This session fixes the bug, re-runs
+the combined benchmark with preflight validation, and closes #349.
+
+1. **Fix `_run_dreaming_ingest()` tenant propagation** (harness bug)
+   The library ingest path passes `self._tenant_id` on each `write()`
+   call (memoryhub.py:173-174). The dreaming path creates threads and
+   extracts facts via `create_thread()` / `extract_thread()` without
+   passing tenant_id. Fix: propagate `self._tenant_id` through the
+   dreaming pipeline. ~10 lines of code.
+
+2. **Fix existing data via SQL update** (fast path, avoids re-extraction)
+   ```sql
+   UPDATE memory_nodes SET tenant_id = 'amb-benchmark'
+   WHERE scope_id = 'amb-combined-pro' AND source = 'dreaming';
+   ```
+   This makes the 985 existing dreaming memories visible to the
+   benchmark search. Verify with preflight.
+
+3. **Run preflight to confirm both sources are visible**
+   ```bash
+   MEMORYHUB_PROJECT_ID=amb-combined-pro uv run omb run \
+     --dataset personamem --split 32k --memory memoryhub \
+     --skip-ingestion --expect-sources agent,dreaming \
+     --name combined-pro-v2 -q 3
+   ```
+   This MUST show both `agent` and `dreaming` in the smoke results
+   before proceeding. If dreaming still doesn't appear, investigate
+   (embedding missing? search filter bug?).
+
+4. **Smoke-test the code fix** (verify, don't just fix)
+   Re-ingest 3-5 personas in dreaming mode with the fixed code.
+   Confirm the extracted memories land under `tenant_id='amb-benchmark'`
+   in the DB. This proves the code fix works without re-extracting
+   all 985 memories.
+
+5. **Run the full 589-query combined benchmark**
+   With `--expect-sources agent,dreaming` and `--skip-ingestion`.
+   This is the real combined run. The result will tell us whether
+   dreaming facts actually contribute to accuracy.
+
+6. **Per-category analysis** (if the result differs from 84.9%)
+   Build the comparison table. This time the deltas will reflect
+   real retrieval differences, not LLM noise.
+
+7. **Source ablation runs** (2 runs, 589 queries each)
+   - `MEMORYHUB_EXCLUDE_SOURCE=dreaming` -- library-only, should
+     match the granite-pro baseline (~84.9%)
+   - `MEMORYHUB_SOURCE=dreaming` -- dreaming-only, expected ~60-70%
+
+8. **Write the final RESULTS.md analysis, close #349**
+
+**Sequencing.** Items 1-4 are the fix-and-verify phase (no Gemini
+calls). Item 5 is the main benchmark run (~90 min if API is stable).
+Items 6-7 depend on item 5's result. Item 8 is the write-up.
+
+**Constraints for the session:**
+- Do NOT modify `amb-granite-pro` (library-only baseline, 84.9%).
+- Gemini Pro API may be unstable. If down, complete items 1-4 (all
+  local/cluster, no Gemini needed) and defer items 5-8.
+- All pushes through PRs (branch protection enforced).
+- Deploy scripts in main context only (2026-05-19 incident).
+- The SQL update (item 2) modifies live benchmark data. Verify the
+  WHERE clause before executing.
+
+**Session start protocol:**
+- Premise checks: `oc whoami --context mcp-rhoai`; verify MCP pod
+  running; verify `amb-combined-pro` has 3,468 agent + 985 dreaming
+  in memory_nodes (check tenant_id distribution); source `~/.secrets`
+  for GEMINI_API_KEY; merge PR #440 (preflight + analysis) first
+- Rules with history: all pushes through PRs (enforced since
+  2026-07-17); deploy scripts in main context only; preflight
+  required before any full run (2026-07-20 lesson)
+- Stop-and-ask before: SQL updates to memory_nodes; modifying
+  baseline project data; any fresh extraction (uses Gemini credits)
+- Close ritual: session summary + NEXT_SESSION update; record
+  combined result against the 84.9% library-only baseline
+
+**Exit predicate:**
+- Tenant bug fixed in harness code (committed)
+- SQL fix applied and verified via preflight
+- Code fix smoke-tested (3-5 personas, correct tenant in DB)
+- Full 589-query combined run completed with both sources in retrieval
+- Per-category analysis in RESULTS.md (if result differs from baseline)
+- Both ablation runs completed
+- #349 closed on GitHub
+
+## Remaining epic phases
+
+MemoryHub should be the obvious memory system for anyone deploying agents
+on OpenShift at scale. No capability gap should exist between MemoryHub
+and any competitor for users who need governed, multi-tenant,
+platform-level memory. Governance features (versioning, RBAC, audit
+trails, multi-tenancy) are additive, not a tax on retrieval or
+extraction quality.
+
+This epic closes that gap across three fronts: retrieval performance
+(match or beat competitors on standard benchmarks), memory management
+(dreaming, reconciliation, reflection), and measurement (prove the
+compound value with benchmarks nobody else runs).
+
+### Phase 3: Layer 1 -- reranker + chunking fix (DONE)
+
+- **3a (#342): Reranker upgrade.** DONE -- granite-embedding-reranker-english-r2
+  deployed on L40S via TEI 1.9 GPU image (2026-07-15).
+- **3b (#343): Chunk-to-parent expansion + tuning.** DONE -- expansion shipped
+  (PR #399). Per-request chunk params shipped (PR #401). Tuning investigation
+  complete: 21-config sweep proves chunk size irrelevant for PersonaMem.
+
+### Phase 4: Benchmark remediation + fact extraction (DONE)
+
+- **4r5 (#360 re-scoped): Matrix A.** DONE -- signal ablation complete,
+  retrieval-saturated at 4-7 parents.
+- **Fact extraction prototype:** DONE -- 63.3% at k=70, 1,256 ctx tokens.
+- **Fact extraction pipeline:** DONE -- PR #407 (write-time extraction via
+  MCP sampling), PR #412 (extract_facts parameter wiring). Deployed build #19.
+- **Extraction model comparison:** DONE -- Flash Lite wins over Flash (-5.6pp).
+- **Matrix B (#370): focus/domain/graph -- deferred post-#349.** Domain
+  tags and graph edges only exist after dreaming-mode extraction.
+
+### Phase 4.5: Pro benchmark validation (DONE)
+
+- **Full Pro run:** 589-query PersonaMem with Granite embeddings + reranker +
+  gemini-3.1-pro-preview. Result: **84.9%** (500/589). Up from 81.2% with
+  MiniLM. Passes Cognee (81.8%) and hybrid-search (84.4%), 1.7pp behind
+  Hindsight (86.6%). Result file: `outputs/personamem/granite-pro/rag/32k.json`.
+
+### Phase 5: Layer 2 -- reconciliation + rollback (DONE)
+
+- **5a (#347): Stage contracts + reconciliation with decision log.** DONE --
+  PR #414 merged. Migration 025 deployed to cluster (2026-07-17).
+- **5b (#348): Run provenance + rollback.** DONE -- PR #415 merged.
+  Consistent run IDs, rollback_extraction_run(), dry-run mode, circuit
+  breaker. 9 tests covering all exit predicates.
+- **5c (#349): Layer 2 benchmark run.** Combined result 84.9% (500/589)
+  INVALIDATED (2026-07-20): tenant mismatch meant dreaming memories were
+  never searched. PRs #436-#438 shipped but result must be re-run after
+  tenant fix. PR #440 adds preflight checks + corrected analysis.
+- **5d (#418): Session-close capture hook.** DONE -- PR #419.
+
+### Phase 5.5: Pipeline validation (DONE)
+
+- **EvalHub infrastructure.** DONE -- PRs #422, #423, #424.
+- **Pipeline validation.** DONE -- PR #433. Validated at 70% (7/10).
+- **Combined mode.** PRs #436, #437, #438 shipped. Result INVALIDATED
+  (tenant mismatch). PR #440 adds preflight + corrected analysis.
+
+### Phase 6-7: Curator Agent + Layer 3 reflection -- MOVED
+
+Moved to `NEXT_SESSION-curation.md` as a standalone epic. Issues #350-353
+(Curator scaffold through staleness sweep) and #345 (provenance-driven
+reflection) are tracked there.
+
+### Phase 8: Full benchmark validation (deferred)
+
+Re-run all benchmarks with full pipeline active after curation epic ships.
+Depends on `NEXT_SESSION-curation.md` completing.
+
+**Reporting rule:** the Flash Lite competitor table and the Pro >= 85%
+headline are SEPARATE tables -- never mixed in one comparison.
+
+## What landed last session (2026-07-20)
+
+Discovered the combined benchmark result (84.9%) was invalid due to a
+tenant mismatch. Built preflight smoke checks into the harness to
+prevent this class of bug from reaching full runs. Scaled GPU from 3
+to 2 nodes.
+
+**Closed:** none. #349 remains open pending the tenant fix + re-run.
+
+**Shipped:** PR #440 (preflight checks + corrected RESULTS.md analysis +
+per-category comparison table + session summary).
+
+**Key finding:** `_run_dreaming_ingest()` writes memories under
+`tenant_id='default'` while searches use `tenant_id='amb-benchmark'`.
+All 589 queries had byte-identical context between library-only and
+combined runs. The dreaming memories were never searched.
+
+**Follow-ups filed:** none. Memories captured:
+`feedback_preflight_before_expensive_runs` (smoke test before full runs).
+
+## Watch out for
+
+- **Tenant mismatch is the known bug.** The 985 dreaming memories in
+  `amb-combined-pro` have `tenant_id='default'`. The SQL update (item 2)
+  fixes this. Double-check the WHERE clause before executing.
+- **Gemini Pro 504s.** The API was unstable 2026-07-18/19/20. The runner
+  retries 504/DEADLINE_EXCEEDED/ConnectError. Use Mac with nohup for
+  long runs (cluster egress IP triggers stricter rate limits).
+- **amb-granite-pro project**: 84.9% baseline. Do not modify.
+- **GPU machineset at 2 nodes.** Scale to 3 if embedding/reranker
+  throughput is insufficient for the full run.
+- **Preflight is now mandatory.** `omb run --skip-ingestion` runs
+  3 smoke queries before the main loop. Use `--expect-sources
+  agent,dreaming` for combined runs. This is the gate that would
+  have caught the tenant bug.
+- **PR #440 must be merged before starting.** The preflight code
+  and corrected RESULTS.md are on that branch.
+
+## If blocked
+
+- If Gemini API is down: complete items 1-4 (tenant fix, SQL update,
+  preflight verification, code smoke test). None require Gemini.
+  Defer items 5-8 (the actual benchmark runs).
+- If cluster DB is inaccessible: the SQL update (item 2) needs DB
+  access via port-forward. The code fix (item 1) and preflight (item 3)
+  only need the MCP server route (public).

--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ All service URLs (auth JWKS, embedding, reranker) are resolved dynamically from 
 
 Expect 8-15 minutes on a first install. The MCP server, auth service, and UI each go through an OpenShift BuildConfig, and the embedding/reranker models need to download weights on first run.
 
+**Prerequisites:** `oc` and `podman` on your PATH, cluster-admin on a cluster with RHOAI installed, a default StorageClass. `make check-prereqs` verifies all of these -- run it first. See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the "new contributor no-deploy" rule: if you're onboarding to this codebase, work against a local SQLite or Podman PostgreSQL instead of deploying to a cluster.
+
 ### Targeting a specific cluster
 
 If you have multiple clusters configured in your kubeconfig, set `MEMORYHUB_CONTEXT` to target a specific one without switching your active context:
@@ -147,20 +149,87 @@ curl -s https://auth-server-memoryhub-auth.apps.<cluster>/healthz
 
 For full tool verification, use `mcp-test-mcp` to connect to the deployed MCP server and list its tools.
 
+### After install
+
+The install summary banner prints the routes for each service. Follow these steps to verify the deployment and connect your first agent.
+
+**1. Get an API key.** The install creates a `memoryhub-users` ConfigMap in the `memory-hub-mcp` namespace with pre-seeded users and API keys. To view the available keys:
+
+```bash
+oc get configmap memoryhub-users -n memory-hub-mcp \
+  -o jsonpath='{.data.users\.json}' | python3 -m json.tool
+```
+
+Copy a key (format: `mh-dev-<hex>`) and store it locally:
+
+```bash
+mkdir -p ~/.config/memoryhub
+echo "mh-dev-<your-key>" > ~/.config/memoryhub/api-key
+```
+
+To add new users or rotate keys, see the [API key provisioning runbook](docs/runbooks/add-mcp-api-user.md).
+
+**2. Install the CLI and SDK.**
+
+```bash
+pip install memoryhub-cli    # terminal client
+pip install memoryhub        # Python SDK (optional, for scripting)
+```
+
+**3. Verify the deployment.** Use the CLI to test the connection:
+
+```bash
+memoryhub login              # configures endpoint + API key
+memoryhub search "test"      # should return empty results on a fresh install
+```
+
+Or use the SDK directly:
+
+```bash
+python scripts/seed-sample-data.py \
+  --url https://<your-mcp-route>/mcp/
+```
+
+This writes sample memories across multiple scopes so the dashboard has content to display.
+
+**4. Connect Claude Code.** Add the MCP server to Claude Code (the server name `memoryhub` is required as the first positional argument):
+
+```bash
+claude mcp add memoryhub \
+  --transport http \
+  -s user \
+  https://<your-mcp-route>/mcp/
+```
+
+Then set up the agent rule file so Claude Code knows how to use the tools:
+
+```bash
+memoryhub config init        # interactive wizard — generates .memoryhub.yaml + .claude/rules/
+```
+
+**5. Open the dashboard from RHOAI.** The install adds a MemoryHub tile to the Red Hat OpenShift AI application catalog:
+
+1. Open the RHOAI dashboard (the URL printed in the install summary, or find it at `https://rhods-dashboard-redhat-ods-applications.apps.<your-cluster>/`)
+2. Click **Applications** in the left sidebar, then **Explore**
+3. Find the **MemoryHub** tile and click it
+4. Click **Open application** to launch the admin dashboard
+
+The dashboard has six panels: Memory Graph (visual node/edge view of memories and relationships), Status Overview (system health), Users & Agents (active sessions), Client Management (OAuth clients), Curation Rules (content filtering), and Contradiction Log (conflicting memories). If you ran `seed-sample-data.py` in step 3, the Memory Graph will show the seeded memories and their relationships.
+
 ## Three ways to use it
 
 ### 1. From an agent via MCP (Claude Code, or anything that speaks MCP)
 
-The deployed server exposes a streamable-HTTP MCP endpoint. Add it to your agent's MCP configuration:
+The deployed server exposes a streamable-HTTP MCP endpoint. Add it to your agent's MCP configuration (note: the server name `memoryhub` is a required positional argument):
 
 ```bash
-claude mcp add --transport http \
-  -s project \
-  memoryhub \
+claude mcp add memoryhub \
+  --transport http \
+  -s user \
   https://memory-hub-mcp-memory-hub-mcp.apps.<your-cluster>.com/mcp/
 ```
 
-Then run `memoryhub config init` (from the CLI, see below) to generate a `.claude/rules/memoryhub-loading.md` that tells the agent when and how to call the tools. The generated rule covers session start, working-set loading, pivot detection, memory hygiene, and contradiction handling — all parameterized by your project's session shape (focused / broad / adaptive).
+Then run `memoryhub config init` (from the CLI, see below) to generate a `.claude/rules/memoryhub-loading.md` that tells the agent when and how to call the tools. The generated rule covers session start, working-set loading, pivot detection, memory hygiene, and contradiction handling -- all parameterized by your project's session shape (focused / broad / adaptive).
 
 For zero-overhead startup, add a [SessionStart hook](docs/guides/hooks-integration.md) that pre-loads memories into the conversation context before the first prompt — no MCP calls, no token overhead from structural metadata. The MCP server remains available for mid-session searches and writes.
 

--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -25,7 +25,6 @@ Raw result JSON files are committed alongside this document in `benchmarks/`.
 | MemPalace (semantic only) | LongMemEval | 0.966 | -- | -- | Wu et al., ICLR 2025 |
 | GPT-4o (no memory layer) | LongMemEval | ~0.30-0.70 | -- | -- | Wu et al., ICLR 2025 |
 
-| **MemoryHub v0.3 (Combined)** | PersonaMem 32k (589q) | **84.9%** | -- | -- | This document, 2026-07-19 |
 | **MemoryHub v0.3 (Granite)** | PersonaMem 32k (589q) | **84.9%** | -- | -- | This document, 2026-07-16 |
 | Hindsight | PersonaMem 32k | 86.6% | -- | -- | AMB leaderboard |
 | hybrid-search | PersonaMem 32k | 84.4% | -- | -- | AMB leaderboard |
@@ -33,11 +32,20 @@ Raw result JSON files are committed alongside this document in `benchmarks/`.
 | MemoryHub v0.2 (MiniLM) | PersonaMem 32k (589q) | 81.2% | -- | -- | This document, 2026-07-12 |
 | BM25 baseline | PersonaMem 32k | 67.7% | -- | -- | This document, 2026-07-12 |
 
+**Source ablation (Flash Lite, not leaderboard-comparable -- same model across all three for relative comparison):**
+
+| Run | PersonaMem 32k (589q) | Accuracy | Delta vs library |
+|-----|----------------------|----------|-----------------|
+| MemoryHub (Combined) | agent + dreaming | 72.8% | +0.1pp |
+| MemoryHub (Library-only) | agent only | 72.7% | baseline |
+| MemoryHub (Dreaming-only) | dreaming only | 50.9% | -21.8pp |
+
 Notes:
 - MemPalace numbers are from the LongMemEval paper's reported "session decomposition + fact-augmented key expansion + time-aware query expansion" pipeline.
 - Our run uses the oracle variant (evidence sessions only, not the full 115K-token haystack). The oracle variant isolates retrieval quality from the haystack-filtering step. Running LongMemEval_S (full haystack) is the next comparison point.
 - MemoryHub v0.3 uses granite-embedding-english + granite-reranker-english-r2 (GPU). MemoryHub v0.2 used all-MiniLM-L6-v2 (384-dim). MemPalace uses text-embedding-3-large (3072-dim).
-- PersonaMem accuracy column shows MCQ exact-match accuracy (not R@k). All MemoryHub and leaderboard runs use Gemini 3.1 Pro Preview as the answer LLM. BM25 number shown is the Flash Lite run (67.7%).
+- PersonaMem accuracy column shows MCQ exact-match accuracy (not R@k). Leaderboard runs use Gemini 3.1 Pro Preview as the answer LLM. The ablation table uses Flash Lite (not comparable to leaderboard numbers, but valid for relative comparison across source configurations).
+- The v0.3 Combined row (84.9%, 2026-07-19) was removed from the main table -- it was invalidated by a tenant mismatch bug (dreaming memories were never searched). See the detailed run section below.
 
 ## Benchmark Inventory
 
@@ -96,63 +104,50 @@ Result files: `amb-outputs/personamem/_archive/memoryhub-pro-unchunked-20260712/
 
 Result file: `outputs/personamem/granite-pro/rag/32k.json`
 
-#### Run: 2026-07-19 (v0.3, Combined library + dreaming, Gemini 3.1 Pro Preview)
+#### Run: 2026-07-19 (v0.3, Combined library + dreaming, Gemini 3.1 Pro Preview) -- INVALIDATED
 
-**Pipeline state:** Combined ingestion mode: library ingest (195 sessions as memory nodes with chunks) then dreaming extraction (985 facts extracted via gemini-3.1-flash-lite from conversation threads). Both coexist in a single project (`amb-combined-pro`): 3,468 agent-written memories (`source=agent`) + 985 extracted facts (`source=dreaming`). Search uses the full pool with Granite embeddings, reranker, and hybrid RRF blend.
+**Status: INVALIDATED.** Tenant mismatch meant dreaming memories were never searched. See root cause analysis below. Superseded by the 2026-07-20 Flash Lite ablation runs.
 
-**Answer LLM:** Gemini 3.1 Pro Preview (leaderboard-comparable).
-
-| Provider | Model | Queries | Correct | Accuracy |
-|----------|-------|---------|---------|----------|
-| **MemoryHub (Combined)** | **Gemini 3.1 Pro Preview** | **589** | **500** | **84.9%** |
-
-**AMB Leaderboard comparison (all using Gemini 3.1 Pro Preview):**
-
-| System | Approach | Accuracy |
-|--------|----------|----------|
-| Hindsight | LLM fact extraction into semantic graph | 86.6% |
-| **MemoryHub (Combined)** | **Granite embed + reranker, hybrid search + dreaming extraction** | **84.9%** |
-| MemoryHub (Granite) | Granite embed + reranker, hybrid search, no extraction | 84.9% |
-| hybrid-search | 512-token chunking, dense+sparse embeddings | 84.4% |
-| Cognee | Chunking + graph entity extraction | 81.8% |
-
-**Per-category comparison (library-only vs combined):**
-
-| Category | Library | Combined | Delta |
-|----------|---------|----------|-------|
-| recall_user_shared_facts | 104/129 (80.6%) | 109/129 (84.5%) | +3.9pp |
-| track_full_preference_evolution | 131/139 (94.2%) | 128/139 (92.1%) | -2.2pp |
-| recalling_the_reasons_behind_previous_updates | 91/99 (91.9%) | 91/99 (91.9%) | 0.0pp |
-| generalizing_to_new_scenarios | 53/57 (93.0%) | 52/57 (91.2%) | -1.8pp |
-| provide_preference_aligned_recommendations | 50/55 (90.9%) | 50/55 (90.9%) | 0.0pp |
-| recalling_facts_mentioned_by_the_user | 15/17 (88.2%) | 15/17 (88.2%) | 0.0pp |
-| suggest_new_ideas | 56/93 (60.2%) | 55/93 (59.1%) | -1.1pp |
-| **Overall** | **500/589 (84.9%)** | **500/589 (84.9%)** | **0.0pp** |
-
-**Key finding: tenant mismatch invalidates this run.** Post-hoc analysis (2026-07-20) revealed that the dreaming memories were ingested under `tenant_id='default'` while searches used `tenant_id='amb-benchmark'`. The two memory populations were never visible to the same search. This run is effectively a duplicate of the library-only baseline, not a combined test.
-
-**Evidence:** All 589 queries return byte-identical retrieved context between the library-only and combined runs. The 12 queries that flipped (6 gained, 6 lost) are pure Gemini Pro answering non-determinism. A direct DB query confirms: `SELECT source, tenant_id, COUNT(*) FROM memory_nodes WHERE scope_id = 'amb-combined-pro' GROUP BY source, tenant_id` returns `agent/amb-benchmark: 3,468` and `dreaming/default: 985`.
-
-**Root cause:** The harness `_run_dreaming_ingest()` creates threads and extracts facts via the MCP server, but never passes `tenant_id` to the thread/extraction pipeline. The library path explicitly passes `tenant_id` on each `write()` call; the dreaming path uses the session default tenant (`default`).
-
-**Per-category deltas (not meaningful given the above, but recorded for completeness):**
-
-| Category | Library | Combined | Delta |
-|----------|---------|----------|-------|
-| recall_user_shared_facts | 104/129 (80.6%) | 109/129 (84.5%) | +3.9pp |
-| track_full_preference_evolution | 131/139 (94.2%) | 128/139 (92.1%) | -2.2pp |
-| recalling_the_reasons_behind_previous_updates | 91/99 (91.9%) | 91/99 (91.9%) | 0.0pp |
-| generalizing_to_new_scenarios | 53/57 (93.0%) | 52/57 (91.2%) | -1.8pp |
-| provide_preference_aligned_recommendations | 50/55 (90.9%) | 50/55 (90.9%) | 0.0pp |
-| recalling_facts_mentioned_by_the_user | 15/17 (88.2%) | 15/17 (88.2%) | 0.0pp |
-| suggest_new_ideas | 56/93 (60.2%) | 55/93 (59.1%) | -1.1pp |
-| **Overall** | **500/589 (84.9%)** | **500/589 (84.9%)** | **0.0pp** |
-
-**Status:** This run must be re-done after fixing the tenant mismatch in the dreaming ingestion path. A preflight smoke-check system was added to `omb run` (2026-07-20) to prevent this class of bug from reaching full runs.
-
-**Source tagging validated:** The `source` column (migration 026) correctly tags library memories as `agent` and extracted facts as `dreaming`. The `exclude_source` search filter enables ablation testing without re-ingestion.
+**Root cause:** The harness `_run_dreaming_ingest()` created threads and extracted facts via the MCP server without passing `tenant_id`. Dreaming memories landed under `tenant_id='default'` while searches used `tenant_id='amb-benchmark'`. All 589 queries returned byte-identical context between library-only and combined runs. Fix: PR #441 adds per-call `tenant_id` to thread create/extract (server, SDK, harness).
 
 Result file: `outputs/personamem/combined-pro/rag/32k.json`
+
+#### Run: 2026-07-20 (v0.3, Source ablation -- combined/library/dreaming, Flash Lite)
+
+**Pipeline state:** Same `amb-combined-pro` project: 3,468 agent-written memories (`source=agent`) + 985 extracted facts (`source=dreaming`). Tenant mismatch fixed (PR #441) and verified via preflight (`--expect-sources agent,dreaming`). Granite embeddings, reranker, hybrid RRF blend. Three runs with source filters isolate each population's contribution.
+
+**Answer LLM:** Gemini 3.1 Flash Lite. Not leaderboard-comparable (leaderboard uses Pro), but valid for measuring dreaming's retrieval contribution since the same model is used across all three runs.
+
+| Run | Source filter | Queries | Correct | Accuracy |
+|-----|--------------|---------|---------|----------|
+| **Combined** | (none) | 589 | 429 | **72.8%** |
+| **Library-only** | exclude_source=dreaming | 589 | 428 | **72.7%** |
+| **Dreaming-only** | source=dreaming | 589 | 300 | **50.9%** |
+
+**Per-category ablation (library-only vs combined vs dreaming-only):**
+
+| Category | Library | Combined | Dreaming | Delta |
+|----------|---------|----------|----------|-------|
+| recalling_the_reasons_behind_previous_updates | 94/99 (94.9%) | 94/99 (94.9%) | 66/99 (66.7%) | 0.0pp |
+| generalizing_to_new_scenarios | 54/57 (94.7%) | 54/57 (94.7%) | 38/57 (66.7%) | 0.0pp |
+| track_full_preference_evolution | 115/139 (82.7%) | 115/139 (82.7%) | 78/139 (56.1%) | 0.0pp |
+| recall_user_shared_facts | 102/129 (79.1%) | 102/129 (79.1%) | 78/129 (60.5%) | 0.0pp |
+| provide_preference_aligned_recommendations | 40/55 (72.7%) | 40/55 (72.7%) | 24/55 (43.6%) | 0.0pp |
+| recalling_facts_mentioned_by_the_user | 10/17 (58.8%) | 10/17 (58.8%) | 5/17 (29.4%) | 0.0pp |
+| suggest_new_ideas | 13/93 (14.0%) | 14/93 (15.1%) | 11/93 (11.8%) | +1.1pp |
+| **Overall** | **428/589 (72.7%)** | **429/589 (72.8%)** | **300/589 (50.9%)** | **+0.1pp** |
+
+**Key finding: dreaming facts do not improve retrieval in the current architecture.** The combined run gains only +0.1pp over library-only (1 additional correct answer out of 589). Six of seven categories show zero delta. The single flipped query (suggest_new_ideas) is within LLM answering noise.
+
+**Root cause analysis:** Raw SQL vector search confirms dreaming memories ARE findable (they appear at cosine rank ~13-15 for a typical persona), but full conversation transcripts dominate the top-k. With k=70 and ~100 agent memories per persona, agent memories fill the retrieval window before dreaming facts rank high enough. The extracted facts are semantically different from the query+transcript embedding space and get pushed below the cutoff.
+
+**Implications for the dreaming pipeline:**
+
+1. **Fact extraction quality is not the bottleneck.** Dreaming-only achieves 50.9%, which means the extracted facts DO contain the right information for half the questions. The problem is retrieval ranking, not extraction.
+2. **Naive pooling doesn't work.** Simply adding facts to the same vector index as transcripts produces near-zero lift because the transcripts crowd them out.
+3. **Architecture changes needed to realize value:** retrieval-unit routing (search facts and transcripts separately, merge results), fact-aware scoring (boost extracted facts in RRF), or a two-stage pipeline (retrieve transcripts, then enrich with related facts).
+
+Result files: `outputs/personamem/combined-flash-lite/rag/32k.json`, `outputs/personamem/ablation-library-only/rag/32k.json`, `outputs/personamem/ablation-dreaming-only/rag/32k.json`
 
 #### Run: 2026-07-12 (v0.2, SDK provider with chunking, Flash Lite)
 

--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -18,24 +18,26 @@ Raw result JSON files are committed alongside this document in `benchmarks/`.
 
 ## Competitive Context
 
-| System | Benchmark | R@5 | R@10 | MRR | Source |
-|--------|-----------|-----|------|-----|--------|
-| **MemoryHub v0.2** | LongMemEval oracle (500q) | **0.999** | **1.000** | **1.000** | This document, 2026-07-10 |
-| MemPalace (hybrid) | LongMemEval | 0.984 | -- | -- | Wu et al., ICLR 2025 |
-| MemPalace (semantic only) | LongMemEval | 0.966 | -- | -- | Wu et al., ICLR 2025 |
-| GPT-4o (no memory layer) | LongMemEval | ~0.30-0.70 | -- | -- | Wu et al., ICLR 2025 |
+| System | Benchmark | R@5 | R@10 | MRR | Embedding Model | Source |
+|--------|-----------|-----|------|-----|-----------------|--------|
+| **MemoryHub v0.2** | LongMemEval oracle (500q) | **0.999** | **1.000** | **1.000** | all-MiniLM-L6-v2 (384d) | This document, 2026-07-10 |
+| MemPalace (hybrid) | LongMemEval | 0.984 | -- | -- | text-embedding-3-large (3072d) | Wu et al., ICLR 2025 |
+| MemPalace (semantic only) | LongMemEval | 0.966 | -- | -- | text-embedding-3-large (3072d) | Wu et al., ICLR 2025 |
+| GPT-4o (no memory layer) | LongMemEval | ~0.30-0.70 | -- | -- | (none) | Wu et al., ICLR 2025 |
 
-| **MemoryHub v0.3 (Granite)** | PersonaMem 32k (589q) | **84.9%** | -- | -- | This document, 2026-07-16 |
-| Hindsight | PersonaMem 32k | 86.6% | -- | -- | AMB leaderboard |
-| hybrid-search | PersonaMem 32k | 84.4% | -- | -- | AMB leaderboard |
-| Cognee | PersonaMem 32k | 81.8% | -- | -- | AMB leaderboard |
-| MemoryHub v0.2 (MiniLM) | PersonaMem 32k (589q) | 81.2% | -- | -- | This document, 2026-07-12 |
-| BM25 baseline | PersonaMem 32k | 67.7% | -- | -- | This document, 2026-07-12 |
+| System | PersonaMem 32k | Answer LLM | Embedding / Retrieval | Source |
+|--------|---------------|------------|----------------------|--------|
+| Hindsight | 86.6% | Gemini 3.1 Pro Preview | LLM fact extraction into semantic graph | AMB leaderboard |
+| **MemoryHub v0.3 (Granite)** | **84.9%** | Gemini 3.1 Pro Preview | granite-embedding-english + granite-reranker-english-r2 (GPU) | This document, 2026-07-16 |
+| hybrid-search | 84.4% | Gemini 3.1 Pro Preview | 512-token chunking, dense+sparse embeddings | AMB leaderboard |
+| Cognee | 81.8% | Gemini 3.1 Pro Preview | chunking + graph entity extraction | AMB leaderboard |
+| MemoryHub v0.2 (MiniLM) | 81.2% | Gemini 3.1 Pro Preview | all-MiniLM-L6-v2 (384d), no reranker | This document, 2026-07-12 |
+| BM25 baseline | 67.7% | Gemini 3.1 Flash Lite | keyword only | This document, 2026-07-12 |
 
-**Source ablation (Flash Lite, not leaderboard-comparable -- same model across all three for relative comparison):**
+**Source ablation (Flash Lite answer LLM, not leaderboard-comparable -- same model across all three for relative comparison):**
 
-| Run | PersonaMem 32k (589q) | Accuracy | Delta vs library |
-|-----|----------------------|----------|-----------------|
+| Run | Source filter | Accuracy | Delta vs library |
+|-----|-------------|----------|-----------------|
 | MemoryHub (Combined) | agent + dreaming | 72.8% | +0.1pp |
 | MemoryHub (Library-only) | agent only | 72.7% | baseline |
 | MemoryHub (Dreaming-only) | dreaming only | 50.9% | -21.8pp |
@@ -44,8 +46,9 @@ Notes:
 - MemPalace numbers are from the LongMemEval paper's reported "session decomposition + fact-augmented key expansion + time-aware query expansion" pipeline.
 - Our run uses the oracle variant (evidence sessions only, not the full 115K-token haystack). The oracle variant isolates retrieval quality from the haystack-filtering step. Running LongMemEval_S (full haystack) is the next comparison point.
 - MemoryHub v0.3 uses granite-embedding-english + granite-reranker-english-r2 (GPU). MemoryHub v0.2 used all-MiniLM-L6-v2 (384-dim). MemPalace uses text-embedding-3-large (3072-dim).
-- PersonaMem accuracy column shows MCQ exact-match accuracy (not R@k). Leaderboard runs use Gemini 3.1 Pro Preview as the answer LLM. The ablation table uses Flash Lite (not comparable to leaderboard numbers, but valid for relative comparison across source configurations).
+- All PersonaMem leaderboard runs use Gemini 3.1 Pro Preview as the answer LLM. The ablation table uses Gemini 3.1 Flash Lite (not comparable to leaderboard numbers, but valid for relative comparison across source configurations).
 - The v0.3 Combined row (84.9%, 2026-07-19) was removed from the main table -- it was invalidated by a tenant mismatch bug (dreaming memories were never searched). See the detailed run section below.
+- Retrieval-unit routing (#447) is the planned architecture change to make dreaming facts contribute to combined search results.
 
 ## Benchmark Inventory
 

--- a/benchmarks/amb-harness/src/memory_bench/memory/memoryhub.py
+++ b/benchmarks/amb-harness/src/memory_bench/memory/memoryhub.py
@@ -222,7 +222,7 @@ class MemoryHubProvider(MemoryProvider):
                 sorted(persona_sessions.items()), 1
             ):
                 owner = f"amb-{persona_id}" if persona_id else "amb-default"
-                thread = await client.create_thread(
+                create_kwargs: dict[str, Any] = dict(
                     scope="project",
                     scope_id=self._project_id,
                     owner_id=owner,
@@ -233,6 +233,9 @@ class MemoryHubProvider(MemoryProvider):
                         "session_count": len(sessions),
                     },
                 )
+                if self._tenant_id:
+                    create_kwargs["tenant_id"] = self._tenant_id
+                thread = await client.create_thread(**create_kwargs)
                 logger.info(
                     "Persona %d/%d (%s): thread %s, %d sessions",
                     p_idx, total_personas, persona_id, thread.id, len(sessions),
@@ -258,6 +261,8 @@ class MemoryHubProvider(MemoryProvider):
                         extract_kwargs["model"] = self._extraction_model
                     if self._extraction_model_url:
                         extract_kwargs["model_url"] = self._extraction_model_url
+                    if self._tenant_id:
+                        extract_kwargs["tenant_id"] = self._tenant_id
 
                     result = await client.extract_thread(thread.id, **extract_kwargs)
                     total_extractions += result.extracted_count

--- a/memory-hub-mcp/src/tools/search_memory.py
+++ b/memory-hub-mcp/src/tools/search_memory.py
@@ -142,6 +142,7 @@ def _compact_entry(
         entry["content"] = item.stub
     entry["content_truncated"] = item.content_truncated
     entry["full_available"] = item.full_available
+    entry["source"] = getattr(item, "source", "agent")
     if relevance_score is not None:
         entry["relevance_score"] = round(relevance_score, 4)
     return entry

--- a/memory-hub-mcp/src/tools/thread.py
+++ b/memory-hub-mcp/src/tools/thread.py
@@ -22,7 +22,7 @@ _VALID_ACTIONS = frozenset({
 
 _CREATE_OPTS = frozenset({
     "title", "participant_ids", "participant_access",
-    "a2a_context_id", "scope_id", "owner_id", "metadata",
+    "a2a_context_id", "scope_id", "owner_id", "metadata", "tenant_id",
 })
 _APPEND_OPTS = frozenset({"actor_id", "tool_call_id", "metadata", "a2a_context_id"})
 _GET_OPTS = frozenset({"limit", "before_sequence", "include_messages"})
@@ -30,7 +30,7 @@ _LIST_OPTS = frozenset({
     "scope_id", "status", "participant_id", "limit", "offset",
 })
 _ARCHIVE_OPTS = frozenset({"reason"})
-_EXTRACT_OPTS = frozenset({"turn_range", "model", "model_url"})
+_EXTRACT_OPTS = frozenset({"turn_range", "model", "model_url", "tenant_id"})
 _FORK_OPTS = frozenset({"from_sequence", "title"})
 _SHARE_OPTS = frozenset({"grantee_id", "access_level", "authorized_by"})
 _DELETE_OPTS = frozenset({"cascade"})
@@ -156,7 +156,7 @@ async def _dispatch_create(scope, opts, ctx):
         AuthenticationError,
         authorize_write,
         get_claims_from_context,
-        get_tenant_filter,
+        resolve_tenant,
     )
     from src.tools._deps import get_db_session, release_db_session
 
@@ -167,7 +167,7 @@ async def _dispatch_create(scope, opts, ctx):
     except AuthenticationError as exc:
         raise ToolError(str(exc)) from exc
 
-    tenant = get_tenant_filter(claims)
+    tenant = resolve_tenant(claims, opts.get("tenant_id"))
     caller_id = claims["sub"]
 
     project_ids: set[str] | None = None
@@ -471,7 +471,7 @@ async def _dispatch_extract(thread_id_str, opts, ctx):
         AuthenticationError,
         authorize_thread_read,
         get_claims_from_context,
-        get_tenant_filter,
+        resolve_tenant,
     )
     from src.tools._deps import get_db_session, get_embedding_service, get_s3_adapter, release_db_session
 
@@ -487,7 +487,7 @@ async def _dispatch_extract(thread_id_str, opts, ctx):
     except AuthenticationError as exc:
         raise ToolError(str(exc)) from exc
 
-    tenant = get_tenant_filter(claims)
+    tenant = resolve_tenant(claims, opts.get("tenant_id"))
     caller_id = claims["sub"]
     s3_adapter = get_s3_adapter()
     embedding_service = get_embedding_service()

--- a/planning/retrieval-unit-routing.md
+++ b/planning/retrieval-unit-routing.md
@@ -1,0 +1,62 @@
+# Retrieval-Unit Routing
+
+Status: skeleton
+Issue: #447
+Epic: #349 (dreaming benchmark)
+
+## Problem
+
+The 2026-07-20 source ablation benchmark showed that naive pooling of
+extracted facts with full conversation transcripts produces negligible
+lift (+0.1pp: 72.8% combined vs 72.7% library-only). Dreaming-only
+achieves 50.9%, proving the facts contain useful information, but full
+transcripts dominate the top-k retrieval window and crowd facts out.
+
+Raw SQL confirms dreaming facts appear at cosine rank ~13-15 per persona,
+behind ~12 agent memories whose embedding similarity is inflated by shared
+persona-header prefixes. With k=70 and ~100 agent memories per persona,
+facts rarely surface in results.
+
+Hindsight (86.6%, #1 on PersonaMem) uses LLM fact extraction into a
+semantic graph searched separately -- the architecture pattern this
+design addresses.
+
+## Approaches
+
+### A. Retrieval-unit routing (search separately, merge)
+
+Search facts and transcripts as independent retrieval units with separate
+top-k pools, then interleave/merge results before passing to the LLM.
+
+Pros: clean separation, tunable mix ratio, easy to A/B test.
+Cons: doubles search cost (two embedding lookups + two reranker passes).
+
+### B. Fact-aware RRF scoring
+
+Boost `source=dreaming` memories in the RRF blend with a configurable
+weight multiplier, similar to the existing domain boost.
+
+Pros: single search path, minimal code change.
+Cons: boost factor requires tuning, may over-promote low-relevance facts.
+
+### C. Two-stage retrieve-then-enrich
+
+Retrieve transcripts first, then for each result find related facts
+(by parent thread or entity overlap) and append them to context.
+
+Pros: facts serve as enrichment rather than competing for rank.
+Cons: requires relationship traversal, adds latency.
+
+## Decision
+
+TBD -- benchmark each approach against the Flash Lite ablation baseline.
+
+## Implementation plan
+
+TBD
+
+## Benchmark validation
+
+Baseline: 72.7% library-only, 72.8% combined (Flash Lite).
+Target: measurable lift from dreaming facts (>= +2pp on combined).
+Method: same ablation protocol (combined vs library-only vs dreaming-only).

--- a/scripts/seed-sample-data.py
+++ b/scripts/seed-sample-data.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""Seed MemoryHub with sample data so the admin UI has content to display.
+
+Usage:
+    # Uses MCP_URL env var or prompts; reads API key from ~/.config/memoryhub/api-key
+    python scripts/seed-sample-data.py
+
+    # Explicit URL and key
+    python scripts/seed-sample-data.py --url https://memory-hub-mcp-....apps.example.com/mcp/ --api-key mh-dev-abc123
+
+    # Skip if data already exists
+    python scripts/seed-sample-data.py --skip-if-exists
+
+Requires: pip install memoryhub
+"""
+import argparse
+import asyncio
+import sys
+from pathlib import Path
+
+try:
+    from memoryhub import MemoryHubClient
+except ImportError:
+    print("Error: memoryhub SDK not installed. Run: pip install memoryhub")
+    sys.exit(1)
+
+
+PROJECT_ID = "sample-project"
+MEMORIES = [
+    # (content, scope, weight, content_type, project_id)
+    (
+        "Use FastAPI over Flask for all new Python web services. FastAPI provides "
+        "built-in async support, automatic OpenAPI documentation, and Pydantic "
+        "validation that eliminates an entire class of bugs.",
+        "user", 0.9, "knowledge", None,
+    ),
+    (
+        "PostgreSQL with pgvector handles relational, vector, and lightweight "
+        "graph queries in a single database. This avoids the operational overhead "
+        "of running separate vector and graph databases for most workloads.",
+        "user", 0.85, "knowledge", None,
+    ),
+    (
+        "When building containers for OpenShift on a Mac, always specify "
+        "--platform linux/amd64 to avoid architecture mismatches. The cluster "
+        "runs x86_64; ARM images will crash with exec format errors.",
+        "user", 0.95, "knowledge", None,
+    ),
+    (
+        "Red Hat UBI base images are required for all container builds in "
+        "regulated environments. They include FIPS-validated crypto modules "
+        "and receive CVE patches on Red Hat's security SLA.",
+        "project", 0.9, "knowledge", PROJECT_ID,
+    ),
+    (
+        "The embedding model (all-MiniLM-L6-v2) runs on CPU and returns "
+        "384-dimensional vectors. It handles up to 256 tokens per input. "
+        "For longer documents, chunk at paragraph boundaries.",
+        "project", 0.8, "knowledge", PROJECT_ID,
+    ),
+    (
+        "Agent memory retrieval uses two-vector RRF: the query vector finds "
+        "semantically relevant memories, and the session focus vector biases "
+        "results toward the current work context. Cross-encoder reranking "
+        "runs as a second pass for precision.",
+        "project", 0.85, "knowledge", PROJECT_ID,
+    ),
+    (
+        "Deploy database schema changes through Alembic migrations, never "
+        "through create_all(). Alembic handles column additions and type "
+        "changes on existing tables; create_all() silently skips them.",
+        "project", 0.9, "knowledge", PROJECT_ID,
+    ),
+    (
+        "The MCP server exposes three tool profiles: compact (4 action-dispatch "
+        "tools, default), full (13 individual tools), and minimal (5 tools). "
+        "Most agents should use compact -- it reduces tool-selection overhead "
+        "while keeping the full API surface available through action parameters.",
+        "project", 0.8, "knowledge", PROJECT_ID,
+    ),
+    (
+        "OAuth 2.1 client_credentials flow is the production auth path. API "
+        "keys (mh-dev-<hex>) are the developer convenience path. Both issue "
+        "JWTs validated against the auth server's JWKS endpoint. Start with "
+        "API keys; move to OAuth when you need automatic token refresh.",
+        "user", 0.75, "experiential", None,
+    ),
+    (
+        "MinIO provides S3-compatible object storage for large memory content. "
+        "Memories under 4KB are stored inline in PostgreSQL; larger content "
+        "is stored in MinIO with a reference pointer in the database row.",
+        "project", 0.7, "knowledge", PROJECT_ID,
+    ),
+]
+
+
+async def main():
+    parser = argparse.ArgumentParser(description="Seed MemoryHub with sample data")
+    parser.add_argument("--url", help="MCP server URL (or set MCP_URL env var)")
+    parser.add_argument("--api-key", help="API key (or store at ~/.config/memoryhub/api-key)")
+    parser.add_argument("--skip-if-exists", action="store_true",
+                        help="Skip seeding if memories already exist")
+    args = parser.parse_args()
+
+    url = args.url
+    if not url:
+        import os
+        url = os.environ.get("MCP_URL")
+    if not url:
+        print("Error: provide --url or set MCP_URL environment variable")
+        sys.exit(1)
+
+    api_key = args.api_key
+    if not api_key:
+        key_path = Path.home() / ".config/memoryhub/api-key"
+        if key_path.exists():
+            api_key = key_path.read_text().strip()
+        else:
+            print(f"Error: provide --api-key or store key at {key_path}")
+            sys.exit(1)
+
+    client = MemoryHubClient(url=url, api_key=api_key)
+
+    async with client:
+        session = await client.get_session()
+        print(f"Authenticated as {session.get('user_id', 'unknown')}")
+
+        if args.skip_if_exists:
+            existing = await client.search("sample seed data check", max_results=1)
+            if existing.results:
+                print("Memories already exist -- skipping (use without --skip-if-exists to add more)")
+                return
+
+        # Create the sample project
+        try:
+            await client._call_action("create_project", project_id=PROJECT_ID)
+            print(f"Created project: {PROJECT_ID}")
+        except Exception:
+            print(f"Project '{PROJECT_ID}' already exists -- continuing")
+
+        # Write memories
+        memory_ids = []
+        for i, (content, scope, weight, content_type, project_id) in enumerate(MEMORIES, 1):
+            try:
+                result = await client.write(
+                    content=content,
+                    scope=scope,
+                    weight=weight,
+                    content_type=content_type,
+                    project_id=project_id,
+                )
+                if result.memory:
+                    memory_ids.append(result.memory.id)
+                    print(f"  [{i}/{len(MEMORIES)}] Written: {content[:60]}...")
+                else:
+                    print(f"  [{i}/{len(MEMORIES)}] Blocked by curation: {content[:40]}...")
+            except Exception as e:
+                print(f"  [{i}/{len(MEMORIES)}] Error: {e}")
+
+        # Create a relationship between two project memories
+        if len(memory_ids) >= 6:
+            try:
+                await client._call_action(
+                    "relate",
+                    options={
+                        "source_id": memory_ids[4],
+                        "target_id": memory_ids[5],
+                        "relationship_type": "related_to",
+                    },
+                )
+                print("  Created relationship: embedding model -> two-vector retrieval")
+            except Exception as e:
+                print(f"  Relationship error: {e}")
+
+        if len(memory_ids) >= 8:
+            try:
+                await client._call_action(
+                    "relate",
+                    options={
+                        "source_id": memory_ids[6],
+                        "target_id": memory_ids[7],
+                        "relationship_type": "related_to",
+                    },
+                )
+                print("  Created relationship: alembic migrations -> MCP server profiles")
+            except Exception as e:
+                print(f"  Relationship error: {e}")
+
+        print(f"\nSeeded {len(memory_ids)} memories across user and project scopes.")
+        print("Open the MemoryHub dashboard to see them in the Memory Graph panel.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/sdk/src/memoryhub/client.py
+++ b/sdk/src/memoryhub/client.py
@@ -1563,6 +1563,7 @@ class MemoryHubClient:
         participant_access: dict[str, str] | None = None,
         a2a_context_id: str | None = None,
         metadata: dict[str, Any] | None = None,
+        tenant_id: str | None = None,
     ) -> ConversationThread:
         """Create a new conversation thread."""
         opts: dict[str, Any] = {}
@@ -1580,6 +1581,8 @@ class MemoryHubClient:
             opts["a2a_context_id"] = a2a_context_id
         if metadata is not None:
             opts["metadata"] = metadata
+        if tenant_id is not None:
+            opts["tenant_id"] = tenant_id
         data = await self._call_thread_action("create", scope=scope, options=opts or None)
         return ConversationThread.model_validate(data)
 
@@ -1653,6 +1656,7 @@ class MemoryHubClient:
         turn_range: tuple[int, int] | None = None,
         model: str | None = None,
         model_url: str | None = None,
+        tenant_id: str | None = None,
     ) -> ExtractionResult:
         """Trigger extraction pipeline on a thread."""
         opts: dict[str, Any] = {}
@@ -1662,6 +1666,8 @@ class MemoryHubClient:
             opts["model"] = model
         if model_url is not None:
             opts["model_url"] = model_url
+        if tenant_id is not None:
+            opts["tenant_id"] = tenant_id
         data = await self._call_thread_action("extract", thread_id=thread_id, options=opts or None)
         return ExtractionResult.model_validate(data)
 

--- a/session-summaries/2026-07-21-install-test-docs.md
+++ b/session-summaries/2026-07-21-install-test-docs.md
@@ -1,0 +1,38 @@
+# Session Summary -- 2026-07-21 -- Install testing & docs
+
+**Plan:** Ad-hoc install validation on fresh clusters   **Commits:** 5fed05d..248fdc2 (feat/dreaming-ablation-results)
+**Deployed:** Two fresh test clusters (memory-hub-install-test-2, memory-hub-install-test-3)   **Model:** Opus 4.6
+
+## Plan vs. actual
+Planned: Test `make install` end-to-end on fresh clusters, fix docs. Shipped: Full install validated on two clusters, README post-install guide added, workshop-setup scripts hardened, seed script created. Scope stayed tight.
+
+## Shipped
+- `248fdc2` docs: Post-install guide (API key retrieval, CLI install, Claude Code connection, RHOAI dashboard walkthrough), fixed `claude mcp add` syntax, fixed `make uninstall` flag syntax, added `scripts/seed-sample-data.py`
+- workshop-setup `4c64bd9` fix: Removed duplicate OperatorGroup that silently blocked RHOAI InstallPlan
+- workshop-setup `613df1e` fix: Added `--context` flag to setup.sh and setup-rhoai.sh, removed hardcoded CSV versions
+- workshop-setup `15db9c8` fix: Phased operand application to avoid CRD race condition on fresh clusters
+
+## Verification & confidence
+- Both clusters installed end-to-end: prereq check, full deploy, MCP roundtrip (register + write + search)
+- Seed script tested on cluster 2 with real data (10 memories, 2 relationships)
+- Confidence: high -- two independent fresh-cluster runs, zero manual intervention on cluster 3
+
+## Judgment calls & deviations
+- Used Python SDK for seed script instead of raw curl -- cleaner, more maintainable, SDK is already a documented dependency
+- Changed `make uninstall` docs to show direct script invocation rather than adding Makefile passthrough targets -- simpler and honest about how Make works
+
+## Backlog delta
+Filed: none. Closed: none. Pre-existing: CI Secret Scanning false positive on example ConfigMap (not new).
+
+## Drift & forward-collisions
+- Backward: none
+- Forward: none
+
+## For the reviewer
+- Sanity-check: the seed script's memory content is reasonable/realistic for a demo
+- Thin verification: local test suite hangs (CI passes); root cause not investigated
+- Wants guidance: none
+
+## Risks / watch-fors
+- Local pytest hangs may indicate a venv or import issue worth investigating in a future session
+- The `users-configmap.example.yaml` false positive in CI Secret Scanning should get a gitleaks allowlist entry eventually


### PR DESCRIPTION
## Summary

- Source ablation benchmark results: dreaming adds +0.1pp (Flash Lite, 589 queries x3 runs)
- Tenant fix for thread create/extract (per-call tenant_id propagation)
- Search compact format includes source field
- Retrieval-unit routing design doc (#447)
- Curation epic plan (NEXT_SESSION-curation.md) for #350-353, #345
- NEXT_SESSION files now tracked in git (removed .gitignore exclusion)
- Branch strategy documented in CLAUDE.md
- Post-install guide, seed script, claude mcp add syntax fix
- Session summary for 2026-07-21

## Test plan

- [x] Source ablation runs completed (72.8% combined, 72.7% library-only, 50.9% dreaming-only)
- [x] Tenant fix validated via preflight --expect-sources
- [x] README conflict resolved cleanly after rebase onto main
- [ ] CI checks pass

Closes #349