### PR TITLE
release: Prepare PyPI publish for personal edition

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
     tags:
       - 'sdk/v*.*.*'
       - 'memoryhub-cli/v*.*.*'
+      - 'memoryhub-local/v*.*.*'
 
 permissions:
   contents: write
@@ -28,7 +29,7 @@ jobs:
         uses: lewagon/wait-on-check-action@v1.3.1
         with:
           ref: ${{ github.ref }}
-          check-regexp: ${{ contains(github.ref, 'sdk/') && 'SDK Tests' || 'CLI Tests' }}
+          check-regexp: ${{ contains(github.ref, 'sdk/') && 'SDK Tests' || contains(github.ref, 'memoryhub-local/') && 'Tests Status' || 'CLI Tests' }}
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 10
 
@@ -50,6 +51,8 @@ jobs:
             VERSION_SRC=$(grep -E '^__version__' sdk/src/memoryhub/__init__.py | cut -d'"' -f2)
           elif [ "$COMPONENT" = "memoryhub-cli" ]; then
             VERSION_SRC=$(grep -E '^__version__' memoryhub-cli/src/memoryhub_cli/__init__.py | cut -d'"' -f2)
+          elif [ "$COMPONENT" = "memoryhub-local" ]; then
+            VERSION_SRC=$(grep -E '^__version__' memoryhub-local/src/memoryhub_local/__init__.py | cut -d'"' -f2)
           else
             echo "Error: Unknown component '$COMPONENT'"
             exit 1
@@ -121,7 +124,7 @@ jobs:
 
     environment:
       name: pypi
-      url: https://pypi.org/p/${{ needs.create-release.outputs.component == 'sdk' && 'memoryhub' || 'memoryhub-cli' }}
+      url: https://pypi.org/p/${{ needs.create-release.outputs.component == 'sdk' && 'memoryhub' || needs.create-release.outputs.component }}
 
     permissions:
       id-token: write

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - 'sdk/**'
       - 'memoryhub-cli/**'
+      - 'memoryhub-local/**'
 
 jobs:
   version-check:
@@ -25,6 +26,7 @@ jobs:
 
           SDK_CHANGED=false
           CLI_CHANGED=false
+          LOCAL_CHANGED=false
 
           if echo "$CHANGED_FILES" | grep -q '^sdk/'; then
             SDK_CHANGED=true
@@ -32,6 +34,10 @@ jobs:
 
           if echo "$CHANGED_FILES" | grep -q '^memoryhub-cli/'; then
             CLI_CHANGED=true
+          fi
+
+          if echo "$CHANGED_FILES" | grep -q '^memoryhub-local/'; then
+            LOCAL_CHANGED=true
           fi
 
           EXIT_CODE=0
@@ -80,8 +86,12 @@ jobs:
             check_component "CLI" "memoryhub-cli" "memoryhub_cli" || EXIT_CODE=1
           fi
 
-          if [ "$SDK_CHANGED" = "false" ] && [ "$CLI_CHANGED" = "false" ]; then
-            echo "No SDK or CLI files changed, skipping version check."
+          if [ "$LOCAL_CHANGED" = "true" ]; then
+            check_component "Local" "memoryhub-local" "memoryhub_local" || EXIT_CODE=1
+          fi
+
+          if [ "$SDK_CHANGED" = "false" ] && [ "$CLI_CHANGED" = "false" ] && [ "$LOCAL_CHANGED" = "false" ]; then
+            echo "No SDK, CLI, or Local files changed, skipping version check."
           fi
 
           exit $EXIT_CODE

--- a/memoryhub-cli/CHANGELOG.md
+++ b/memoryhub-cli/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the `memoryhub-cli` package.
 
+## [0.12.0] -- 2026-07-28
+
+- **`memoryhub mcp`**: Start a local MCP server (personal edition, stdio).
+- **`memoryhub doctor`**: Health check for personal edition -- database,
+  model, migrations, memory count.
+- **`memoryhub dream`**: Extract facts from conversation threads using a
+  local LLM (Ollama or any OpenAI-compatible endpoint).
+
 ## [0.11.0] — 2026-06-12
 
 - **Hook scaffolding**: `memoryhub config init` now generates the full

--- a/memoryhub-local/CHANGELOG.md
+++ b/memoryhub-local/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog -- memoryhub-local
+
+All notable changes to the `memoryhub-local` package.
+
+## [0.1.0] -- 2026-07-28
+
+Initial release. Personal edition of MemoryHub -- agent memory without infrastructure.
+
+- SQLite backend with WAL mode, brute-force KNN via sqlite-vec, FTS5
+- RecallBackend protocol with SQLiteBackend and PostgresBackend implementations
+- FastMCP server (stdio) with 4 tools: register_session, memory, thread, admin_memory
+- ONNX embeddings (Granite Embedding Small English R2, 384 dim, CPU-only)
+- Extraction pipeline with MCP sampling and windowed processing
+- On-connect dreaming (automatic extraction on session start)
+- Alembic migrations with batch-mode SQLite support
+- Versioned memory with full history
+- Graph relationships (relate, relationships, similar)
+- Contradiction detection (report action)
+- Thread operations (create, append, get, list, archive, delete, extract)
+- Admin moderation (quarantine, restore, hard_delete)

--- a/reconciliations/2026-07-28-personal-edition.md
+++ b/reconciliations/2026-07-28-personal-edition.md
@@ -1,0 +1,34 @@
+# Reconciliation -- 2026-07-28 -- personal-edition
+
+**Range:** summaries 2026-07-27..2026-07-28 (7 sessions)   **Plan:** NEXT_SESSION-local.md / planning/personal-edition.md
+
+## Backlog reconciled
+
+| # | Was | Action | Why |
+|---|-----|--------|-----|
+| #308 | Local/offline embedding fallback (all-MiniLM, sentence-transformers) | Re-scope | Personal edition built EmbeddingService ABC + OnnxEmbeddingService (Granite, ONNX). Remaining: wire as cluster fallback. Commented. |
+| #375 | Full local test suite hangs | Keep | Integration tests still need local PostgreSQL; hang is unrelated to personal-edition work. |
+| #458 | CLI create-agent omits api_key | Keep | Cluster-edition bug, unrelated. |
+| #459 | CLI rotate-api-key subcommand | Keep | Cluster-edition auth, unrelated. |
+| #460 | README quickstart | Closed | Shipped in 260c6ec, closed in P5S1. |
+| #461 | Parity matrix | Closed | Shipped in 260c6ec, closed in P5S1. |
+| #462 | Clean-venv verification | Closed | Verified in dc40694, closed in P5S1. |
+
+## Forward-collisions banked
+
+- #308 -- embedding abstraction already built at `memoryhub-local/embeddings/` -- comment landed
+- #310 -- stdio MCP server is framework-agnostic, partially advances non-Claude-Code onboarding -- comment landed
+
+## Deferred items resolved
+
+- Stale all-MiniLM model comment (arch session) -- cleaned up during P1 implementation, verified no references remain
+- Version bump 0.2.0 (P4S1) -- deferred to PyPI publish
+- Extraction prompt sync (P4S1) -- valid watch-for, not yet an issue
+
+## Critique
+
+On track: epic shipped completely, all 5 phases done, 45 commits squash-merged to main via #463. No scope creep, no recurring friction. Single gap: two-command install requires PyPI publishing.
+
+## Guidance for next
+
+PyPI publishing is the highest-leverage next step. After that, #308 re-scope (cluster embedding fallback) would let the cluster edition benefit from the abstraction built here.

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the `memoryhub` SDK package.
 
+## [0.15.0] -- 2026-07-28
+
+- **`[local]` extra**: `pip install "memoryhub[local]"` pulls in memoryhub-cli
+  and memoryhub-local for zero-infrastructure personal edition.
+
 ## [0.14.0] — 2026-06-12
 
 - **`reconstruct()` method**: Convenience wrapper for behavioral memory

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "memoryhub"
-version = "0.14.0"
+version = "0.15.0"
 description = "Centralized, governed memory for AI agents"
 readme = "README.md"
 license = "Apache-2.0"

--- a/sdk/src/memoryhub/__init__.py
+++ b/sdk/src/memoryhub/__init__.py
@@ -22,7 +22,7 @@ from memoryhub.exceptions import (
     ValidationError,
 )
 
-__version__ = "0.14.0"
+__version__ = "0.15.0"
 
 __all__ = [
     "MemoryHubClient",


### PR DESCRIPTION
## Summary

- Extend release and version-check workflows to support `memoryhub-local`
- Bump SDK to 0.15.0 (adds `[local]` optional extra)
- Add CHANGELOG entries for all three packages
- Add personal-edition reconciliation record

After merge, tag in order:
1. `memoryhub-local/v0.1.0` (new package, no deps)
2. `memoryhub-cli/v0.12.0` (depends on memoryhub>=0.14.0, already on PyPI)
3. `sdk/v0.15.0` (depends on the other two via `[local]` extra)

Prerequisite: add `memoryhub-local` as a pending trusted publisher on PyPI.

## Test plan

- [x] Version consistency: pyproject.toml and __init__.py match for all three packages
- [x] Release workflow handles memoryhub-local tag pattern
- [x] CHANGELOG entries present for all three versions