### PR TITLE
ci: Add memoryhub-local tag trigger to test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,7 @@ on:
       - 'sdk/v*.*.*'
       - 'mcp/v*.*.*'
       - 'memoryhub-cli/v*.*.*'
+      - 'memoryhub-local/v*.*.*'
   pull_request:
     branches: [ main ]
 


### PR DESCRIPTION
One-line fix: the release workflow for memoryhub-local waits for `Tests Status`, but test.yml didn't trigger on `memoryhub-local/v*` tags.

Blocking the memoryhub-local/v0.1.0 release.