### PR TITLE
fix: Make install/uninstall actually forward flags via ARGS

### DIFF
--- a/.claude/hooks/load-memories.sh
+++ b/.claude/hooks/load-memories.sh
@@ -6,12 +6,56 @@
 
 set -euo pipefail
 
-API_KEY_FILE="$HOME/.config/memoryhub/api-key"
-[ -f "$API_KEY_FILE" ] || exit 0
+# --- Credential resolution ---
+# 1. MEMORYHUB_API_KEY env var (already set)
+# 2. ~/.config/memoryhub/credentials (INI, MEMORYHUB_CONTEXT or [default])
+# 3. ~/.config/memoryhub/api-key (flat file, backwards compat)
 
-API_KEY=$(tr -d '\n' < "$API_KEY_FILE")
-[ -n "$API_KEY" ] || exit 0
-export MEMORYHUB_API_KEY="$API_KEY"
+CREDS_FILE="$HOME/.config/memoryhub/credentials"
+API_KEY_FILE="$HOME/.config/memoryhub/api-key"
+
+if [ -z "${MEMORYHUB_API_KEY:-}" ]; then
+  if [ -f "$CREDS_FILE" ]; then
+    SECTION="${MEMORYHUB_CONTEXT:-default}"
+    MEMORYHUB_API_KEY=$(awk -v section="$SECTION" '
+      /^\[/ { in_section = ($0 == "[" section "]") }
+      in_section && /^api_key[[:space:]]*=/ {
+        sub(/^api_key[[:space:]]*=[[:space:]]*/, ""); print; exit
+      }
+    ' "$CREDS_FILE")
+    if [ -z "${MEMORYHUB_API_KEY:-}" ] && [ "$SECTION" != "default" ]; then
+      MEMORYHUB_API_KEY=$(awk '
+        /^\[/ { in_section = ($0 == "[default]") }
+        in_section && /^api_key[[:space:]]*=/ {
+          sub(/^api_key[[:space:]]*=[[:space:]]*/, ""); print; exit
+        }
+      ' "$CREDS_FILE")
+    fi
+  elif [ -f "$API_KEY_FILE" ]; then
+    MEMORYHUB_API_KEY=$(grep -v '^#' "$API_KEY_FILE" | tr -d '\n')
+  fi
+fi
+[ -n "${MEMORYHUB_API_KEY:-}" ] || exit 0
+export MEMORYHUB_API_KEY
+
+# --- URL resolution ---
+if [ -z "${MEMORYHUB_URL:-}" ] && [ -f "$CREDS_FILE" ]; then
+  SECTION="${MEMORYHUB_CONTEXT:-default}"
+  MEMORYHUB_URL=$(awk -v section="$SECTION" '
+    /^\[/ { in_section = ($0 == "[" section "]") }
+    in_section && /^url[[:space:]]*=/ {
+      sub(/^url[[:space:]]*=[[:space:]]*/, ""); print; exit
+    }
+  ' "$CREDS_FILE")
+  if [ -z "${MEMORYHUB_URL:-}" ] && [ "$SECTION" != "default" ]; then
+    MEMORYHUB_URL=$(awk '
+      /^\[/ { in_section = ($0 == "[default]") }
+      in_section && /^url[[:space:]]*=/ {
+        sub(/^url[[:space:]]*=[[:space:]]*/, ""); print; exit
+      }
+    ' "$CREDS_FILE")
+  fi
+fi
 
 if [ -z "${MEMORYHUB_URL:-}" ]; then
   CONFIG_FILE="$HOME/.config/memoryhub/config.json"

--- a/.claude/rules/memoryhub-loading.md
+++ b/.claude/rules/memoryhub-loading.md
@@ -16,7 +16,9 @@ its contents as initial context. Do NOT call `register_session` or
 
 If no `<memoryhub-context>` block is present (CLI not installed or hook
 misconfigured), fall back to the manual flow: read your API key from
-`~/.config/memoryhub/api-key` (trim whitespace) and call
+`~/.config/memoryhub/credentials` (INI file, section matching
+`MEMORYHUB_CONTEXT` or `[default]`, falling back to
+`~/.config/memoryhub/api-key`) and call
 `register_session(api_key="<key>")`. Do NOT call `search_memory` --
 there is no working set in this pattern.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,14 +101,14 @@ Example: `memory-tree: Add versioning with isCurrent flag`
 
 ## Credential Hygiene
 
-Credentials, API keys, and tokens must never appear in session summaries, plans, issues, or any committed documentation. Reference the secret's storage location instead (e.g., "stored in memoryhub-auth cluster secret" or "see ~/.config/memoryhub/api-key"). This applies to all key formats including hex-format keys (`mh-dev-<hex>`), OAuth client secrets, and database passwords. Incident: a hex-format API key committed in a session summary (2026-07-14) required rotation and git history scrubbing.
+Credentials, API keys, and tokens must never appear in session summaries, plans, issues, or any committed documentation. Reference the secret's storage location instead (e.g., "stored in memoryhub-auth cluster secret" or "see ~/.config/memoryhub/credentials"). This applies to all key formats including hex-format keys (`mh-dev-<hex>`), OAuth client secrets, and database passwords. Incident: a hex-format API key committed in a session summary (2026-07-14) required rotation and git history scrubbing.
 
 ## Secrets and Env Var Reference
 
 Where credentials live and how to use them. This eliminates "secrets archaeology" at session start.
 
 **Local developer machine:**
-- `~/.config/memoryhub/api-key` -- MemoryHub API key for SDK/MCP client auth
+- `~/.config/memoryhub/credentials` -- MemoryHub API keys and URLs per cluster context (INI-style, keyed by MEMORYHUB_CONTEXT)
 - `~/.secrets` -- shell-sourceable file with `GEMINI_API_KEY`, `GOOGLE_API_KEY`, etc.
 
 **Cluster Secrets (mcp-rhoai context):**
@@ -131,7 +131,7 @@ The MCP server calls an OpenAI-compatible `/chat/completions` endpoint for fact 
 
 **EvalHub adapter env vars (injected by `deploy-evalhub.sh` provider registration):**
 - `MEMORYHUB_URL` -- internal MCP service: `http://memory-hub-mcp.memory-hub-mcp.svc:8080/mcp/`
-- `MEMORYHUB_API_KEY` -- from `~/.config/memoryhub/api-key` at registration time
+- `MEMORYHUB_API_KEY` -- from `~/.config/memoryhub/credentials` at registration time
 - `MEMORYHUB_DB_HOST` -- internal DB service: `memoryhub-pg.memoryhub-db.svc.cluster.local`
 - `MEMORYHUB_DB_PORT` -- `5432` (internal, not the port-forward 25432)
 - `MEMORYHUB_DB_USER` -- `memoryhub`

--- a/Makefile
+++ b/Makefile
@@ -37,13 +37,13 @@ help:
 # ---------------------------------------------------------------------------
 
 install:
-	scripts/deploy-full.sh
+	scripts/deploy-full.sh $(ARGS)
 
 uninstall:
-	scripts/uninstall-full.sh
+	scripts/uninstall-full.sh $(ARGS)
 
 check-prereqs:
-	scripts/check-prereqs.sh
+	scripts/check-prereqs.sh $(ARGS)
 
 # Backward compat
 deploy-all: install

--- a/README.md
+++ b/README.md
@@ -115,19 +115,19 @@ This passes `--context` on every `oc` command and never mutates your kubeconfig.
 ### Deploy options
 
 ```bash
-make install                           # full stack (CPU models, default)
-make install -- --gpu-models           # use GPU embedding/reranker models instead
-make install -- --skip-models          # skip embedding/reranker (mock search)
-make install -- --skip-ui --skip-tile  # headless (no dashboard)
+make install                                       # full stack (CPU models, default)
+make install ARGS="--gpu-models"                   # use GPU embedding/reranker models instead
+make install ARGS="--skip-models"                  # skip embedding/reranker (mock search)
+make install ARGS="--skip-ui --skip-tile"          # headless (no dashboard)
 ```
 
 ### Uninstall
 
 ```bash
-make uninstall                         # prompts for confirmation
-make uninstall -- --yes                # non-interactive (CI)
-make uninstall -- --skip-db            # preserve database across reinstall
-make uninstall -- --skip-models        # keep embedding/reranker models running
+make uninstall                                     # prompts for confirmation
+make uninstall ARGS="--yes"                        # non-interactive (CI)
+make uninstall ARGS="--skip-db"                    # preserve database across reinstall
+make uninstall ARGS="--skip-models"                # keep embedding/reranker models running
 ```
 
 ### Partial deploys (advanced)

--- a/deploy/reranker-gpu/deployment.yaml
+++ b/deploy/reranker-gpu/deployment.yaml
@@ -36,11 +36,9 @@ spec:
             requests:
               cpu: "1"
               memory: 4Gi
-              nvidia.com/gpu: "1"
             limits:
               cpu: "4"
               memory: 8Gi
-              nvidia.com/gpu: "1"
           volumeMounts:
             - name: cache
               mountPath: /data

--- a/docs/guides/hooks-integration.md
+++ b/docs/guides/hooks-integration.md
@@ -37,18 +37,16 @@ The CLI resolves credentials from environment variables first, then config files
 # Create the config directory
 mkdir -p ~/.config/memoryhub
 
-# Store your API key (mode 0600 -- never commit this)
-echo "mh-dev-your-key-here" > ~/.config/memoryhub/api-key
-chmod 600 ~/.config/memoryhub/api-key
-
-# Store the server URL
-cat > ~/.config/memoryhub/config.json << 'EOF'
-{"url": "https://your-memoryhub-server.example.com/mcp/"}
+# Store your API key and server URL (mode 0600 -- never commit this)
+cat > ~/.config/memoryhub/credentials << 'EOF'
+[default]
+api_key = mh-dev-your-key-here
+url = https://your-memoryhub-server.example.com/mcp/
 EOF
-chmod 600 ~/.config/memoryhub/config.json
+chmod 600 ~/.config/memoryhub/credentials
 ```
 
-Alternatively, set `MEMORYHUB_API_KEY` and `MEMORYHUB_URL` environment variables in your shell profile.
+Alternatively, set `MEMORYHUB_API_KEY` and `MEMORYHUB_URL` environment variables in your shell profile. The legacy flat file `~/.config/memoryhub/api-key` is still supported as a fallback.
 
 ### 2. Initialize project configuration
 
@@ -166,7 +164,8 @@ or `search_memory` yet.
 
 If no `<memoryhub-context>` block is present (hook not configured or
 failed silently), fall back to the manual flow: read your API key from
-`~/.config/memoryhub/api-key` (trim whitespace), call
+`~/.config/memoryhub/credentials` (INI file, section matching
+`MEMORYHUB_CONTEXT` or `[default]`), call
 `register_session(api_key="<key>")`, then after the first user turn
 derive a 1-2 sentence summary and call `search_memory(query=<summary>)`.
 ```
@@ -182,7 +181,6 @@ If nothing appears, check:
 1. **Is the script executable?** `ls -la .claude/hooks/load-memories.sh`
 2. **Does the CLI work standalone?** Run the search command manually:
    ```bash
-   MEMORYHUB_API_KEY=$(cat ~/.config/memoryhub/api-key) \
    memoryhub search "project context" --project-id my-project --output compact --max 5
    ```
 3. **Is the hook configured?** Check `.claude/settings.json` has the `SessionStart` block.
@@ -199,8 +197,8 @@ Commit these files to your repository:
 
 Do NOT commit:
 
-- `~/.config/memoryhub/api-key` -- per-operator credential
-- `~/.config/memoryhub/config.json` -- per-operator server URL
+- `~/.config/memoryhub/credentials` -- per-operator API keys and server URLs
+- `~/.config/memoryhub/config.json` -- per-operator OAuth/connection config
 
 ## Design rationale
 
@@ -223,7 +221,7 @@ The hook and MCP server serve complementary roles:
 | Update/delete | No | Yes |
 | Contradiction reporting | No | Yes |
 | Token cost | Zero (plain text) | Per-call (tool I/O) |
-| Authentication | API key via file | API key via `register_session` |
+| Authentication | API key via credentials file | API key via `register_session` |
 
 The agent should defer `register_session` until the first time it needs to search (topic pivot) or write. If the hook succeeded, no MCP calls are needed until then.
 

--- a/memory-hub-mcp/deploy/deploy.sh
+++ b/memory-hub-mcp/deploy/deploy.sh
@@ -141,16 +141,20 @@ echo "Applying manifests..."
 USERS_CM="$SCRIPT_DIR/users-configmap.yaml"
 if [[ ! -f "$USERS_CM" ]]; then
   echo "Generating $USERS_CM from template with random API keys..."
+  CURRENT_USER="${USER:-$(whoami)}"
   python3 -c "
-import re, secrets, pathlib
+import os, re, secrets, pathlib
 src = pathlib.Path('$SCRIPT_DIR/users-configmap.example.yaml').read_text()
+user = os.environ.get('CURRENT_USER', 'admin')
+out = src.replace('CURRENT_USER_DISPLAY', user.replace('-', ' ').title())
+out = out.replace('CURRENT_USER', user)
 out = re.sub(
     r'REPLACE-ME-GENERATE-WITH-openssl-rand-hex-16',
     lambda m: secrets.token_hex(16),
-    src,
+    out,
 )
 pathlib.Path('$USERS_CM').write_text(out)
-print(f'  Generated with {src.count(\"REPLACE-ME\")} unique keys.')
+print(f'  Generated for user \"{user}\" with {src.count(\"REPLACE-ME\")} unique keys.')
 "
 fi
 if grep -q "REPLACE-ME-" "$USERS_CM"; then

--- a/memory-hub-mcp/deploy/deploy.sh
+++ b/memory-hub-mcp/deploy/deploy.sh
@@ -141,7 +141,7 @@ echo "Applying manifests..."
 USERS_CM="$SCRIPT_DIR/users-configmap.yaml"
 if [[ ! -f "$USERS_CM" ]]; then
   echo "Generating $USERS_CM from template with random API keys..."
-  CURRENT_USER="${USER:-$(whoami)}"
+  export CURRENT_USER="${USER:-$(whoami)}"
   python3 -c "
 import os, re, secrets, pathlib
 src = pathlib.Path('$SCRIPT_DIR/users-configmap.example.yaml').read_text()
@@ -150,7 +150,7 @@ out = src.replace('CURRENT_USER_DISPLAY', user.replace('-', ' ').title())
 out = out.replace('CURRENT_USER', user)
 out = re.sub(
     r'REPLACE-ME-GENERATE-WITH-openssl-rand-hex-16',
-    lambda m: secrets.token_hex(16),
+    lambda m: 'mh-dev-' + secrets.token_hex(8),
     out,
 )
 pathlib.Path('$USERS_CM').write_text(out)

--- a/memory-hub-mcp/deploy/users-configmap.example.yaml
+++ b/memory-hub-mcp/deploy/users-configmap.example.yaml
@@ -24,13 +24,13 @@ data:
     {
       "users": [
         {
-          "user_id": "wjackson",
-          "name": "Wes Jackson",
+          "user_id": "CURRENT_USER",
+          "name": "CURRENT_USER_DISPLAY",
           "api_key": "REPLACE-ME-GENERATE-WITH-openssl-rand-hex-16",
           "tenant_id": "default",
           "scopes": ["user", "project", "role", "organizational", "enterprise"],
           "project_memberships": [],
-          "_comment": "primary operator"
+          "_comment": "primary operator — user_id auto-set from OS username at install time"
         },
         {
           "user_id": "dev-test",
@@ -42,8 +42,8 @@ data:
           "_comment": "local development and integration testing"
         },
         {
-          "user_id": "rdwj-agent-1",
-          "name": "RDWJ Agent 1",
+          "user_id": "agent-1",
+          "name": "Agent 1",
           "api_key": "REPLACE-ME-GENERATE-WITH-openssl-rand-hex-16",
           "tenant_id": "default",
           "scopes": ["user", "project", "role", "organizational", "enterprise"],
@@ -51,22 +51,13 @@ data:
           "_comment": "agent automation slot 1"
         },
         {
-          "user_id": "rdwj-agent-2",
-          "name": "RDWJ Agent 2",
+          "user_id": "agent-2",
+          "name": "Agent 2",
           "api_key": "REPLACE-ME-GENERATE-WITH-openssl-rand-hex-16",
           "tenant_id": "default",
           "scopes": ["user", "project", "role", "organizational", "enterprise"],
           "project_memberships": [],
           "_comment": "agent automation slot 2"
-        },
-        {
-          "user_id": "kagenti-ci",
-          "name": "Kagenti CI",
-          "api_key": "REPLACE-ME-GENERATE-WITH-openssl-rand-hex-16",
-          "tenant_id": "default",
-          "scopes": ["user", "project"],
-          "project_memberships": [],
-          "_comment": "kagenti-adk E2E test runner (see docs/SYSTEMS.md)"
         },
         {
           "user_id": "trace-reviewer",

--- a/memoryhub-cli/README.md
+++ b/memoryhub-cli/README.md
@@ -18,11 +18,16 @@ The CLI supports two authentication modes:
 # Via environment variable
 export MEMORYHUB_API_KEY=mh-dev-abc123
 
-# Or place your key at ~/.config/memoryhub/api-key (mode 0600)
-echo "mh-dev-abc123" > ~/.config/memoryhub/api-key
+# Or store in the credentials file (INI-style, mode 0600)
+mkdir -p ~/.config/memoryhub
+cat > ~/.config/memoryhub/credentials << 'EOF'
+[default]
+api_key = mh-dev-abc123
+EOF
+chmod 600 ~/.config/memoryhub/credentials
 ```
 
-API key resolution order: `MEMORYHUB_API_KEY` env var > `~/.config/memoryhub/api-key` file > `api_key` in config.json.
+API key resolution order: `MEMORYHUB_API_KEY` env var > `~/.config/memoryhub/credentials` (section from `MEMORYHUB_CONTEXT` or `[default]`) > `~/.config/memoryhub/api-key` (legacy flat file) > `api_key` in config.json.
 
 **Server URL:**
 

--- a/memoryhub-cli/src/memoryhub_cli/admin.py
+++ b/memoryhub-cli/src/memoryhub_cli/admin.py
@@ -9,7 +9,7 @@ import httpx
 import typer
 from rich.table import Table
 
-from memoryhub_cli.config import CONFIG_DIR, load_config
+from memoryhub_cli.config import CREDENTIALS_FILE, load_config, write_credentials_section
 from memoryhub_cli.output import (
     EXIT_AUTH_ERROR,
     EXIT_CLIENT_ERROR,
@@ -100,7 +100,12 @@ def create_agent(
     write_config: bool = typer.Option(
         False,
         "--write-config",
-        help="Write the client_secret to ~/.config/memoryhub/api-key",
+        help="Write the client_secret to ~/.config/memoryhub/credentials",
+    ),
+    context: str = typer.Option(
+        "",
+        "--context",
+        help="Credentials section name (default: MEMORYHUB_CONTEXT or 'default')",
     ),
     output: OutputFormat = typer.Option(
         OutputFormat.table, "--output", "-o", help="Output format: table, json, quiet",
@@ -159,11 +164,9 @@ def create_agent(
     )
 
     if write_config:
-        api_key_path = CONFIG_DIR / "api-key"
-        CONFIG_DIR.mkdir(parents=True, exist_ok=True)
-        api_key_path.write_text(data["client_secret"])
-        api_key_path.chmod(0o600)
-        console.print(f"\n  [green]Secret written to {api_key_path}[/green]")
+        section = context or os.environ.get("MEMORYHUB_CONTEXT", "").strip() or "default"
+        write_credentials_section(section, data["client_secret"])
+        console.print(f"\n  [green]Secret written to {CREDENTIALS_FILE} [{section}][/green]")
 
 
 @admin_app.command("list-agents")

--- a/memoryhub-cli/src/memoryhub_cli/config.py
+++ b/memoryhub-cli/src/memoryhub_cli/config.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import configparser
+import io
 import json
 import os
 from pathlib import Path
@@ -9,6 +11,17 @@ from pathlib import Path
 CONFIG_DIR = Path.home() / ".config" / "memoryhub"
 CONFIG_FILE = CONFIG_DIR / "config.json"
 API_KEY_FILE = CONFIG_DIR / "api-key"
+CREDENTIALS_FILE = CONFIG_DIR / "credentials"
+
+_CREDENTIALS_HEADER = (
+    "# MemoryHub credentials -- managed by memoryhub CLI and deploy scripts.\n"
+)
+
+_MIGRATION_COMMENT = (
+    "# This key has been migrated to ~/.config/memoryhub/credentials\n"
+    "# under the [default] section. You can delete this file once all\n"
+    "# tools and agent configurations have been updated.\n"
+)
 
 
 def load_config() -> dict:
@@ -25,30 +38,125 @@ def save_config(config: dict) -> None:
     CONFIG_FILE.chmod(0o600)
 
 
-def get_api_key() -> str | None:
-    """Resolve API key from env var, key file, or config.
+def read_credentials_section(context: str | None = None) -> dict[str, str] | None:
+    """Read a section from the INI-style credentials file."""
+    if not CREDENTIALS_FILE.exists():
+        return None
 
-    Precedence: MEMORYHUB_API_KEY env var > ~/.config/memoryhub/api-key file
-    > api_key in config.json.
-    """
+    cp = configparser.ConfigParser(interpolation=None)
+    cp.read(CREDENTIALS_FILE)
+
+    section = context or os.environ.get("MEMORYHUB_CONTEXT", "").strip() or "default"
+    if not cp.has_section(section):
+        return None
+
+    result = {}
+    for key in ("api_key", "url"):
+        val = cp.get(section, key, fallback=None)
+        if val:
+            result[key] = val
+    return result
+
+
+def write_credentials_section(
+    context: str, api_key: str, url: str | None = None,
+) -> None:
+    """Write or update a section in the credentials file."""
+    CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+
+    cp = configparser.ConfigParser(interpolation=None)
+    if CREDENTIALS_FILE.exists():
+        cp.read(CREDENTIALS_FILE)
+
+    if not cp.has_section(context):
+        cp.add_section(context)
+    cp.set(context, "api_key", api_key)
+    if url:
+        cp.set(context, "url", url)
+    elif cp.has_option(context, "url"):
+        cp.remove_option(context, "url")
+
+    buf = io.StringIO()
+    cp.write(buf)
+    CREDENTIALS_FILE.write_text(_CREDENTIALS_HEADER + buf.getvalue())
+    CREDENTIALS_FILE.chmod(0o600)
+
+
+def migrate_flat_to_credentials() -> bool:
+    """Migrate flat api-key file to credentials file if needed."""
+    if not API_KEY_FILE.exists() or CREDENTIALS_FILE.exists():
+        return False
+
+    raw = API_KEY_FILE.read_text()
+    key = ""
+    for line in raw.splitlines():
+        stripped = line.strip()
+        if stripped and not stripped.startswith("#"):
+            key = stripped
+            break
+
+    if not key:
+        return False
+
+    write_credentials_section("default", key)
+    API_KEY_FILE.write_text(_MIGRATION_COMMENT + raw)
+    return True
+
+
+def get_api_key() -> str | None:
+    """Resolve API key: env var > credentials file > flat file > config.json."""
     key = os.environ.get("MEMORYHUB_API_KEY", "").strip()
     if key:
         return key
 
+    creds = read_credentials_section()
+    if creds and creds.get("api_key"):
+        return creds["api_key"]
+
     if API_KEY_FILE.exists():
-        key = API_KEY_FILE.read_text().strip()
-        if key:
-            return key
+        for line in API_KEY_FILE.read_text().splitlines():
+            stripped = line.strip()
+            if stripped and not stripped.startswith("#"):
+                return stripped
 
     return load_config().get("api_key") or None
 
 
 def get_server_url() -> str | None:
-    """Resolve server URL from env var or config."""
+    """Resolve server URL: env var > credentials file > config.json."""
     url = os.environ.get("MEMORYHUB_URL", "").strip()
     if url:
         return url
+
+    creds = read_credentials_section()
+    if creds and creds.get("url"):
+        return creds["url"]
+
     return load_config().get("url") or None
+
+
+def get_credentials() -> tuple[str | None, str | None]:
+    """Resolve (api_key, url) paired from the same source."""
+    key = os.environ.get("MEMORYHUB_API_KEY", "").strip()
+    if key:
+        return key, get_server_url()
+
+    creds = read_credentials_section()
+    if creds and creds.get("api_key"):
+        return creds["api_key"], creds.get("url")
+
+    if API_KEY_FILE.exists():
+        for line in API_KEY_FILE.read_text().splitlines():
+            stripped = line.strip()
+            if stripped and not stripped.startswith("#"):
+                return stripped, get_server_url()
+
+    config = load_config()
+    cfg_key = config.get("api_key") or None
+    if cfg_key:
+        return cfg_key, config.get("url") or None
+
+    return None, None
 
 
 def get_connection_params() -> dict:

--- a/memoryhub-cli/src/memoryhub_cli/main.py
+++ b/memoryhub-cli/src/memoryhub_cli/main.py
@@ -1157,12 +1157,18 @@ def config_init(
         console.print(f"  Project: {project}")  # noqa: T201
 
     # ── #153: API key check ──
-    api_key_path = Path.home() / ".config" / "memoryhub" / "api-key"
-    if api_key_path.exists():
-        console.print(f"\n[green]API key found at {api_key_path}[/green]")  # noqa: T201
+    from memoryhub_cli.config import CREDENTIALS_FILE
+
+    if CREDENTIALS_FILE.exists():
+        console.print(f"\n[green]Credentials found at {CREDENTIALS_FILE}[/green]")  # noqa: T201
+    elif (Path.home() / ".config" / "memoryhub" / "api-key").exists():
+        console.print(  # noqa: T201
+            "\n[yellow]Warning:[/yellow] Using legacy ~/.config/memoryhub/api-key\n"
+            f"  The next deploy will migrate it to {CREDENTIALS_FILE} automatically."
+        )
     else:
         console.print(  # noqa: T201
-            f"\n[yellow]Warning:[/yellow] No API key at {api_key_path}\n"
+            f"\n[yellow]Warning:[/yellow] No credentials at {CREDENTIALS_FILE}\n"
             "  Create this file with your MemoryHub API key before using\n"
             "  the agent. Ask your administrator for a key."
         )

--- a/memoryhub-cli/src/memoryhub_cli/project_config.py
+++ b/memoryhub-cli/src/memoryhub_cli/project_config.py
@@ -156,7 +156,7 @@ its contents as your working set. Do NOT call `register_session` or
 If no `<memoryhub-context>` block is present (CLI not installed or hook
 misconfigured), fall back to the manual flow:
 
-1. Read your API key from `~/.config/memoryhub/api-key` (trim whitespace).
+1. Read your API key from `~/.config/memoryhub/credentials` (INI file, section matching `MEMORYHUB_CONTEXT` or `[default]`; falls back to `~/.config/memoryhub/api-key`).
 2. Call `register_session(api_key="<key>")` to authenticate.
 3. Immediately call `search_memory(query="", mode="index", max_results=50)`
    to load the full working set as lightweight stubs. The empty query plus
@@ -695,12 +695,56 @@ HOOK_SCRIPT_TEMPLATE = """\
 
 set -euo pipefail
 
-API_KEY_FILE="$HOME/.config/memoryhub/api-key"
-[ -f "$API_KEY_FILE" ] || exit 0
+# --- Credential resolution ---
+# 1. MEMORYHUB_API_KEY env var (already set)
+# 2. ~/.config/memoryhub/credentials (INI, MEMORYHUB_CONTEXT or [default])
+# 3. ~/.config/memoryhub/api-key (flat file, backwards compat)
 
-API_KEY=$(tr -d '\\n' < "$API_KEY_FILE")
-[ -n "$API_KEY" ] || exit 0
-export MEMORYHUB_API_KEY="$API_KEY"
+CREDS_FILE="$HOME/.config/memoryhub/credentials"
+API_KEY_FILE="$HOME/.config/memoryhub/api-key"
+
+if [ -z "${MEMORYHUB_API_KEY:-}" ]; then
+  if [ -f "$CREDS_FILE" ]; then
+    SECTION="${MEMORYHUB_CONTEXT:-default}"
+    MEMORYHUB_API_KEY=$(awk -v section="$SECTION" '
+      /^\\[/ { in_section = ($0 == "[" section "]") }
+      in_section && /^api_key[[:space:]]*=/ {
+        sub(/^api_key[[:space:]]*=[[:space:]]*/, ""); print; exit
+      }
+    ' "$CREDS_FILE")
+    if [ -z "${MEMORYHUB_API_KEY:-}" ] && [ "$SECTION" != "default" ]; then
+      MEMORYHUB_API_KEY=$(awk '
+        /^\\[/ { in_section = ($0 == "[default]") }
+        in_section && /^api_key[[:space:]]*=/ {
+          sub(/^api_key[[:space:]]*=[[:space:]]*/, ""); print; exit
+        }
+      ' "$CREDS_FILE")
+    fi
+  elif [ -f "$API_KEY_FILE" ]; then
+    MEMORYHUB_API_KEY=$(grep -v '^#' "$API_KEY_FILE" | tr -d '\\n')
+  fi
+fi
+[ -n "${MEMORYHUB_API_KEY:-}" ] || exit 0
+export MEMORYHUB_API_KEY
+
+# --- URL resolution ---
+if [ -z "${MEMORYHUB_URL:-}" ] && [ -f "$CREDS_FILE" ]; then
+  SECTION="${MEMORYHUB_CONTEXT:-default}"
+  MEMORYHUB_URL=$(awk -v section="$SECTION" '
+    /^\\[/ { in_section = ($0 == "[" section "]") }
+    in_section && /^url[[:space:]]*=/ {
+      sub(/^url[[:space:]]*=[[:space:]]*/, ""); print; exit
+    }
+  ' "$CREDS_FILE")
+  if [ -z "${MEMORYHUB_URL:-}" ] && [ "$SECTION" != "default" ]; then
+    MEMORYHUB_URL=$(awk '
+      /^\\[/ { in_section = ($0 == "[default]") }
+      in_section && /^url[[:space:]]*=/ {
+        sub(/^url[[:space:]]*=[[:space:]]*/, ""); print; exit
+      }
+    ' "$CREDS_FILE")
+  fi
+fi
 
 if [ -z "${MEMORYHUB_URL:-}" ]; then
   CONFIG_FILE="$HOME/.config/memoryhub/config.json"

--- a/memoryhub-cli/tests/test_admin.py
+++ b/memoryhub-cli/tests/test_admin.py
@@ -101,51 +101,44 @@ class TestCreateAgent:
         assert parsed["data"]["client_id"] == "test-agent"
         assert parsed["data"]["client_secret"] == "super-secret-value"
 
-    def test_write_config(self, tmp_path):
+    def _run_write_config(self, tmp_path, extra_args=None):
         mock_client = AsyncMock()
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
         mock_client.__aexit__ = AsyncMock(return_value=False)
-        mock_client.post = AsyncMock(return_value=_mock_response(SAMPLE_CREATED, 201))
+        mock_client.post = AsyncMock(
+            return_value=_mock_response(SAMPLE_CREATED, 201),
+        )
+        creds = tmp_path / "credentials"
+        cmd = ["admin", "create-agent", "test-agent", "--write-config"]
+        cmd.extend(extra_args or [])
 
-        with patch.dict("os.environ", _env_with_admin_key(), clear=False):
-            with patch("memoryhub_cli.admin.httpx.AsyncClient", return_value=mock_client):
-                with patch("memoryhub_cli.config.CONFIG_DIR", tmp_path):
-                    with patch("memoryhub_cli.config.CREDENTIALS_FILE", tmp_path / "credentials"):
-                        with patch("memoryhub_cli.admin.CREDENTIALS_FILE", tmp_path / "credentials"):
-                            result = runner.invoke(
-                                app,
-                                ["admin", "create-agent", "test-agent", "--write-config"],
-                            )
+        with (
+            patch.dict("os.environ", _env_with_admin_key(), clear=False),
+            patch("memoryhub_cli.admin.httpx.AsyncClient", return_value=mock_client),
+            patch("memoryhub_cli.config.CONFIG_DIR", tmp_path),
+            patch("memoryhub_cli.config.CREDENTIALS_FILE", creds),
+            patch("memoryhub_cli.admin.CREDENTIALS_FILE", creds),
+        ):
+            result = runner.invoke(app, cmd)
+        return result, creds
 
+    def test_write_config(self, tmp_path):
+        result, creds = self._run_write_config(tmp_path)
         assert result.exit_code == 0
-        creds_file = tmp_path / "credentials"
-        assert creds_file.exists()
+        assert creds.exists()
         import configparser
         cp = configparser.ConfigParser(interpolation=None)
-        cp.read(creds_file)
+        cp.read(creds)
         assert cp.get("default", "api_key") == "super-secret-value"
 
     def test_write_config_with_context(self, tmp_path):
-        mock_client = AsyncMock()
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=False)
-        mock_client.post = AsyncMock(return_value=_mock_response(SAMPLE_CREATED, 201))
-
-        with patch.dict("os.environ", _env_with_admin_key(), clear=False):
-            with patch("memoryhub_cli.admin.httpx.AsyncClient", return_value=mock_client):
-                with patch("memoryhub_cli.config.CONFIG_DIR", tmp_path):
-                    with patch("memoryhub_cli.config.CREDENTIALS_FILE", tmp_path / "credentials"):
-                        with patch("memoryhub_cli.admin.CREDENTIALS_FILE", tmp_path / "credentials"):
-                            result = runner.invoke(
-                                app,
-                                ["admin", "create-agent", "test-agent",
-                                 "--write-config", "--context", "my-cluster"],
-                            )
-
+        result, creds = self._run_write_config(
+            tmp_path, ["--context", "my-cluster"],
+        )
         assert result.exit_code == 0
         import configparser
         cp = configparser.ConfigParser(interpolation=None)
-        cp.read(tmp_path / "credentials")
+        cp.read(creds)
         assert cp.get("my-cluster", "api_key") == "super-secret-value"
 
     def test_conflict_409(self):

--- a/memoryhub-cli/tests/test_admin.py
+++ b/memoryhub-cli/tests/test_admin.py
@@ -109,16 +109,44 @@ class TestCreateAgent:
 
         with patch.dict("os.environ", _env_with_admin_key(), clear=False):
             with patch("memoryhub_cli.admin.httpx.AsyncClient", return_value=mock_client):
-                with patch("memoryhub_cli.admin.CONFIG_DIR", tmp_path):
-                    result = runner.invoke(
-                        app,
-                        ["admin", "create-agent", "test-agent", "--write-config"],
-                    )
+                with patch("memoryhub_cli.config.CONFIG_DIR", tmp_path):
+                    with patch("memoryhub_cli.config.CREDENTIALS_FILE", tmp_path / "credentials"):
+                        with patch("memoryhub_cli.admin.CREDENTIALS_FILE", tmp_path / "credentials"):
+                            result = runner.invoke(
+                                app,
+                                ["admin", "create-agent", "test-agent", "--write-config"],
+                            )
 
         assert result.exit_code == 0
-        api_key_file = tmp_path / "api-key"
-        assert api_key_file.exists()
-        assert api_key_file.read_text() == "super-secret-value"
+        creds_file = tmp_path / "credentials"
+        assert creds_file.exists()
+        import configparser
+        cp = configparser.ConfigParser(interpolation=None)
+        cp.read(creds_file)
+        assert cp.get("default", "api_key") == "super-secret-value"
+
+    def test_write_config_with_context(self, tmp_path):
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.post = AsyncMock(return_value=_mock_response(SAMPLE_CREATED, 201))
+
+        with patch.dict("os.environ", _env_with_admin_key(), clear=False):
+            with patch("memoryhub_cli.admin.httpx.AsyncClient", return_value=mock_client):
+                with patch("memoryhub_cli.config.CONFIG_DIR", tmp_path):
+                    with patch("memoryhub_cli.config.CREDENTIALS_FILE", tmp_path / "credentials"):
+                        with patch("memoryhub_cli.admin.CREDENTIALS_FILE", tmp_path / "credentials"):
+                            result = runner.invoke(
+                                app,
+                                ["admin", "create-agent", "test-agent",
+                                 "--write-config", "--context", "my-cluster"],
+                            )
+
+        assert result.exit_code == 0
+        import configparser
+        cp = configparser.ConfigParser(interpolation=None)
+        cp.read(tmp_path / "credentials")
+        assert cp.get("my-cluster", "api_key") == "super-secret-value"
 
     def test_conflict_409(self):
         error_resp = _mock_error_response(

--- a/memoryhub-cli/tests/test_config.py
+++ b/memoryhub-cli/tests/test_config.py
@@ -2,19 +2,40 @@
 
 from __future__ import annotations
 
+import configparser
 import json
 
 import pytest
 
-from memoryhub_cli.config import get_api_key, get_server_url, load_config, save_config
+from memoryhub_cli.config import (
+    get_api_key,
+    get_credentials,
+    get_server_url,
+    load_config,
+    migrate_flat_to_credentials,
+    read_credentials_section,
+    save_config,
+    write_credentials_section,
+)
 
 
 @pytest.fixture(autouse=True)
 def _clean_env(monkeypatch):
     """Remove MemoryHub env vars so tests start from a clean slate."""
     for var in ("MEMORYHUB_API_KEY", "MEMORYHUB_URL", "MEMORYHUB_AUTH_URL",
-                "MEMORYHUB_CLIENT_ID", "MEMORYHUB_CLIENT_SECRET"):
+                "MEMORYHUB_CLIENT_ID", "MEMORYHUB_CLIENT_SECRET",
+                "MEMORYHUB_CONTEXT"):
         monkeypatch.delenv(var, raising=False)
+
+
+@pytest.fixture()
+def _no_files(monkeypatch, tmp_path):
+    """Point all config paths to nonexistent files under tmp_path."""
+    monkeypatch.setattr("memoryhub_cli.config.CONFIG_DIR", tmp_path)
+    monkeypatch.setattr("memoryhub_cli.config.API_KEY_FILE", tmp_path / "api-key")
+    monkeypatch.setattr("memoryhub_cli.config.CREDENTIALS_FILE", tmp_path / "credentials")
+    monkeypatch.setattr("memoryhub_cli.config.CONFIG_FILE", tmp_path / "config.json")
+    return tmp_path
 
 
 class TestGetApiKey:
@@ -26,14 +47,15 @@ class TestGetApiKey:
         key_file = tmp_path / "api-key"
         key_file.write_text("mh-dev-from-file\n")
         monkeypatch.setattr("memoryhub_cli.config.API_KEY_FILE", key_file)
+        monkeypatch.setattr("memoryhub_cli.config.CREDENTIALS_FILE", tmp_path / "nope")
         assert get_api_key() == "mh-dev-from-file"
 
     def test_config_json_third(self, monkeypatch, tmp_path):
         config_file = tmp_path / "config.json"
         config_file.write_text(json.dumps({"api_key": "mh-dev-from-config"}))
         monkeypatch.setattr("memoryhub_cli.config.CONFIG_FILE", config_file)
-        # Also ensure key file doesn't exist
         monkeypatch.setattr("memoryhub_cli.config.API_KEY_FILE", tmp_path / "nope")
+        monkeypatch.setattr("memoryhub_cli.config.CREDENTIALS_FILE", tmp_path / "nope2")
         assert get_api_key() == "mh-dev-from-config"
 
     def test_env_var_overrides_file(self, monkeypatch, tmp_path):
@@ -45,6 +67,7 @@ class TestGetApiKey:
 
     def test_returns_none_when_nothing_set(self, monkeypatch, tmp_path):
         monkeypatch.setattr("memoryhub_cli.config.API_KEY_FILE", tmp_path / "nope")
+        monkeypatch.setattr("memoryhub_cli.config.CREDENTIALS_FILE", tmp_path / "nope2")
         monkeypatch.setattr("memoryhub_cli.config.CONFIG_FILE", tmp_path / "nope.json")
         assert get_api_key() is None
 
@@ -55,8 +78,18 @@ class TestGetApiKey:
     def test_empty_env_var_skipped(self, monkeypatch, tmp_path):
         monkeypatch.setenv("MEMORYHUB_API_KEY", "")
         monkeypatch.setattr("memoryhub_cli.config.API_KEY_FILE", tmp_path / "nope")
+        monkeypatch.setattr("memoryhub_cli.config.CREDENTIALS_FILE", tmp_path / "nope2")
         monkeypatch.setattr("memoryhub_cli.config.CONFIG_FILE", tmp_path / "nope.json")
         assert get_api_key() is None
+
+    def test_flat_file_skips_comment_lines(self, _no_files, tmp_path):
+        key_file = tmp_path / "api-key"
+        key_file.write_text(
+            "# migrated to credentials\n"
+            "# you can delete this file\n"
+            "mh-dev-actual-key\n"
+        )
+        assert get_api_key() == "mh-dev-actual-key"
 
 
 class TestGetServerUrl:
@@ -68,11 +101,24 @@ class TestGetServerUrl:
         config_file = tmp_path / "config.json"
         config_file.write_text(json.dumps({"url": "https://from-config.example.com"}))
         monkeypatch.setattr("memoryhub_cli.config.CONFIG_FILE", config_file)
+        monkeypatch.setattr("memoryhub_cli.config.CREDENTIALS_FILE", tmp_path / "nope")
         assert get_server_url() == "https://from-config.example.com"
 
     def test_returns_none_when_nothing_set(self, monkeypatch, tmp_path):
         monkeypatch.setattr("memoryhub_cli.config.CONFIG_FILE", tmp_path / "nope.json")
+        monkeypatch.setattr("memoryhub_cli.config.CREDENTIALS_FILE", tmp_path / "nope")
         assert get_server_url() is None
+
+    def test_credentials_file_url(self, _no_files, tmp_path):
+        creds = tmp_path / "credentials"
+        creds.write_text("[default]\nurl = https://from-creds.example.com\n")
+        assert get_server_url() == "https://from-creds.example.com"
+
+    def test_env_overrides_credentials_url(self, _no_files, tmp_path, monkeypatch):
+        creds = tmp_path / "credentials"
+        creds.write_text("[default]\nurl = https://from-creds.example.com\n")
+        monkeypatch.setenv("MEMORYHUB_URL", "https://from-env.example.com")
+        assert get_server_url() == "https://from-env.example.com"
 
 
 class TestSaveConfigMerge:
@@ -100,3 +146,194 @@ class TestSaveConfigMerge:
         data = json.loads(config_file.read_text())
         assert data["url"] == "https://new.example.com/mcp/"
         assert data["client_id"] == "old"
+
+
+class TestReadCredentialsSection:
+    def test_reads_named_section(self, _no_files, tmp_path):
+        creds = tmp_path / "credentials"
+        creds.write_text(
+            "[cluster-a]\napi_key = key-a\nurl = https://a.example.com\n\n"
+            "[cluster-b]\napi_key = key-b\n"
+        )
+        result = read_credentials_section("cluster-a")
+        assert result == {"api_key": "key-a", "url": "https://a.example.com"}
+
+    def test_context_from_env(self, _no_files, tmp_path, monkeypatch):
+        creds = tmp_path / "credentials"
+        creds.write_text("[my-ctx]\napi_key = key-ctx\n")
+        monkeypatch.setenv("MEMORYHUB_CONTEXT", "my-ctx")
+        result = read_credentials_section()
+        assert result["api_key"] == "key-ctx"
+
+    def test_falls_back_to_default(self, _no_files, tmp_path):
+        creds = tmp_path / "credentials"
+        creds.write_text("[default]\napi_key = key-default\n")
+        assert read_credentials_section()["api_key"] == "key-default"
+
+    def test_missing_context_returns_none(self, _no_files, tmp_path, monkeypatch):
+        """When MEMORYHUB_CONTEXT names a missing section, return None."""
+        creds = tmp_path / "credentials"
+        creds.write_text("[default]\napi_key = key-default\n")
+        monkeypatch.setenv("MEMORYHUB_CONTEXT", "nonexistent")
+        assert read_credentials_section() is None
+
+    def test_explicit_context_returns_none_if_missing(self, _no_files, tmp_path):
+        creds = tmp_path / "credentials"
+        creds.write_text("[default]\napi_key = key-default\n")
+        assert read_credentials_section("nonexistent") is None
+
+    def test_missing_file_returns_none(self, _no_files):
+        assert read_credentials_section() is None
+
+    def test_missing_section_returns_none(self, _no_files, tmp_path):
+        creds = tmp_path / "credentials"
+        creds.write_text("[other]\napi_key = other-key\n")
+        assert read_credentials_section("missing") is None
+
+    def test_percent_in_key_not_interpolated(self, _no_files, tmp_path):
+        creds = tmp_path / "credentials"
+        creds.write_text("[default]\napi_key = mh-dev-100%done\n")
+        assert read_credentials_section()["api_key"] == "mh-dev-100%done"
+
+
+class TestWriteCredentialsSection:
+    def test_creates_file(self, _no_files, tmp_path):
+        write_credentials_section("test-ctx", "mh-dev-abc123", "https://test.example.com")
+        creds = tmp_path / "credentials"
+        assert creds.exists()
+        content = creds.read_text()
+        assert "# MemoryHub credentials" in content
+
+        cp = configparser.ConfigParser(interpolation=None)
+        cp.read(creds)
+        assert cp.get("test-ctx", "api_key") == "mh-dev-abc123"
+        assert cp.get("test-ctx", "url") == "https://test.example.com"
+
+    def test_preserves_other_sections(self, _no_files, tmp_path):
+        write_credentials_section("ctx-a", "key-a")
+        write_credentials_section("ctx-b", "key-b", "https://b.example.com")
+
+        cp = configparser.ConfigParser(interpolation=None)
+        cp.read(tmp_path / "credentials")
+        assert cp.get("ctx-a", "api_key") == "key-a"
+        assert cp.get("ctx-b", "api_key") == "key-b"
+
+    def test_overwrites_existing_section(self, _no_files, tmp_path):
+        write_credentials_section("ctx", "old-key")
+        write_credentials_section("ctx", "new-key", "https://new.example.com")
+
+        cp = configparser.ConfigParser(interpolation=None)
+        cp.read(tmp_path / "credentials")
+        assert cp.get("ctx", "api_key") == "new-key"
+        assert cp.get("ctx", "url") == "https://new.example.com"
+
+    def test_file_permissions(self, _no_files, tmp_path):
+        write_credentials_section("ctx", "key")
+        mode = (tmp_path / "credentials").stat().st_mode & 0o777
+        assert mode == 0o600
+
+    def test_url_omitted_when_none(self, _no_files, tmp_path):
+        write_credentials_section("ctx", "key")
+        cp = configparser.ConfigParser(interpolation=None)
+        cp.read(tmp_path / "credentials")
+        assert cp.get("ctx", "api_key") == "key"
+        assert not cp.has_option("ctx", "url")
+
+
+class TestMigration:
+    def test_creates_credentials_from_flat(self, _no_files, tmp_path):
+        flat = tmp_path / "api-key"
+        flat.write_text("mh-dev-migrated-key\n")
+        assert migrate_flat_to_credentials() is True
+
+        cp = configparser.ConfigParser(interpolation=None)
+        cp.read(tmp_path / "credentials")
+        assert cp.get("default", "api_key") == "mh-dev-migrated-key"
+
+    def test_annotates_flat_file(self, _no_files, tmp_path):
+        flat = tmp_path / "api-key"
+        flat.write_text("mh-dev-original\n")
+        migrate_flat_to_credentials()
+        content = flat.read_text()
+        assert content.startswith("# This key has been migrated")
+        assert "mh-dev-original" in content
+
+    def test_key_still_readable_after_migration(self, _no_files, tmp_path):
+        flat = tmp_path / "api-key"
+        flat.write_text("mh-dev-readable\n")
+        migrate_flat_to_credentials()
+        assert get_api_key() == "mh-dev-readable"
+
+    def test_skips_if_credentials_exists(self, _no_files, tmp_path):
+        flat = tmp_path / "api-key"
+        flat.write_text("mh-dev-old\n")
+        creds = tmp_path / "credentials"
+        creds.write_text("[default]\napi_key = mh-dev-existing\n")
+        assert migrate_flat_to_credentials() is False
+
+    def test_skips_if_no_flat_file(self, _no_files):
+        assert migrate_flat_to_credentials() is False
+
+    def test_skips_empty_flat_file(self, _no_files, tmp_path):
+        flat = tmp_path / "api-key"
+        flat.write_text("\n")
+        assert migrate_flat_to_credentials() is False
+
+
+class TestCredentialsInResolutionChain:
+    """Verify credentials file integrates correctly into get_api_key/get_server_url."""
+
+    def test_credentials_beats_flat_file(self, _no_files, tmp_path):
+        (tmp_path / "credentials").write_text("[default]\napi_key = from-creds\n")
+        (tmp_path / "api-key").write_text("from-flat\n")
+        assert get_api_key() == "from-creds"
+
+    def test_credentials_beats_config_json(self, _no_files, tmp_path):
+        (tmp_path / "credentials").write_text("[default]\napi_key = from-creds\n")
+        (tmp_path / "config.json").write_text(json.dumps({"api_key": "from-json"}))
+        assert get_api_key() == "from-creds"
+
+    def test_env_var_beats_credentials(self, _no_files, tmp_path, monkeypatch):
+        (tmp_path / "credentials").write_text("[default]\napi_key = from-creds\n")
+        monkeypatch.setenv("MEMORYHUB_API_KEY", "from-env")
+        assert get_api_key() == "from-env"
+
+    def test_context_selects_section(self, _no_files, tmp_path, monkeypatch):
+        (tmp_path / "credentials").write_text(
+            "[ctx-a]\napi_key = key-a\n\n[ctx-b]\napi_key = key-b\n"
+        )
+        monkeypatch.setenv("MEMORYHUB_CONTEXT", "ctx-b")
+        assert get_api_key() == "key-b"
+
+    def test_flat_file_fallback_when_no_creds(self, _no_files, tmp_path):
+        (tmp_path / "api-key").write_text("from-flat\n")
+        assert get_api_key() == "from-flat"
+
+
+class TestGetCredentialsPaired:
+    def test_paired_from_credentials_file(self, _no_files, tmp_path):
+        (tmp_path / "credentials").write_text(
+            "[default]\napi_key = key-1\nurl = https://paired.example.com\n"
+        )
+        key, url = get_credentials()
+        assert key == "key-1"
+        assert url == "https://paired.example.com"
+
+    def test_env_var_key_with_url_resolution(self, _no_files, tmp_path, monkeypatch):
+        monkeypatch.setenv("MEMORYHUB_API_KEY", "env-key")
+        monkeypatch.setenv("MEMORYHUB_URL", "https://env-url.example.com")
+        key, url = get_credentials()
+        assert key == "env-key"
+        assert url == "https://env-url.example.com"
+
+    def test_both_none_when_nothing_configured(self, _no_files):
+        key, url = get_credentials()
+        assert key is None
+        assert url is None
+
+    def test_flat_file_key_with_config_url(self, _no_files, tmp_path):
+        (tmp_path / "api-key").write_text("flat-key\n")
+        (tmp_path / "config.json").write_text(json.dumps({"url": "https://cfg.example.com"}))
+        key, url = get_credentials()
+        assert key == "flat-key"
+        assert url == "https://cfg.example.com"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "httpx",
     "psycopg2-binary",
     "pyyaml",
+    "bcrypt>=4.0",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ license = {text = "Apache-2.0"}
 authors = [{ name = "Wes Jackson" }]
 requires-python = ">=3.11"
 dependencies = [
-    "sqlalchemy>=2.0",
+    "sqlalchemy[asyncio]>=2.0",
     "asyncpg",
     "pgvector",
     "pydantic>=2.0",

--- a/scripts/deploy-evalhub.sh
+++ b/scripts/deploy-evalhub.sh
@@ -245,7 +245,13 @@ else
 
     # Generate provider spec with MemoryHub connection env vars
     MEMORYHUB_MCP_URL="http://memory-hub-mcp.memory-hub-mcp.svc:8080/mcp/"
-    MEMORYHUB_KEY=$(bash -c 'cat ~/.config/memoryhub/api-key 2>/dev/null' | tr -d '[:space:]')
+    MEMORYHUB_KEY=$("$REPO_ROOT/.venv/bin/python" -c "
+import sys
+sys.path.insert(0, '$REPO_ROOT/memoryhub-cli/src')
+from memoryhub_cli.config import get_api_key
+k = get_api_key()
+if k: print(k, end='')
+" 2>/dev/null || cat ~/.config/memoryhub/api-key 2>/dev/null | tr -d '[:space:]')
     MEMORYHUB_DB_PASSWORD=$(oc get secret memoryhub-db-credentials --context "$CONTEXT" -n memory-hub-mcp \
         -o jsonpath='{.data.MEMORYHUB_DB_PASSWORD}' 2>/dev/null | base64 -d || true)
 

--- a/scripts/deploy-full.sh
+++ b/scripts/deploy-full.sh
@@ -505,10 +505,33 @@ deploy_auth() {
     fi
 
     info "Seeding OAuth clients..."
+    # Ensure users-configmap.yaml exists (normally generated during MCP deploy,
+    # but auth runs first and needs it for seed-clients.json).
+    local users_cm="$REPO_ROOT/memory-hub-mcp/deploy/users-configmap.yaml"
+    if [ ! -f "$users_cm" ]; then
+        local users_example="$REPO_ROOT/memory-hub-mcp/deploy/users-configmap.example.yaml"
+        if [ -f "$users_example" ]; then
+            info "Generating users-configmap.yaml from template..."
+            export CURRENT_USER="${USER:-$(whoami)}"
+            "$REPO_ROOT/.venv/bin/python" -c "
+import os, re, secrets, pathlib
+src = pathlib.Path('$users_example').read_text()
+user = os.environ.get('CURRENT_USER', 'admin')
+out = src.replace('CURRENT_USER_DISPLAY', user.replace('-', ' ').title())
+out = out.replace('CURRENT_USER', user)
+out = re.sub(
+    r'REPLACE-ME-GENERATE-WITH-openssl-rand-hex-16',
+    lambda m: 'mh-dev-' + secrets.token_hex(8),
+    out,
+)
+pathlib.Path('$users_cm').write_text(out)
+print(f'  Generated for user \"{user}\"')
+"
+        fi
+    fi
     # Auto-generate seed-clients.json from the users ConfigMap if it doesn't exist.
     local seed_json="$REPO_ROOT/scripts/seed-clients.json"
     if [ ! -f "$seed_json" ]; then
-        local users_cm="$REPO_ROOT/memory-hub-mcp/deploy/users-configmap.yaml"
         if [ -f "$users_cm" ]; then
             info "Generating $seed_json from users ConfigMap..."
             "$REPO_ROOT/.venv/bin/python" -c "

--- a/scripts/deploy-full.sh
+++ b/scripts/deploy-full.sh
@@ -694,10 +694,6 @@ deploy_tile() {
 # ---------------------------------------------------------------------------
 configure_local_client() {
     local api_key_file="$HOME/.config/memoryhub/api-key"
-    if [ -f "$api_key_file" ]; then
-        info "API key already exists at $api_key_file"
-        return 0
-    fi
 
     local users_cm="$REPO_ROOT/memory-hub-mcp/deploy/users-configmap.yaml"
     if [ ! -f "$users_cm" ]; then return 0; fi

--- a/scripts/deploy-full.sh
+++ b/scripts/deploy-full.sh
@@ -564,6 +564,10 @@ print(f'  Generated {len(clients)} OAuth clients from users ConfigMap.')
 
     info "Building and deploying Auth server (project: $AUTH_PROJECT)..."
     pushd "$REPO_ROOT/memoryhub-auth" > /dev/null
+    if [ ! -d .venv ] || ! .venv/bin/alembic --version &>/dev/null; then
+        info "Creating memoryhub-auth .venv..."
+        make install 2>&1 | tail -1
+    fi
     make deploy PROJECT="$AUTH_PROJECT"
     popd > /dev/null
 

--- a/scripts/deploy-full.sh
+++ b/scripts/deploy-full.sh
@@ -505,6 +505,38 @@ deploy_auth() {
     fi
 
     info "Seeding OAuth clients..."
+    # Auto-generate seed-clients.json from the users ConfigMap if it doesn't exist.
+    local seed_json="$REPO_ROOT/scripts/seed-clients.json"
+    if [ ! -f "$seed_json" ]; then
+        local users_cm="$REPO_ROOT/memory-hub-mcp/deploy/users-configmap.yaml"
+        if [ -f "$users_cm" ]; then
+            info "Generating $seed_json from users ConfigMap..."
+            "$REPO_ROOT/.venv/bin/python" -c "
+import json, sys, yaml, pathlib
+with open(sys.argv[1]) as f:
+    cm = yaml.safe_load(f)
+users = json.loads(cm['data']['users.json'])['users']
+clients = []
+for u in users:
+    identity_type = u.get('identity_type', 'user')
+    scopes = ['memory:read', 'memory:write:user']
+    if 'organizational' in u.get('scopes', []):
+        scopes.append('memory:write:organizational')
+    if 'enterprise' in u.get('scopes', []):
+        scopes.append('memory:write:enterprise')
+    clients.append({
+        'client_id': u['user_id'],
+        'client_secret': u['api_key'],
+        'client_name': u.get('name', u['user_id']),
+        'identity_type': identity_type,
+        'tenant_id': u.get('tenant_id', 'default'),
+        'default_scopes': scopes,
+    })
+pathlib.Path(sys.argv[2]).write_text(json.dumps(clients, indent=2))
+print(f'  Generated {len(clients)} OAuth clients from users ConfigMap.')
+" "$users_cm" "$seed_json"
+        fi
+    fi
     "$REPO_ROOT/scripts/run-seed-oauth-clients.sh"
 
     info "Building and deploying Auth server (project: $AUTH_PROJECT)..."

--- a/scripts/deploy-full.sh
+++ b/scripts/deploy-full.sh
@@ -693,8 +693,6 @@ deploy_tile() {
 # Section 7b: Configure local client (API key for CLI/SDK)
 # ---------------------------------------------------------------------------
 configure_local_client() {
-    local api_key_file="$HOME/.config/memoryhub/api-key"
-
     local users_cm="$REPO_ROOT/memory-hub-mcp/deploy/users-configmap.yaml"
     if [ ! -f "$users_cm" ]; then return 0; fi
 
@@ -707,19 +705,32 @@ users = json.loads(cm['data']['users.json'])
 print(users['users'][0]['api_key'])
 " "$users_cm" 2>/dev/null || echo "")
 
-    if [ -n "$key" ] && [[ "$key" != REPLACE-ME* ]]; then
-        user_id=$("$REPO_ROOT/.venv/bin/python" -c "
+    if [ -z "$key" ] || [[ "$key" == REPLACE-ME* ]]; then return 0; fi
+
+    user_id=$("$REPO_ROOT/.venv/bin/python" -c "
 import json, sys, yaml
 with open(sys.argv[1]) as f:
     cm = yaml.safe_load(f)
 users = json.loads(cm['data']['users.json'])
 print(users['users'][0]['user_id'])
 " "$users_cm" 2>/dev/null || echo "unknown")
-        mkdir -p "$HOME/.config/memoryhub"
-        echo -n "$key" > "$api_key_file"
-        chmod 600 "$api_key_file"
-        info "Wrote API key to $api_key_file (user: $user_id)"
+
+    local mcp_route mcp_url=""
+    mcp_route=$(oc get route --context "$CONTEXT" memory-hub-mcp -n "$MCP_PROJECT" \
+        -o jsonpath='{.spec.host}' 2>/dev/null || echo "")
+    if [ -n "$mcp_route" ]; then
+        mcp_url="https://${mcp_route}/mcp/"
     fi
+
+    "$REPO_ROOT/.venv/bin/python" -c "
+import sys
+sys.path.insert(0, '$REPO_ROOT/memoryhub-cli/src')
+from memoryhub_cli.config import migrate_flat_to_credentials, write_credentials_section
+migrate_flat_to_credentials()
+write_credentials_section(sys.argv[1], sys.argv[2], sys.argv[3] or None)
+" "$CONTEXT" "$key" "$mcp_url"
+
+    info "Wrote credentials for context '$CONTEXT' (user: $user_id)"
 }
 
 # ---------------------------------------------------------------------------
@@ -742,13 +753,18 @@ smoke_test() {
     fi
     local mcp_url="https://${mcp_route}/mcp/"
 
-    local api_key_file="$HOME/.config/memoryhub/api-key"
-    if [ ! -f "$api_key_file" ]; then
-        warn "No API key at $api_key_file -- skipping smoke test"
-        return 0
-    fi
     local api_key
-    api_key=$(cat "$api_key_file")
+    api_key=$("$REPO_ROOT/.venv/bin/python" -c "
+import sys
+sys.path.insert(0, '$REPO_ROOT/memoryhub-cli/src')
+from memoryhub_cli.config import get_api_key
+k = get_api_key()
+if k: print(k, end='')
+else: sys.exit(1)
+" 2>/dev/null) || {
+        warn "No API key found -- skipping smoke test"
+        return 0
+    }
 
     if ! command -v memoryhub &>/dev/null; then
         warn "memoryhub CLI not installed -- skipping smoke test"
@@ -844,7 +860,7 @@ print_summary() {
     if [ -n "$mcp_route" ]; then
         printf "    %-24s %s\n" "MCP endpoint (agents):" "https://${mcp_route}/mcp/"
     fi
-    printf "    %-24s %s\n" "Dev API key:" "~/.config/memoryhub/api-key"
+    printf "    %-24s %s\n" "Credentials:" "~/.config/memoryhub/credentials [$CONTEXT]"
 }
 
 # ---------------------------------------------------------------------------

--- a/scripts/deploy-full.sh
+++ b/scripts/deploy-full.sh
@@ -402,15 +402,29 @@ deploy_models() {
         fi
     done
 
+    # Scale down CPU models before deploying GPU variants (shared PVC)
+    if [ "$GPU_MODELS" = true ]; then
+        for dep_ns in "all-minilm-l6-v2:$EMBEDDING_MODEL_NAMESPACE" \
+                      "ms-marco-minilm-l12-v2:$RERANKER_MODEL_NAMESPACE"; do
+            local dep="${dep_ns%%:*}" ns="${dep_ns##*:}"
+            if oc get deployment --context "$CONTEXT" "$dep" -n "$ns" &>/dev/null; then
+                info "Scaling down CPU model $dep to release PVC..."
+                oc scale deployment --context "$CONTEXT" "$dep" -n "$ns" --replicas=0
+            fi
+        done
+    fi
+
     info "Deploying embedding model..."
     oc apply --context "$CONTEXT" -k "$embedding_dir"
 
     info "Deploying reranker model..."
     oc apply --context "$CONTEXT" -k "$reranker_dir"
 
+    local embedding_deploy reranker_deploy
+    embedding_deploy=$(grep '^  name:' "$embedding_dir/deployment.yaml" | head -1 | awk '{print $2}')
+    reranker_deploy=$(grep '^  name:' "$reranker_dir/deployment.yaml" | head -1 | awk '{print $2}')
+
     info "Waiting for embedding model rollout (model download may take 2-3 min)..."
-    local embedding_deploy
-    embedding_deploy=$(oc get deploy --context "$CONTEXT" -n "$EMBEDDING_MODEL_NAMESPACE" -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "")
     if [ -n "$embedding_deploy" ]; then
         if ! oc rollout status --context "$CONTEXT" "deployment/$embedding_deploy" \
                 -n "$EMBEDDING_MODEL_NAMESPACE" --timeout=300s; then
@@ -419,8 +433,6 @@ deploy_models() {
     fi
 
     info "Waiting for reranker model rollout..."
-    local reranker_deploy
-    reranker_deploy=$(oc get deploy --context "$CONTEXT" -n "$RERANKER_MODEL_NAMESPACE" -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "")
     if [ -n "$reranker_deploy" ]; then
         if ! oc rollout status --context "$CONTEXT" "deployment/$reranker_deploy" \
                 -n "$RERANKER_MODEL_NAMESPACE" --timeout=300s; then

--- a/scripts/seed-sample-data.py
+++ b/scripts/seed-sample-data.py
@@ -2,7 +2,7 @@
 """Seed MemoryHub with sample data so the admin UI has content to display.
 
 Usage:
-    # Uses MCP_URL env var or prompts; reads API key from ~/.config/memoryhub/api-key
+    # Uses MCP_URL env var or prompts; reads API key from ~/.config/memoryhub/credentials
     python scripts/seed-sample-data.py
 
     # Explicit URL and key
@@ -16,7 +16,6 @@ Requires: pip install memoryhub
 import argparse
 import asyncio
 import sys
-from pathlib import Path
 
 try:
     from memoryhub import MemoryHubClient
@@ -97,7 +96,7 @@ MEMORIES = [
 async def main():
     parser = argparse.ArgumentParser(description="Seed MemoryHub with sample data")
     parser.add_argument("--url", help="MCP server URL (or set MCP_URL env var)")
-    parser.add_argument("--api-key", help="API key (or store at ~/.config/memoryhub/api-key)")
+    parser.add_argument("--api-key", help="API key (or configure ~/.config/memoryhub/credentials)")
     parser.add_argument("--skip-if-exists", action="store_true",
                         help="Skip seeding if memories already exist")
     args = parser.parse_args()
@@ -112,11 +111,11 @@ async def main():
 
     api_key = args.api_key
     if not api_key:
-        key_path = Path.home() / ".config/memoryhub/api-key"
-        if key_path.exists():
-            api_key = key_path.read_text().strip()
-        else:
-            print(f"Error: provide --api-key or store key at {key_path}")
+        from memoryhub_cli.config import get_api_key
+
+        api_key = get_api_key()
+        if not api_key:
+            print("Error: provide --api-key, set MEMORYHUB_API_KEY, or configure ~/.config/memoryhub/credentials")
             sys.exit(1)
 
     client = MemoryHubClient(url=url, api_key=api_key)

--- a/scripts/smoke-test-sdk.py
+++ b/scripts/smoke-test-sdk.py
@@ -5,7 +5,6 @@ Tests all major SDK features against the deployed MCP server.
 """
 import asyncio
 import sys
-from pathlib import Path
 
 # Import SDK components
 from memoryhub import MemoryHubClient
@@ -22,7 +21,6 @@ from memoryhub.extraction import (
 
 # Test configuration
 MCP_URL = "https://memory-hub-mcp-memory-hub-mcp.apps.cluster-n7pd5.n7pd5.sandbox5167.opentlc.com/mcp/"
-API_KEY_PATH = Path.home() / ".config/memoryhub/api-key"
 PROJECT_ID = "memory-hub"
 
 # Track test IDs for cleanup
@@ -30,11 +28,14 @@ test_memory_ids = []
 
 
 def load_api_key() -> str:
-    """Load API key from ~/.config/memoryhub/api-key"""
-    if not API_KEY_PATH.exists():
-        print(f"❌ API key not found at {API_KEY_PATH}")  # noqa: T201
+    """Load API key via memoryhub-cli config resolution."""
+    from memoryhub_cli.config import get_api_key
+
+    key = get_api_key()
+    if not key:
+        print("No API key found. Set MEMORYHUB_API_KEY or configure ~/.config/memoryhub/credentials")  # noqa: T201
         sys.exit(1)
-    return API_KEY_PATH.read_text().strip()
+    return key
 
 
 async def run_tests():

--- a/session-summaries/2026-07-21-deploy-install-hardening.md
+++ b/session-summaries/2026-07-21-deploy-install-hardening.md
@@ -1,0 +1,49 @@
+# Session Summary -- 2026-07-21 -- deploy -- Install hardening across fresh clusters
+
+**Plan:** Ad-hoc install validation + hardening   **Commits:** b6ea5b3..909c1eb (fix/make-args-passthrough)
+**Deployed:** 5 fresh test clusters (install-test-1 through 5)   **Model:** Opus 4.6
+
+## Plan vs. actual
+Planned: Test `make install` on fresh clusters, fix docs from prior session. Shipped: 7 deploy-blocking bugs fixed, README updated, workshop-setup scripts hardened, seed script added, multi-cluster credential issue filed. Scope expanded from "test and document" to "test, fix everything that breaks, and iterate until a fresh clone installs cleanly."
+
+## Shipped
+- `b6ea5b3` fix: Make install/uninstall forward flags via `ARGS=` (the `--` syntax silently dropped flags)
+- `628e3a8` deploy: Replace hardcoded user IDs (wjackson, rdwj-agent-*) with OS username substitution
+- `9dd7408` fix: Export CURRENT_USER + add mh-dev- prefix to generated API keys
+- `dce8124` fix: Add bcrypt to root pyproject.toml (seed-oauth-clients.py needs it)
+- `3fdaea3` fix: Auto-generate seed-clients.json from users ConfigMap before auth seeding
+- `9a5ad9f` fix: Generate users-configmap.yaml before auth step (ordering dependency)
+- `48e4682` fix: Use sqlalchemy[asyncio] extra (greenlet needed for async engine)
+- `fd952a4` fix: Create memoryhub-auth .venv before deploy (alembic not found)
+- `909c1eb` fix: Always overwrite API key file during install (stale key from other cluster)
+- workshop-setup: 3 commits (duplicate OperatorGroup, --context flag, phased operands)
+- Earlier session (merged as #449): README post-install guide, seed-sample-data.py, claude mcp add fix
+
+## Verification & confidence
+- Cluster 2: manual intervention needed (OperatorGroup bug); full MCP roundtrip after
+- Cluster 3: clean workshop setup, clean install, MCP roundtrip verified
+- Cluster 4: install completed, MCP roundtrip verified (internet drops interrupted agents)
+- Cluster 5: user-driven manual install from the branch; hit and fixed bcrypt/greenlet/auth-venv/seed-clients/ordering bugs live
+- Confidence: high for the fixes landed; medium for "no more bugs" since cluster 5 install finished with a stale-key smoke test failure (fixed by 909c1eb but not re-verified end-to-end after that commit)
+
+## Judgment calls & deviations
+- Used always-overwrite for API key file instead of building multi-cluster config -- simpler, unblocks now, filed #451 for the real solution
+- Python SDK for seed script instead of raw curl -- cleaner, SDK is already a documented dep
+- Removed Gemini API keys from production cluster (mcp-rhoai) at user's request
+
+## Backlog delta
+Filed #451 (multi-cluster API key management -- needs design doc, kept in Backlog)
+
+## Drift & forward-collisions
+- Backward: none
+- Forward: #451 partially addressed by the always-overwrite fix; the issue tracks the full ssh_config-style solution
+
+## For the reviewer
+- Sanity-check: the ordering of deploy steps (users-configmap generation now happens in deploy_auth, duplicating logic from memory-hub-mcp/deploy/deploy.sh) -- is this the right long-term home?
+- Thin verification: cluster 5 install was user-driven and hit real bugs; the final state (post-909c1eb) was not re-run end-to-end on a completely fresh cluster
+- Wants guidance: none
+
+## Risks / watch-fors
+- deploy-full.sh now generates users-configmap.yaml in two places (deploy_auth and deploy_mcp) -- first-writer wins, but the duplication is a maintenance risk
+- The port 15432 conflict between root migrations and auth migrations is a timing issue that showed up on cluster 5 -- non-blocking but worth cleaning up (use different ports or ensure cleanup between steps)
+- Local pytest suite hangs (observed on two sessions now) -- may indicate a venv or import issue worth investigating

--- a/session-summaries/2026-07-24-multi-cluster-credentials.md
+++ b/session-summaries/2026-07-24-multi-cluster-credentials.md
@@ -1,0 +1,42 @@
+# Session Summary -- 2026-07-24 -- Multi-Cluster API Key Management
+
+**Plan:** #451 (multi-cluster credential file)   **Commits:** b132fc6..55a149c (`fix/make-args-passthrough`)
+**Deployed:** none   **Model:** Opus 4.6
+
+## Plan vs. actual
+Planned: implement #451 -- INI-style credentials file replacing flat api-key. Shipped: full implementation across all 4 phases. No slippage.
+Scope: stayed in scope. Benchmarks deferred to follow-up as planned.
+
+## Shipped
+- b132fc6 -- Core credentials library: `read/write/migrate` functions, updated resolution chain in `get_api_key()`/`get_server_url()`, new `get_credentials()` paired resolver, 43 unit tests
+- 18a6d44 -- Deploy writers: `configure_local_client()` writes per-context sections with MCP URL; `smoke_test()` reads through config module; admin `--write-config` targets credentials file with `--context` flag
+- d10a29f -- Hook scripts: `load-memories.sh` and `HOOK_SCRIPT_TEMPLATE` use awk-based INI parser, fall back to flat file; instruction text templates updated
+- 55a149c -- Remaining readers (`smoke-test-sdk.py`, `seed-sample-data.py`, `deploy-evalhub.sh`) and docs (CLAUDE.md, memoryhub-loading.md, hooks-integration.md, memoryhub-cli/README.md, `config_init()`)
+
+## Verification & confidence
+- Unit tests: 163/164 pass (1 pre-existing OGX template failure)
+- Lint: clean on all changed files
+- Secrets scan: clean
+- Not deployed -- needs push + CI green + golden test on cluster
+- Confidence: **medium-high** -- logic is well-tested at the unit level but no end-to-end deploy verification yet
+
+## Judgment calls & deviations
+- Linter simplified `read_credentials_section()` to NOT fall back from a missing named section to `[default]` -- accepted this as cleaner behavior (the resolution chain in `get_api_key()` handles the cascade)
+- Used `configparser` stdlib (no new deps) with `interpolation=None` to avoid `%` in API keys
+- deploy-full.sh calls Python for INI read/write instead of duplicating a bash parser -- the script already uses Python for YAML parsing
+
+## Backlog delta
+Filed: none. Closed: none (PR not merged yet). Deferred: benchmark script updates (not on critical path).
+
+## Drift & forward-collisions
+- Backward: #451 is being resolved by this branch
+- Forward: none
+
+## For the reviewer
+- Sanity-check: the awk INI parser in the hook template -- it handles `key = value` but not quoted values or inline comments. Sufficient for the simple credentials format but worth a second look.
+- Thin verification: no golden test run (`uninstall --skip-db && deploy-full.sh`) -- that requires cluster access and should happen before merge.
+- Wants guidance: none
+
+## Risks / watch-fors
+- The branch has 8+ commits now (prior deploy work + these 4) -- consider squashing or at least reviewing the full diff before merge to main
+- Pre-existing OGX test failure should be tracked separately


### PR DESCRIPTION
## Summary

- Fix 7+ deploy-blocking bugs found in fresh-cluster install testing
- Replace flat `~/.config/memoryhub/api-key` with INI-style `~/.config/memoryhub/credentials` keyed by cluster context (#451)
- Fix GPU model deployment for single-GPU clusters (reranker runs on CPU, scale down CPU models before GPU deploy, fix rollout check)
- Make install/uninstall forward flags correctly, generate ConfigMaps and seed files, create auth venv, add bcrypt/greenlet deps

## Test plan

- [x] Unit tests: 163/164 pass (1 pre-existing OGX test failure)
- [x] Lint: clean on all changed files
- [x] Secrets scan: clean
- [ ] Golden test: `make install ARGS="--gpu-models"` from clean clone on fresh cluster