### PR TITLE
docs: Refresh README -- personal edition front door, trim to 213 lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,68 +1,37 @@
 # MemoryHub
 
-Centralized, governed memory for AI agents on OpenShift AI. MemoryHub gives every agent in your organization a shared, persistent memory layer with multi-tier scoping (`user` / `project` / `campaign` / `role` / `organizational` / `enterprise`), version history, semantic search via pgvector, audit logging (structured events shipped; durable audit store in progress), and an OAuth 2.1 authorization story.
+Persistent, governed memory for AI agents. MemoryHub gives agents a shared memory layer with semantic search, version history, scoped access control, and audit logging. It works with any agent framework that speaks MCP.
 
-It works with any agent framework that speaks MCP — Claude Code, LlamaStack workflows, LangGraph/CrewAI/AG2 agents, custom Python agents — and ships a typed Python SDK and a CLI for direct use.
+**Try it now** -- `pip install "memoryhub[local]"` for a personal edition backed by SQLite (no infrastructure needed), or deploy the [cluster edition](docs/guides/cluster-install.md) on OpenShift AI for multi-agent governance, OAuth 2.1, and team-wide shared memory.
 
-**Requires Python 3.11+** (use [uv](https://docs.astral.sh/uv/) to install it automatically). See [Local Development](docs/guides/local-development.md) to get the MCP server running on your machine, or the [Agent Integration Guide](docs/guides/agent-integration-guide.md) for the conceptual overview of rules, hooks, and agent-driven memory plus the integration reference.
+Retrieval quality: 84.9% on [AMB PersonaMem](benchmarks/RESULTS.md) (2nd on the leaderboard), R@5=0.999 on LongMemEval. Requires Python 3.10+.
 
 ## How to think about agent memory
 
-The model never remembers anything — at inference time, a memory is just tokens in context, and it makes no difference whether they came from a markdown file, a vector store, or a graph. Memory is a **context-assembly policy problem**: how did the right items get selected, who was allowed to see them, what happens when they conflict, and can you reconstruct what an agent knew when it acted?
+The model never remembers anything -- at inference time, a memory is just tokens in context, and it makes no difference whether they came from a markdown file, a vector store, or a graph. Memory is a **context-assembly policy problem**: how did the right items get selected, who was allowed to see them, what happens when they conflict, and can you reconstruct what an agent knew when it acted?
 
-Two principles drive everything here. First, give the agent **100% of what it needs and 0% of what it doesn't** — no retrieval trick compensates for missing context, and garbage overlap degrades performance even when the right facts are present. Second, **work backwards from the forensic investigation**: who or what did the thing, what memories were in context, who wrote them, were they in conflict, did storing them violate policy, and which other agents were exposed to them?
+Two principles drive everything here. First, give the agent **100% of what it needs and 0% of what it doesn't** -- no retrieval trick compensates for missing context, and garbage overlap degrades performance even when the right facts are present. Second, **work backwards from the forensic investigation**: who or what did the thing, what memories were in context, who wrote them, were they in conflict, did storing them violate policy, and which other agents were exposed to them?
 
-That second principle is the honest dividing line. One developer coding on one machine? Use your harness's built-in memory and you are well-served. Just you, beyond coding? llm-wiki or Obsidian is the right answer. But a fleet of agents sharing fast-changing operational memory, a team of developers with coding agents in a controlled environment, or agents in a healthcare process — and any scenario where the forensic questions will actually be asked — need identity, scopes, curation, contradiction handling, and audit. That's what MemoryHub is.
+That second principle is the honest dividing line. One developer coding on one machine? Use your harness's built-in memory and you are well-served. Just you, beyond coding? llm-wiki or Obsidian is the right answer. But a fleet of agents sharing fast-changing operational memory, a team of developers with coding agents in a controlled environment, or agents in a healthcare process -- and any scenario where the forensic questions will actually be asked -- need identity, scopes, curation, contradiction handling, and audit. That's what MemoryHub is.
 
 The full argument, including when *not* to use MemoryHub: [What Agent Memory Really Is](docs/guides/what-is-agent-memory.md).
 
-## Why MemoryHub
+## Get started
 
-- **Governed memory operations.** Every write, read, update, and deletion is access-controlled by [six-tier scope isolation](docs/design/governance.md) enforced at the SQL level. Memories carry [version history with provenance branches](docs/design/memory-tree.md), contradiction detection, and a [three-layer curation rules engine](docs/design/curator-agent.md) with inline secrets/PII scanning. Enterprise-scope memories require human approval. This is the substrate that makes all other capabilities trustworthy.
+### Personal edition
 
-- **Shared agent memory.** Agents don't just remember for themselves — they build an organizational hive mind. [Project-scoped memories](docs/design/memory-tree.md) surface for every agent working in that context, with auto-enrollment on first write to open projects so agents can start contributing without manual membership setup. [Campaign scoping](planning/archive/campaign-domain-framework.md) enables bounded cross-project initiatives where knowledge discovered by one project's agent is available to all enrolled projects. Domain tags enable crosscutting retrieval. [Two-vector retrieval](docs/design/two-vector-retrieval.md) blends query relevance with session focus context via RRF and cross-encoder reranking, so search results match both what the agent asked and what it's currently working on. [Real-time push notifications](docs/agent-memory-ergonomics/design.md) keep agent swarms current. A planned promotion pipeline will lift patterns discovered by individual agents into organizational knowledge.
+Zero infrastructure. Memories are stored locally in SQLite at `~/.local/share/memoryhub/`.
 
-- **Inference cost optimization.** [Cache-optimized assembly](research/infra/vllm-kv-cache.md) returns memories in a deterministic, epoch-locked order designed for KV cache prefix hits across vLLM (2x throughput, 152x TTFT), Anthropic (90% cost reduction), OpenAI (50%), and Gemini (75-90%). The key insight: the first agent pays full inference cost; subsequent agents with overlapping memory contexts get the cached prefix nearly free. Token budget caps and weight-based stub/full injection keep context windows lean. [Governed context compaction](research/surveys/retrieval-compaction-persistence.md) is on the roadmap.
+```bash
+pip install "memoryhub[local]"
+claude mcp add memoryhub -- memoryhub mcp
+```
 
-- **Compliance-oriented architecture.** Version history, provenance branches, structured audit events, and a planned [durable audit trail](docs/design/governance.md) position MemoryHub for EU AI Act transparency requirements (enforcement begins August 2026), GDPR data governance, HIPAA, and financial regulations. Compaction will use readable summaries — not opaque tokens — so the compliance team can inspect what was kept.
+Start a new Claude Code session and your agent has persistent memory. See [`memoryhub-local/README.md`](memoryhub-local/README.md) for configuration, dreaming (offline fact extraction), and how it works under the hood.
 
-- **Framework-agnostic integration.** Works with any agent framework that speaks MCP. A [typed Python SDK](sdk/README.md), a CLI, a [project config wizard](docs/agent-memory-ergonomics/design.md) that generates agent rule files, and a designed integration path for [LlamaStack](planning/llamastack-integration/overview.md).
+### Cluster edition
 
-- **Kubernetes-native on OpenShift AI.** [PostgreSQL + pgvector](docs/design/storage-layer.md) handling relational, vector, and graph queries in one database, with MinIO for object storage. FIPS compliance by delegation. Air-gap deployable with on-cluster embedding models. Red Hat UBI images. An [llm-d integration path](research/infra/vllm-kv-cache.md) for automatic cache-aware routing at the infrastructure level.
-
-**Status (2026-04-15).** Core memory operations, OAuth 2.1 + JWT auth with service-layer RBAC, the dashboard UI, the published Python SDK, the agent-memory-ergonomics work (search shape, session focus vector with cross-encoder reranking, project config + rule generation), and cache-optimized memory assembly with compilation epochs are all shipped. The Kubernetes operator and the curator-as-background-agent layer are still on the roadmap. See [`docs/SYSTEMS.md`](docs/SYSTEMS.md) for the per-subsystem status table.
-
-## What's in this repo
-
-| Component | Path | What it is |
-|---|---|---|
-| **MCP server** | [`memory-hub-mcp/`](memory-hub-mcp/) | FastMCP 3 server exposing memory operations (search, read, write, update, delete, similarity, relationships, curation, contradictions, threads, session registration, project discovery) over streamable-HTTP via profile-selectable tool sets — compact (4 action-dispatch tools, default), full (13), minimal (5). The primary agent surface. |
-| **Server-side library** | [`src/memoryhub_core/`](src/memoryhub_core/) | SQLAlchemy models, service layer, embedding integration, RBAC enforcement (`core/authz.py`). Distribution name `memoryhub-core`; import name `memoryhub_core`. The MCP server, BFF, alembic migrations, and the seed-OAuth-clients script all import from here. |
-| **Python SDK** | [`sdk/`](sdk/) | `pip install memoryhub` — typed async client wrapping the MCP tools. OAuth 2.1 token management is automatic. See [`sdk/README.md`](sdk/README.md). |
-| **CLI** | [`memoryhub-cli/`](memoryhub-cli/) | `pip install memoryhub-cli` — terminal client for search/read/write/delete plus `memoryhub config init` for generating project-level `.memoryhub.yaml` and `.claude/rules/memoryhub-loading.md` rule files. |
-| **Dashboard UI** | [`memoryhub-ui/`](memoryhub-ui/) | React + PatternFly 6 frontend behind a FastAPI BFF, deployed as a single container. Six panels: Memory Graph, Status Overview, Users & Agents, Client Management, Curation Rules, Contradiction Log. OAuth-proxy sidecar in front of OpenShift login. |
-| **Auth service** | [`memoryhub-auth/`](memoryhub-auth/) | Standalone OAuth 2.1 authorization server. FastAPI with `client_credentials` and `refresh_token` grants, RSA-2048 JWT signing, JWKS endpoint, admin client management API. |
-| **Database migrations** | [`alembic/`](alembic/) | Schema migrations for the server-side library. PostgreSQL with the pgvector extension. |
-| **Design docs** | [`docs/`](docs/) | Subsystem designs, the agent-memory-ergonomics design cluster, package layout, auth and identity model. Start at [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md). |
-| **Planning** | [`planning/`](planning/) | In-flight designs for unimplemented features (operator, observability, org-ingestion) and the LlamaStack integration plan. |
-| **Research** | [`research/`](research/) | Investigations and explorations — FIPS storage analysis, agent-memory-ergonomics research notes. |
-| **Demos** | [`demos/`](demos/) | Conference demo scripts (HIMSS, RSA, IACP, IAEM, World AgriTech) and the RHOAI dashboard demo material. |
-| **Retrospectives** | [`retrospectives/`](retrospectives/) | Per-session retros documenting decisions, gaps, and patterns. Read these for the "why" behind major design choices. |
-
-## Install in your cluster
-
-MemoryHub installs to any OpenShift cluster with Red Hat OpenShift AI (RHOAI). The full stack is seven services across six namespaces, all deployed by a single `make install`.
-
-### Prerequisites
-
-- `oc` logged in with cluster-admin on a cluster with RHOAI installed
-- `podman` on your PATH (checked but not required for server-side builds)
-- A default StorageClass (most clusters have one)
-- Python 3.11+ on your PATH (the deploy script creates `.venv` automatically)
-
-Run `make check-prereqs` to verify all of these non-destructively. GPUs are not required; the default install uses CPU-based embedding and reranker models.
-
-### Quick start
+Full governed stack on OpenShift AI: PostgreSQL + pgvector, OAuth 2.1, embedding + reranker models, dashboard UI.
 
 ```bash
 git clone https://github.com/redhat-ai-americas/memory-hub.git
@@ -71,160 +40,42 @@ oc login <cluster-api-url>      # cluster-admin required
 make install                    # full stack deploy (~10 min)
 ```
 
-That's it. The deploy script auto-creates the Python virtualenv (for Alembic migrations), generates API keys for the users ConfigMap if it doesn't exist, writes the first key to `~/.config/memoryhub/api-key` for CLI/SDK use, and runs a write/search/read smoke test at the end.
+The deploy script auto-creates a Python virtualenv, generates API keys, writes the first key to `~/.config/memoryhub/api-key`, and runs a smoke test. See the [cluster install guide](docs/guides/cluster-install.md) for prerequisites, deploy options, troubleshooting, and post-install setup.
 
-To bring your own API keys instead, copy the template before running install:
+## Why MemoryHub
 
-```bash
-cp memory-hub-mcp/deploy/users-configmap.example.yaml \
-   memory-hub-mcp/deploy/users-configmap.yaml
-# Replace REPLACE-ME placeholders with: openssl rand -hex 16
-make install
-```
+- **Governed memory operations.** Every write, read, update, and deletion is access-controlled by [six-tier scope isolation](docs/design/governance.md) enforced at the SQL level. Memories carry [version history with provenance branches](docs/design/memory-tree.md), contradiction detection, and a [three-layer curation rules engine](docs/design/curator-agent.md) with inline secrets/PII scanning. Enterprise-scope memories require human approval. This is the substrate that makes all other capabilities trustworthy.
 
-### What gets deployed
+- **Shared agent memory.** Agents don't just remember for themselves -- they build an organizational hive mind. [Project-scoped memories](docs/design/memory-tree.md) surface for every agent working in that context, with auto-enrollment on first write to open projects so agents can start contributing without manual membership setup. [Campaign scoping](planning/archive/campaign-domain-framework.md) enables bounded cross-project initiatives where knowledge discovered by one project's agent is available to all enrolled projects. Domain tags enable crosscutting retrieval. [Two-vector retrieval](docs/design/two-vector-retrieval.md) blends query relevance with session focus context via RRF and cross-encoder reranking, so search results match both what the agent asked and what it's currently working on. [Real-time push notifications](docs/agent-memory-ergonomics/design.md) keep agent swarms current. A promotion pipeline lifts patterns discovered by individual agents into organizational knowledge.
 
-| Service | Namespace | What |
-|---------|-----------|------|
-| PostgreSQL + pgvector | `memoryhub-db` | Database (memories, threads, graph, auth tables) |
-| MinIO | `memory-hub-mcp` | S3-compatible object storage for oversized content |
-| Valkey | `memory-hub-mcp` | Session focus state and compilation epoch cache |
-| Embedding model | `embedding-model` | all-MiniLM-L6-v2 via HuggingFace TEI (CPU, 384-dim) |
-| Reranker model | `reranker-model` | ms-marco-MiniLM-L12-v2 cross-encoder via TEI (CPU) |
-| Auth service | `memoryhub-auth` | OAuth 2.1 authorization server (JWT, PKCE, API keys) |
-| MCP server | `memory-hub-mcp` | FastMCP 3 server exposing memory operations |
-| Dashboard UI | `memoryhub-ui` | React + PatternFly 6 frontend with FastAPI BFF |
+- **Inference cost optimization.** [Cache-optimized assembly](research/infra/vllm-kv-cache.md) returns memories in a deterministic, epoch-locked order designed for KV cache prefix hits across vLLM (2x throughput, 152x TTFT), Anthropic (90% cost reduction), OpenAI (50%), and Gemini (75-90%). The key insight: the first agent pays full inference cost; subsequent agents with overlapping memory contexts get the cached prefix nearly free. Token budget caps and weight-based stub/full injection keep context windows lean. [Governed context compaction](research/surveys/retrieval-compaction-persistence.md) is on the roadmap.
 
-All service URLs (auth JWKS, embedding, reranker) are resolved dynamically from cluster state at deploy time. No hardcoded cluster domains.
+- **Compliance-oriented architecture.** Version history, provenance branches, structured audit events, and a durable [audit trail](docs/design/governance.md) position MemoryHub for EU AI Act transparency requirements (enforcement begins August 2026), GDPR data governance, HIPAA, and financial regulations. Compaction will use readable summaries -- not opaque tokens -- so the compliance team can inspect what was kept.
 
-Expect 8-15 minutes on a first install. The MCP server, auth service, and UI each go through an OpenShift BuildConfig, and the embedding/reranker models need to download weights on first run.
+- **Framework-agnostic integration.** Works with any agent framework that speaks MCP. A [typed Python SDK](sdk/README.md), a CLI, a [project config wizard](docs/agent-memory-ergonomics/design.md) that generates agent rule files, and a designed integration path for [LlamaStack](planning/llamastack-integration/overview.md).
 
-**Prerequisites:** `oc` and `podman` on your PATH, cluster-admin on a cluster with RHOAI installed, a default StorageClass. `make check-prereqs` verifies all of these -- run it first. See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the "new contributor no-deploy" rule: if you're onboarding to this codebase, work against a local SQLite or Podman PostgreSQL instead of deploying to a cluster.
+- **Kubernetes-native on OpenShift AI.** [PostgreSQL + pgvector](docs/design/storage-layer.md) handling relational, vector, and graph queries in one database, with MinIO for object storage. FIPS compliance by delegation. Air-gap deployable with on-cluster embedding models. Red Hat UBI images. An [llm-d integration path](research/infra/vllm-kv-cache.md) for automatic cache-aware routing at the infrastructure level.
 
-### Targeting a specific cluster
+Per-subsystem status and dependency graph: [`docs/SYSTEMS.md`](docs/SYSTEMS.md).
 
-If you have multiple clusters configured in your kubeconfig, set `MEMORYHUB_CONTEXT` to target a specific one without switching your active context:
+## What's in this repo
 
-```bash
-MEMORYHUB_CONTEXT=my-cluster make install
-MEMORYHUB_CONTEXT=my-cluster make uninstall
-```
-
-This passes `--context` on every `oc` command and never mutates your kubeconfig.
-
-### Deploy options
-
-```bash
-make install                                       # full stack (CPU models, default)
-make install ARGS="--gpu-models"                   # use GPU embedding/reranker models instead
-make install ARGS="--skip-models"                  # skip embedding/reranker (mock search)
-make install ARGS="--skip-ui --skip-tile"          # headless (no dashboard)
-```
-
-### Uninstall
-
-```bash
-make uninstall                                     # prompts for confirmation
-make uninstall ARGS="--yes"                        # non-interactive (CI)
-make uninstall ARGS="--skip-db"                    # preserve database across reinstall
-make uninstall ARGS="--skip-models"                # keep embedding/reranker models running
-```
-
-### Troubleshooting
-
-**Image digest mismatch.** If the MCP deploy fails with `running digest does not match imagestream :latest`, the OpenShift deployment cached a stale image. Re-run the install and it will pick up the correct digest:
-
-```bash
-make install ARGS="--skip-db --skip-migrations --skip-auth"
-```
-
-**Reranker timeout with `--gpu-models`.** On single-GPU clusters, the embedding model takes the GPU. The reranker runs on CPU (with a GPU node toleration for scheduling). If the reranker times out, check for PVC contention -- the CPU model variant may still be running and holding the shared PVC. The deploy script scales down CPU models automatically, but leftover deployments from a prior install can interfere. Delete them manually: `oc delete deployment <cpu-model-name> -n reranker-model`.
-
-### Partial deploys (advanced)
-
-`make deploy-db`, `make deploy-mcp`, `make deploy-auth`, `make deploy-ui`, `make deploy-tile` each deploy a single service and skip the others. `make help` lists everything.
-
-### Post-install verification
-
-The deploy script prints a summary banner with all Route URLs. Verify the MCP endpoint with:
-
-```bash
-# Health check (406 = correct for streamable-HTTP MCP)
-curl -s -o /dev/null -w "%{http_code}" \
-  https://memory-hub-mcp-memory-hub-mcp.apps.<cluster>/mcp/
-
-# Auth health
-curl -s https://auth-server-memoryhub-auth.apps.<cluster>/healthz
-```
-
-For full tool verification, use `mcp-test-mcp` to connect to the deployed MCP server and list its tools.
-
-### After install
-
-The install summary banner prints the routes for each service. Follow these steps to verify the deployment and connect your first agent.
-
-**1. Get an API key.** The install creates a `memoryhub-users` ConfigMap in the `memory-hub-mcp` namespace with pre-seeded users and API keys. To view the available keys:
-
-```bash
-oc get configmap memoryhub-users -n memory-hub-mcp \
-  -o jsonpath='{.data.users\.json}' | python3 -m json.tool
-```
-
-Copy a key (format: `mh-dev-<hex>`) and store it locally:
-
-```bash
-mkdir -p ~/.config/memoryhub
-echo "mh-dev-<your-key>" > ~/.config/memoryhub/api-key
-```
-
-To add new users or rotate keys, see the [API key provisioning runbook](docs/runbooks/add-mcp-api-user.md).
-
-**2. Install the CLI and SDK.**
-
-```bash
-pip install memoryhub-cli    # terminal client
-pip install memoryhub        # Python SDK (optional, for scripting)
-```
-
-**3. Verify the deployment.** Use the CLI to test the connection:
-
-```bash
-memoryhub login              # configures endpoint + API key
-memoryhub search "test"      # should return empty results on a fresh install
-```
-
-Or use the SDK directly:
-
-```bash
-python scripts/seed-sample-data.py \
-  --url https://<your-mcp-route>/mcp/
-```
-
-This writes sample memories across multiple scopes so the dashboard has content to display.
-
-**4. Connect Claude Code.** Add the MCP server to Claude Code (the server name `memoryhub` is required as the first positional argument):
-
-```bash
-claude mcp add memoryhub \
-  --transport http \
-  -s user \
-  https://<your-mcp-route>/mcp/
-```
-
-Then set up the agent rule file so Claude Code knows how to use the tools:
-
-```bash
-memoryhub config init        # interactive wizard — generates .memoryhub.yaml + .claude/rules/
-```
-
-**5. Open the dashboard from RHOAI.** The install adds a MemoryHub tile to the Red Hat OpenShift AI application catalog:
-
-1. Open the RHOAI dashboard (the URL printed in the install summary, or find it at `https://rhods-dashboard-redhat-ods-applications.apps.<your-cluster>/`)
-2. Click **Applications** in the left sidebar, then **Explore**
-3. Find the **MemoryHub** tile and click it
-4. Click **Open application** to launch the admin dashboard
-
-The dashboard has six panels: Memory Graph (visual node/edge view of memories and relationships), Status Overview (system health), Users & Agents (active sessions), Client Management (OAuth clients), Curation Rules (content filtering), and Contradiction Log (conflicting memories). If you ran `seed-sample-data.py` in step 3, the Memory Graph will show the seeded memories and their relationships.
+| Component | Path | What it is |
+|---|---|---|
+| **MCP server** | [`memory-hub-mcp/`](memory-hub-mcp/) | FastMCP 3 server exposing memory operations over streamable-HTTP. Four action-dispatch tools (compact profile, default) or 13 individual tools (full profile). The primary agent surface. |
+| **Server-side library** | [`src/memoryhub_core/`](src/memoryhub_core/) | SQLAlchemy models, service layer, embedding integration, RBAC enforcement (`core/authz.py`). Distribution name `memoryhub-core`; import name `memoryhub_core`. The MCP server, BFF, alembic migrations, and the seed-OAuth-clients script all import from here. |
+| **Python SDK** | [`sdk/`](sdk/) | `pip install memoryhub` -- typed async client wrapping the MCP tools. OAuth 2.1 token management is automatic. See [`sdk/README.md`](sdk/README.md). |
+| **CLI** | [`memoryhub-cli/`](memoryhub-cli/) | `pip install memoryhub-cli` -- terminal client for search/read/write/delete plus `memoryhub config init` for generating project-level `.memoryhub.yaml` and `.claude/rules/memoryhub-loading.md` rule files. |
+| **Personal edition** | [`memoryhub-local/`](memoryhub-local/) | SQLite backend + local runtime for zero-infrastructure agent memory. `pip install "memoryhub[local]"`. |
+| **Curation agents** | [`memoryhub-agents/`](memoryhub-agents/) | Background agents (Fact Checker, Trace Reviewer) running on Valkey job queues with leader election. |
+| **Dashboard UI** | [`memoryhub-ui/`](memoryhub-ui/) | React + PatternFly 6 frontend behind a FastAPI BFF, deployed as a single container. Six panels: Memory Graph, Status Overview, Users & Agents, Client Management, Curation Rules, Contradiction Log. OAuth-proxy sidecar in front of OpenShift login. |
+| **Auth service** | [`memoryhub-auth/`](memoryhub-auth/) | Standalone OAuth 2.1 authorization server. FastAPI with `client_credentials` and `refresh_token` grants, RSA-2048 JWT signing, JWKS endpoint, admin client management API. |
+| **Database migrations** | [`alembic/`](alembic/) | Schema migrations for the server-side library. PostgreSQL with the pgvector extension. |
+| **Design docs** | [`docs/`](docs/) | Subsystem designs, the agent-memory-ergonomics design cluster, package layout, auth and identity model. Start at [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md). |
+| **Planning** | [`planning/`](planning/) | In-flight designs for unimplemented features (operator, observability, org-ingestion) and the LlamaStack integration plan. |
+| **Research** | [`research/`](research/) | Investigations and explorations -- FIPS storage analysis, agent-memory-ergonomics research notes. |
+| **Demos** | [`demos/`](demos/) | Conference demo scripts (HIMSS, RSA, IACP, IAEM, World AgriTech) and the RHOAI dashboard demo material. |
+| **Retrospectives** | [`retrospectives/`](retrospectives/) | Per-session retros documenting decisions, gaps, and patterns. Read these for the "why" behind major design choices. |
 
 ## Three ways to use it
 
@@ -239,9 +90,7 @@ claude mcp add memoryhub \
   https://memory-hub-mcp-memory-hub-mcp.apps.<your-cluster>.com/mcp/
 ```
 
-Then run `memoryhub config init` (from the CLI, see below) to generate a `.claude/rules/memoryhub-loading.md` that tells the agent when and how to call the tools. The generated rule covers session start, working-set loading, pivot detection, memory hygiene, and contradiction handling -- all parameterized by your project's session shape (focused / broad / adaptive).
-
-For zero-overhead startup, add a [SessionStart hook](docs/guides/hooks-integration.md) that pre-loads memories into the conversation context before the first prompt — no MCP calls, no token overhead from structural metadata. The MCP server remains available for mid-session searches and writes.
+Then run `memoryhub config init` to generate a `.memoryhub.yaml` and agent rule file that tells the agent when and how to call the tools. For zero-overhead startup, add a [SessionStart hook](docs/guides/hooks-integration.md) that pre-loads memories before the first prompt.
 
 ### 2. From Python via the SDK
 
@@ -288,57 +137,30 @@ MemoryHub supports two authentication paths. **API keys** are the simplest optio
 
 MemoryHub splits configuration into two files with different lifecycles: project-level policy lives in `.memoryhub.yaml` at the repo root (committed, shared across all contributors), while per-developer connection params and secrets live in `~/.config/memoryhub/config.json` (not committed, managed by `memoryhub login`).
 
-`memoryhub config init` is an interactive wizard that asks about session shape, loading pattern, focus source, and retrieval defaults, then writes both files — commit them so every contributor's agent inherits the same loading pattern. After hand-editing the YAML, `memoryhub config regenerate` re-renders the rule file. The YAML schema (`memory_loading` + `retrieval_defaults`), field reference, rule-file templates, and the `/memoryhub-init` slash command for running the wizard from inside Claude Code are all documented in [`docs/agent-memory-ergonomics/design.md`](docs/agent-memory-ergonomics/design.md) and the [CLI README](memoryhub-cli/README.md).
+`memoryhub config init` is an interactive wizard that asks about session shape, loading pattern, focus source, and retrieval defaults, then writes both files -- commit them so every contributor's agent inherits the same loading pattern. After hand-editing the YAML, `memoryhub config regenerate` re-renders the rule file. The YAML schema (`memory_loading` + `retrieval_defaults`), field reference, rule-file templates, and the `/memoryhub-init` slash command for running the wizard from inside Claude Code are all documented in [`docs/agent-memory-ergonomics/design.md`](docs/agent-memory-ergonomics/design.md) and the [CLI README](memoryhub-cli/README.md).
 
-## Architecture at a glance
+## Architecture
 
-```
-                    ┌─────────────────────────────────────────┐
-                    │  Consumer surfaces                      │
-                    │   • Agents over MCP (streamable-HTTP)   │
-                    │   • Python SDK (memoryhub on PyPI)      │
-                    │   • CLI (memoryhub-cli)                 │
-                    │   • Dashboard UI (React + PF6 + BFF)    │
-                    └────────────────┬────────────────────────┘
-                                     │
-                          ┌──────────▼──────────┐
-                          │   memory-hub-mcp    │
-                          │   (FastMCP 3)       │
-                          │   4 tools (compact) │
-                          └──────────┬──────────┘
-                                     │
-              ┌──────────────────────┼──────────────────────┐
-              │                      │                      │
-      ┌───────▼───────┐    ┌─────────▼─────────┐   ┌────────▼──────────┐
-      │  authz / RBAC │    │ services / models │   │  embedding model  │
-      │  (JWT verify, │    │ (memoryhub_core)  │   │  + cross-encoder  │
-      │   scope match)│    │                   │   │  (RHOAI vLLM)     │
-      └───────┬───────┘    └─────────┬─────────┘   └───────────────────┘
-              │                      │
-      ┌───────▼─────────┐   ┌────────▼─────────┐
-      │ memoryhub-auth  │   │  PostgreSQL +    │
-      │  (OAuth 2.1 AS) │   │  pgvector        │
-      └─────────────────┘   └──────────────────┘
-```
-
-Every memory operation flows through the MCP server; authorization, curation, and governance are enforced in the service layer — no surface talks to PostgreSQL directly. The full design, data flows, and deployment topology live in [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md); the per-subsystem map is [`docs/SYSTEMS.md`](docs/SYSTEMS.md).
+Every memory operation flows through the MCP server; authorization, curation, and governance are enforced in the service layer -- no surface talks to PostgreSQL directly. The full design, data flows, and deployment topology live in [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md); the per-subsystem map is [`docs/SYSTEMS.md`](docs/SYSTEMS.md).
 
 ## Documentation
 
 Full documentation lives in four top-level directories. Start with [`docs/README.md`](docs/README.md) for a guided tour, or jump straight to whichever area matches your need:
 
-- **[`docs/`](docs/README.md)** — Shipped architecture and reference material. Subsystem designs (memory tree, storage layer, governance, curator, MCP server), agent memory ergonomics, auth, identity model, admin operations.
-- **[`planning/`](planning/)** — In-flight designs, open questions, and integration roadmaps (Kubernetes operator, observability, LlamaStack integration).
-- **[`research/`](research/)** — Investigations and benchmarks that informed shipped decisions (FIPS storage evaluation, two-vector retrieval ranking, pivot detection, FastMCP push notifications, Claude Code JWT limitations).
-- **[`demos/`](demos/)** — Conference demo scripts and scenario material (HIMSS, RSA, IACP, IAEM, World AgriTech, and the RHOAI dashboard tile demo).
+- **[`docs/`](docs/README.md)** -- Shipped architecture and reference material. Subsystem designs (memory tree, storage layer, governance, curator, MCP server), agent memory ergonomics, auth, identity model, admin operations.
+- **[`planning/`](planning/)** -- In-flight designs, open questions, and integration roadmaps (Kubernetes operator, observability, LlamaStack integration).
+- **[`research/`](research/)** -- Investigations and benchmarks that informed shipped decisions (FIPS storage evaluation, two-vector retrieval ranking, pivot detection, FastMCP push notifications, Claude Code JWT limitations).
+- **[`demos/`](demos/)** -- Conference demo scripts and scenario material (HIMSS, RSA, IACP, IAEM, World AgriTech, and the RHOAI dashboard tile demo).
 
 Package-specific docs live in each package's own README:
 
-- **[Python SDK](sdk/README.md)** — quickstart, API reference, project config, authentication
-- **[CLI](memoryhub-cli/README.md)** — commands, project config, credential setup
-- **[MCP server](memory-hub-mcp/README.md)** — tool list, deployment, testing
-- **[Auth service](memoryhub-auth/)** — standalone OAuth 2.1 authorization server
-- **[Hooks integration](docs/guides/hooks-integration.md)** — zero-overhead memory injection at Claude Code session start
+- **[Python SDK](sdk/README.md)** -- quickstart, API reference, project config, authentication
+- **[CLI](memoryhub-cli/README.md)** -- commands, project config, credential setup
+- **[MCP server](memory-hub-mcp/README.md)** -- tool list, deployment, testing
+- **[Auth service](memoryhub-auth/)** -- standalone OAuth 2.1 authorization server
+- **[Hooks integration](docs/guides/hooks-integration.md)** -- zero-overhead memory injection at Claude Code session start
+- **[Personal edition](memoryhub-local/README.md)** -- local SQLite backend, dreaming, configuration
+- **[Benchmarks](benchmarks/RESULTS.md)** -- AMB PersonaMem and LongMemEval results, methodology, competitive context
 
 For LLM agents crawling this repo: [`llms.txt`](llms.txt) at the repo root follows the [llmstxt.org](https://llmstxt.org/) convention and is the most direct entry point.
 
@@ -354,56 +176,38 @@ memory-hub/
 │   └── frontend/
 ├── sdk/                        # Python SDK published to PyPI as `memoryhub`
 ├── memoryhub-cli/              # CLI client (`pip install memoryhub-cli`)
+├── memoryhub-local/            # Personal edition: SQLite backend + local runtime
+├── memoryhub-agents/           # Curation agents (Fact Checker, Trace Reviewer)
 ├── alembic/                    # Database migrations
 ├── tests/                      # Server-side library tests
 ├── docs/                       # Shipped architecture and subsystem designs
 ├── planning/                   # In-flight designs for unimplemented features
 ├── research/                   # Investigations and explorations
 ├── demos/                      # Conference demo scripts and dashboard demo material
-├── retrospectives/             # Session retros — read for design context
+├── retrospectives/             # Session retros -- read for design context
 ├── deploy/                     # K8s manifests (PostgreSQL, MinIO, Valkey, embedding, reranker)
 └── benchmarks/                 # Empirical benchmark results (e.g. two-vector-retrieval/)
 ```
 
-A note on the package layout: the server-side library at `src/memoryhub_core/` is published locally as `memoryhub-core` (used by the MCP server, BFF, alembic, and the root test suite), while the client SDK at `sdk/src/memoryhub/` is published to PyPI as `memoryhub`. Distinct distribution names, distinct import names. See [`planning/archive/package-layout.md`](planning/archive/package-layout.md) for the rationale.
+See [`planning/archive/package-layout.md`](planning/archive/package-layout.md) for the package naming rationale.
 
 ## Development
 
-Requires Python 3.11+. We recommend [uv](https://docs.astral.sh/uv/) for environment management -- it handles Python installation, venv creation, and dependency resolution in one tool. If you don't have Python 3.11, uv fetches it automatically.
+Requires Python 3.11+. We recommend [uv](https://docs.astral.sh/uv/) for environment management -- it handles Python installation, venv creation, and dependency resolution in one tool. Each subproject maintains its own venv to avoid dependency conflicts.
 
-Each subproject maintains its own venv to avoid dependency conflicts.
-
-Set up the server-side library:
-
-```bash
-# With uv (recommended — installs Python 3.11 if needed)
-uv venv --python 3.11
-uv pip install -e ".[dev]"
-source .venv/bin/activate
-pytest tests/ -v
-
-# Or with plain venv (requires Python 3.11+ already installed)
-python3.11 -m venv .venv
-source .venv/bin/activate
-pip install -e ".[dev]"
-pytest tests/ -v
-```
-
-Each subproject (MCP server, SDK, CLI, BFF, auth) has its own venv and `pytest` suite — per-subproject setup commands are in [`CONTRIBUTING.md`](CONTRIBUTING.md). See [`CLAUDE.md`](CLAUDE.md) for project conventions, the issue-tracker workflow, and the MCP-server scaffold rules.
+See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the full development setup and PR flow, or [`docs/guides/local-development.md`](docs/guides/local-development.md) for per-subproject instructions.
 
 ## Contributing
 
-Issues and PRs are welcome. Start with [`CONTRIBUTING.md`](CONTRIBUTING.md) for the local dev setup, coding conventions, and PR flow. Use the `/issue-tracker` slash command (or follow [`CLAUDE.md`](CLAUDE.md)) when filing — every issue references a design document and follows the Backlog → In Progress → Done flow.
+Issues and PRs are welcome. Start with [`CONTRIBUTING.md`](CONTRIBUTING.md) for the local dev setup, coding conventions, and PR flow. Use the `/issue-tracker` slash command (or follow [`CLAUDE.md`](CLAUDE.md)) when filing -- every issue references a design document and follows the Backlog -> In Progress -> Done flow.
 
-Most contributions do not need access to the demo OpenShift cluster — local SQLite or a podman PostgreSQL container is enough. If you do need cluster access, see [`docs/admin/contributor-cluster-access.md`](docs/admin/contributor-cluster-access.md) for the access policy, GitHub IdP setup, and the no-deploy rule for new contributors.
-
-Maintainers inviting new contributors should follow the checklist in [`docs/admin/inviting-new-contributors.md`](docs/admin/inviting-new-contributors.md).
+Most contributions do not need access to the demo OpenShift cluster -- local SQLite or a podman PostgreSQL container is enough. If you do need cluster access, see [`docs/admin/contributor-cluster-access.md`](docs/admin/contributor-cluster-access.md) for the access policy, GitHub IdP setup, and the no-deploy rule for new contributors.
 
 ## License
 
-Apache 2.0 — see [`LICENSE`](LICENSE).
+Apache 2.0 -- see [`LICENSE`](LICENSE).
 
 ## Links
 
-- [What agent memory really is](docs/guides/what-is-agent-memory.md) · [Agent integration guide](docs/guides/agent-integration-guide.md) · [Architecture](docs/ARCHITECTURE.md) · [Subsystems](docs/SYSTEMS.md)
-- [Python SDK on PyPI](https://pypi.org/project/memoryhub/) · [GitHub issues](https://github.com/redhat-ai-americas/memory-hub/issues)
+- [What agent memory really is](docs/guides/what-is-agent-memory.md) · [Agent integration guide](docs/guides/agent-integration-guide.md) · [Architecture](docs/ARCHITECTURE.md) · [Subsystems](docs/SYSTEMS.md) · [Benchmarks](benchmarks/RESULTS.md)
+- [Python SDK on PyPI](https://pypi.org/project/memoryhub/) · [Personal edition](memoryhub-local/README.md) · [GitHub issues](https://github.com/redhat-ai-americas/memory-hub/issues)

--- a/docs/guides/cluster-install.md
+++ b/docs/guides/cluster-install.md
@@ -1,0 +1,176 @@
+# Cluster Install Guide
+
+MemoryHub installs to any OpenShift cluster with Red Hat OpenShift AI (RHOAI). The full stack is seven services across six namespaces, all deployed by a single `make install`. For the personal edition (no infrastructure needed), see the [root README](../../README.md#get-started).
+
+## Prerequisites
+
+- `oc` logged in with cluster-admin on a cluster with RHOAI installed
+- `podman` on your PATH (checked but not required for server-side builds)
+- A default StorageClass (most clusters have one)
+- Python 3.11+ on your PATH (the deploy script creates `.venv` automatically)
+
+Run `make check-prereqs` to verify all of these non-destructively. GPUs are not required; the default install uses CPU-based embedding and reranker models.
+
+See [`CONTRIBUTING.md`](../../CONTRIBUTING.md) for the "new contributor no-deploy" rule: if you're onboarding to this codebase, work against a local SQLite or Podman PostgreSQL instead of deploying to a cluster.
+
+## Quick start
+
+```bash
+git clone https://github.com/redhat-ai-americas/memory-hub.git
+cd memory-hub
+oc login <cluster-api-url>      # cluster-admin required
+make install                    # full stack deploy (~10 min)
+```
+
+That's it. The deploy script auto-creates the Python virtualenv (for Alembic migrations), generates API keys for the users ConfigMap if it doesn't exist, writes the first key to `~/.config/memoryhub/api-key` for CLI/SDK use, and runs a write/search/read smoke test at the end.
+
+To bring your own API keys instead, copy the template before running install:
+
+```bash
+cp memory-hub-mcp/deploy/users-configmap.example.yaml \
+   memory-hub-mcp/deploy/users-configmap.yaml
+# Replace REPLACE-ME placeholders with: openssl rand -hex 16
+make install
+```
+
+## What gets deployed
+
+| Service | Namespace | What |
+|---------|-----------|------|
+| PostgreSQL + pgvector | `memoryhub-db` | Database (memories, threads, graph, auth tables) |
+| MinIO | `memory-hub-mcp` | S3-compatible object storage for oversized content |
+| Valkey | `memory-hub-mcp` | Session focus state and compilation epoch cache |
+| Embedding model | `embedding-model` | all-MiniLM-L6-v2 via HuggingFace TEI (CPU, 384-dim) |
+| Reranker model | `reranker-model` | ms-marco-MiniLM-L12-v2 cross-encoder via TEI (CPU) |
+| Auth service | `memoryhub-auth` | OAuth 2.1 authorization server (JWT, PKCE, API keys) |
+| MCP server | `memory-hub-mcp` | FastMCP 3 server exposing memory operations |
+| Dashboard UI | `memoryhub-ui` | React + PatternFly 6 frontend with FastAPI BFF |
+
+All service URLs (auth JWKS, embedding, reranker) are resolved dynamically from cluster state at deploy time. No hardcoded cluster domains.
+
+Expect 8-15 minutes on a first install. The MCP server, auth service, and UI each go through an OpenShift BuildConfig, and the embedding/reranker models need to download weights on first run.
+
+## Targeting a specific cluster
+
+If you have multiple clusters configured in your kubeconfig, set `MEMORYHUB_CONTEXT` to target a specific one without switching your active context:
+
+```bash
+MEMORYHUB_CONTEXT=my-cluster make install
+MEMORYHUB_CONTEXT=my-cluster make uninstall
+```
+
+This passes `--context` on every `oc` command and never mutates your kubeconfig.
+
+## Deploy options
+
+```bash
+make install                                       # full stack (CPU models, default)
+make install ARGS="--gpu-models"                   # use GPU embedding/reranker models instead
+make install ARGS="--skip-models"                  # skip embedding/reranker (mock search)
+make install ARGS="--skip-ui --skip-tile"          # headless (no dashboard)
+```
+
+## Uninstall
+
+```bash
+make uninstall                                     # prompts for confirmation
+make uninstall ARGS="--yes"                        # non-interactive (CI)
+make uninstall ARGS="--skip-db"                    # preserve database across reinstall
+make uninstall ARGS="--skip-models"                # keep embedding/reranker models running
+```
+
+## Troubleshooting
+
+**Image digest mismatch.** If the MCP deploy fails with `running digest does not match imagestream :latest`, the OpenShift deployment cached a stale image. Re-run the install and it will pick up the correct digest:
+
+```bash
+make install ARGS="--skip-db --skip-migrations --skip-auth"
+```
+
+**Reranker timeout with `--gpu-models`.** On single-GPU clusters, the embedding model takes the GPU. The reranker runs on CPU (with a GPU node toleration for scheduling). If the reranker times out, check for PVC contention -- the CPU model variant may still be running and holding the shared PVC. The deploy script scales down CPU models automatically, but leftover deployments from a prior install can interfere. Delete them manually: `oc delete deployment <cpu-model-name> -n reranker-model`.
+
+## Partial deploys
+
+`make deploy-db`, `make deploy-mcp`, `make deploy-auth`, `make deploy-ui`, `make deploy-tile` each deploy a single service and skip the others. `make help` lists everything.
+
+## Post-install verification
+
+The deploy script prints a summary banner with all Route URLs. Verify the MCP endpoint with:
+
+```bash
+# Health check (406 = correct for streamable-HTTP MCP)
+curl -s -o /dev/null -w "%{http_code}" \
+  https://memory-hub-mcp-memory-hub-mcp.apps.<cluster>/mcp/
+
+# Auth health
+curl -s https://auth-server-memoryhub-auth.apps.<cluster>/healthz
+```
+
+For full tool verification, use `mcp-test-mcp` to connect to the deployed MCP server and list its tools.
+
+## After install
+
+The install summary banner prints the routes for each service. Follow these steps to verify the deployment and connect your first agent.
+
+**1. Get an API key.** The install creates a `memoryhub-users` ConfigMap in the `memory-hub-mcp` namespace with pre-seeded users and API keys. To view the available keys:
+
+```bash
+oc get configmap memoryhub-users -n memory-hub-mcp \
+  -o jsonpath='{.data.users\.json}' | python3 -m json.tool
+```
+
+Copy a key (format: `mh-dev-<hex>`) and store it locally:
+
+```bash
+mkdir -p ~/.config/memoryhub
+echo "mh-dev-<your-key>" > ~/.config/memoryhub/api-key
+```
+
+To add new users or rotate keys, see the [API key provisioning runbook](../runbooks/add-mcp-api-user.md).
+
+**2. Install the CLI and SDK.**
+
+```bash
+pip install memoryhub-cli    # terminal client
+pip install memoryhub        # Python SDK (optional, for scripting)
+```
+
+**3. Verify the deployment.** Use the CLI to test the connection:
+
+```bash
+memoryhub login              # configures endpoint + API key
+memoryhub search "test"      # should return empty results on a fresh install
+```
+
+Or use the SDK directly:
+
+```bash
+python scripts/seed-sample-data.py \
+  --url https://<your-mcp-route>/mcp/
+```
+
+This writes sample memories across multiple scopes so the dashboard has content to display.
+
+**4. Connect Claude Code.** Add the MCP server to Claude Code (the server name `memoryhub` is required as the first positional argument):
+
+```bash
+claude mcp add memoryhub \
+  --transport http \
+  -s user \
+  https://<your-mcp-route>/mcp/
+```
+
+Then set up the agent rule file so Claude Code knows how to use the tools:
+
+```bash
+memoryhub config init        # interactive wizard -- generates .memoryhub.yaml + .claude/rules/
+```
+
+**5. Open the dashboard from RHOAI.** The install adds a MemoryHub tile to the Red Hat OpenShift AI application catalog:
+
+1. Open the RHOAI dashboard (the URL printed in the install summary, or find it at `https://rhods-dashboard-redhat-ods-applications.apps.<your-cluster>/`)
+2. Click **Applications** in the left sidebar, then **Explore**
+3. Find the **MemoryHub** tile and click it
+4. Click **Open application** to launch the admin dashboard
+
+The dashboard has six panels: Memory Graph (visual node/edge view of memories and relationships), Status Overview (system health), Users & Agents (active sessions), Client Management (OAuth clients), Curation Rules (content filtering), and Contradiction Log (conflicting memories). If you ran `seed-sample-data.py` in step 3, the Memory Graph will show the seeded memories and their relationships.

--- a/llms.txt
+++ b/llms.txt
@@ -1,8 +1,8 @@
 # MemoryHub
 
-> Kubernetes-native agent memory component for OpenShift AI. Provides a centralized, governed memory layer for AI agents with multi-tier scoping (user / project / role / organizational / enterprise), version history, semantic search via pgvector, an immutable audit trail, and an OAuth 2.1 authorization story. Works with any agent framework that speaks MCP.
+> Persistent, governed memory for AI agents. Available as a personal edition (`pip install "memoryhub[local]"` -- SQLite, zero infrastructure) or a cluster edition on OpenShift AI with PostgreSQL + pgvector, OAuth 2.1, and multi-agent governance. Multi-tier scoping (user / project / campaign / role / organizational / enterprise), version history, semantic search, audit logging. Works with any agent framework that speaks MCP. 84.9% on AMB PersonaMem (2nd on the leaderboard), R@5=0.999 on LongMemEval.
 
-MemoryHub is a monorepo. The primary agent surface is an MCP server exposing 15 tools over streamable-HTTP. It ships a typed Python SDK and a CLI for direct use, plus a React dashboard and a standalone OAuth 2.1 authorization server. Documentation is organized into four top-level directories: `docs/` (shipped architecture), `planning/` (in-flight designs), `research/` (investigations that informed shipped decisions), and `demos/` (presentation and scenario material).
+MemoryHub is a monorepo. The primary agent surface is an MCP server exposing 4 action-dispatch tools (compact profile, default) over streamable-HTTP. It ships a typed Python SDK and a CLI for direct use, plus a React dashboard and a standalone OAuth 2.1 authorization server. Documentation is organized into four top-level directories: `docs/` (shipped architecture), `planning/` (in-flight designs), `research/` (investigations that informed shipped decisions), and `demos/` (presentation and scenario material).
 
 ## Start here
 
@@ -13,12 +13,12 @@ MemoryHub is a monorepo. The primary agent surface is an MCP server exposing 15 
 
 ## Architecture and data model
 
-- [Memory tree](https://github.com/redhat-ai-americas/memory-hub/blob/main/docs/memory-tree.md): Core data model — tree/branch structure, versioning with `isCurrent`, rationale and provenance branches.
+- [Memory tree](https://github.com/redhat-ai-americas/memory-hub/blob/main/docs/memory-tree.md): Core data model -- tree/branch structure, versioning with `isCurrent`, rationale and provenance branches.
 - [Storage layer](https://github.com/redhat-ai-americas/memory-hub/blob/main/docs/storage-layer.md): PostgreSQL + pgvector schema, row-level security, migration conventions.
-- [Governance](https://github.com/redhat-ai-americas/memory-hub/blob/main/docs/governance.md): Memory governance model — scopes, visibility, ownership, tenant isolation, audit.
+- [Governance](https://github.com/redhat-ai-americas/memory-hub/blob/main/docs/governance.md): Memory governance model -- scopes, visibility, ownership, tenant isolation, audit.
 - [MCP server](https://github.com/redhat-ai-americas/memory-hub/blob/main/docs/mcp-server.md): FastMCP 3 server design, 15-tool catalog, streamable-http transport, session handling.
 - [Curator agent](https://github.com/redhat-ai-americas/memory-hub/blob/main/docs/curator-agent.md): Curation pipeline for duplicate detection, merge suggestions, and rule-driven curation.
-- [Agent memory ergonomics](https://github.com/redhat-ai-americas/memory-hub/blob/main/docs/agent-memory-ergonomics/design.md): Full design — search shape, session focus vector, cross-encoder reranking, loading patterns, real-time push.
+- [Agent memory ergonomics](https://github.com/redhat-ai-americas/memory-hub/blob/main/docs/agent-memory-ergonomics/design.md): Full design -- search shape, session focus vector, cross-encoder reranking, loading patterns, real-time push.
 
 ## Auth and identity
 
@@ -28,17 +28,20 @@ MemoryHub is a monorepo. The primary agent surface is an MCP server exposing 15 
 
 ## Packages
 
-- [Python SDK](https://github.com/redhat-ai-americas/memory-hub/blob/main/sdk/README.md): `pip install memoryhub` — typed async client wrapping the MCP tools. OAuth 2.1 token management is automatic; `.memoryhub.yaml` auto-discovery applies project-level retrieval defaults.
-- [CLI](https://github.com/redhat-ai-americas/memory-hub/blob/main/memoryhub-cli/README.md): `pip install memoryhub-cli` — terminal client for search/read/write/delete plus `memoryhub config init` for generating project-level `.memoryhub.yaml` and `.claude/rules/memoryhub-loading.md`.
-- [MCP server](https://github.com/redhat-ai-americas/memory-hub/blob/main/memory-hub-mcp/README.md): FastMCP 3 server exposing the 15 tools — the primary agent surface.
+- [Python SDK](https://github.com/redhat-ai-americas/memory-hub/blob/main/sdk/README.md): `pip install memoryhub` -- typed async client wrapping the MCP tools. OAuth 2.1 token management is automatic; `.memoryhub.yaml` auto-discovery applies project-level retrieval defaults.
+- [CLI](https://github.com/redhat-ai-americas/memory-hub/blob/main/memoryhub-cli/README.md): `pip install memoryhub-cli` -- terminal client for search/read/write/delete plus `memoryhub config init` for generating project-level `.memoryhub.yaml` and `.claude/rules/memoryhub-loading.md`.
+- [Personal edition](https://github.com/redhat-ai-americas/memory-hub/blob/main/memoryhub-local/README.md): `pip install "memoryhub[local]"` -- SQLite backend + local runtime for zero-infrastructure agent memory. Includes local ONNX embeddings and optional dreaming (offline fact extraction).
+- [MCP server](https://github.com/redhat-ai-americas/memory-hub/blob/main/memory-hub-mcp/README.md): FastMCP 3 server exposing 4 action-dispatch tools (compact profile) -- the primary agent surface.
 
 ## Optional
 
 - [Package layout](https://github.com/redhat-ai-americas/memory-hub/blob/main/docs/package-layout.md): How `memoryhub-core` (server-side library), `memoryhub` (SDK on PyPI), and `memoryhub-cli` fit together.
 - [Build and deploy hardening](https://github.com/redhat-ai-americas/memory-hub/blob/main/docs/build-deploy-hardening.md): Build and deploy invariants shared across all MemoryHub components.
 - [Planning directory](https://github.com/redhat-ai-americas/memory-hub/tree/main/planning): In-flight designs for unimplemented features (Kubernetes operator, observability, LlamaStack integration).
-- [Research directory](https://github.com/redhat-ai-americas/memory-hub/tree/main/research): Investigations and benchmarks — FIPS storage evaluation, two-vector retrieval ranking, pivot detection, FastMCP push notifications, Claude Code JWT limitations.
+- [Research directory](https://github.com/redhat-ai-americas/memory-hub/tree/main/research): Investigations and benchmarks -- FIPS storage evaluation, two-vector retrieval ranking, pivot detection, FastMCP push notifications, Claude Code JWT limitations.
 - [Demos directory](https://github.com/redhat-ai-americas/memory-hub/tree/main/demos): Conference demo scripts (HIMSS, RSA, IACP, IAEM, World AgriTech) and the RHOAI dashboard tile demo material.
-- [Retrospectives](https://github.com/redhat-ai-americas/memory-hub/tree/main/retrospectives): Per-session retros documenting decisions, gaps, and patterns — read for the "why" behind major design choices.
+- [Retrospectives](https://github.com/redhat-ai-americas/memory-hub/tree/main/retrospectives): Per-session retros documenting decisions, gaps, and patterns -- read for the "why" behind major design choices.
+- [Benchmarks](https://github.com/redhat-ai-americas/memory-hub/blob/main/benchmarks/RESULTS.md): AMB PersonaMem and LongMemEval results, methodology, and competitive context.
+- [Cluster install guide](https://github.com/redhat-ai-americas/memory-hub/blob/main/docs/guides/cluster-install.md): Full OpenShift deployment guide with prerequisites, deploy options, troubleshooting, and post-install setup.
 - [Issue tracker](https://github.com/redhat-ai-americas/memory-hub/issues): Open issues and feature requests.
 - [License (Apache 2.0)](https://github.com/redhat-ai-americas/memory-hub/blob/main/LICENSE)


### PR DESCRIPTION
## Summary

- Lead with personal edition (`pip install "memoryhub[local]"`) and benchmark credentials (84.9% AMB PersonaMem, R@5=0.999 LongMemEval)
- Extract 170 lines of cluster install content to `docs/guides/cluster-install.md`
- Kill the stale Status (2026-04-15) line, point to `docs/SYSTEMS.md`
- Remove the ASCII architecture diagram (duplicated `docs/ARCHITECTURE.md`, contained "RHOAI vLLM" error)
- Fix stale "planned" qualifiers for shipped features (audit logging, promotion pipeline, curation agents)
- Add `memoryhub-local` and `memoryhub-agents` to component table and project layout
- Update `llms.txt`: personal edition entry, correct tool count (4 action-dispatch, not 15), fix em-dashes

410 lines -> 213 lines. No content lost -- cluster install detail moved to the guide.

## Test plan

- [ ] All relative links in README.md verified against filesystem (done locally)
- [ ] All relative links in cluster-install.md verified (done locally)
- [ ] Line count confirmed: 213 (README), 176 (cluster-install), 47 (llms.txt)