### PR TITLE
cli: Defer topic search until user provides actionable signal

### DIFF
--- a/memoryhub-cli/src/memoryhub_cli/project_config.py
+++ b/memoryhub-cli/src/memoryhub_cli/project_config.py
@@ -184,16 +184,16 @@ its contents as your working set. Do NOT call `register_session` or
 If no `<memoryhub-context>` block is present (CLI not installed or hook
 misconfigured), fall back to the manual flow: read your API key from
 `~/.config/memoryhub/api-key` (trim whitespace), call
-`register_session(api_key="<key>")`, then after the first user turn
-derive a 1-2 sentence summary and call `search_memory(query=<summary>)`.
+`register_session(api_key="<key>")`, then wait until the user states a
+task or question with enough detail to form a meaningful search query.
+Derive a 1-2 sentence summary and call `search_memory(query=<summary>)`.
+If the opening turn is low-signal ("hi", "can you help me?"), do not
+search yet -- wait for a follow-up that reveals the topic.
 
 ## During the session
 
 - Trust your working set. Re-search only when the user explicitly
   references a concept you don't have loaded.
-- If the opening turn was vague ("can you take a look at this?"), your
-  working set may miss relevant memories. Watch for it and re-search with
-  a more specific query as soon as the topic firms up.
 """,
     "lazy_with_rebias": """\
 ## At session start
@@ -206,8 +206,11 @@ its contents as your working set. Do NOT call `register_session` or
 If no `<memoryhub-context>` block is present (CLI not installed or hook
 misconfigured), fall back to the manual flow: read your API key from
 `~/.config/memoryhub/api-key` (trim whitespace), call
-`register_session(api_key="<key>")`, then after the first user turn
-derive a 1-2 sentence summary and call `search_memory(query=<summary>)`.
+`register_session(api_key="<key>")`, then wait until the user states a
+task or question with enough detail to form a meaningful search query.
+Derive a 1-2 sentence summary and call `search_memory(query=<summary>)`.
+If the opening turn is low-signal ("hi", "can you help me?"), do not
+search yet -- wait for a follow-up that reveals the topic.
 
 ## During the session -- watch for pivots
 
@@ -283,17 +286,17 @@ your working set. Otherwise, follow the manual flow below.
 If your agent framework pre-loads memory context at startup, use it as
 your working set. Otherwise, follow the manual flow below.
 
-Authenticate with `register_session(api_key=<your_key>)`, then after the
-first user turn derive a 1-2 sentence summary and call
-`search_memory(query=<summary>)`.
+Authenticate with `register_session(api_key=<your_key>)`, then wait until
+the user states a task or question with enough detail to form a meaningful
+search query. Derive a 1-2 sentence summary and call
+`search_memory(query=<summary>)`. If the opening turn is low-signal
+("hi", "can you help me?"), do not search yet -- wait for a follow-up
+that reveals the topic.
 
 ## During the session
 
 - Trust your working set. Re-search only when the user explicitly
   references a concept you don't have loaded.
-- If the opening turn was vague ("can you take a look at this?"), your
-  working set may miss relevant memories. Watch for it and re-search with
-  a more specific query as soon as the topic firms up.
 """,
     "lazy_with_rebias": """\
 ## At session start
@@ -301,9 +304,12 @@ first user turn derive a 1-2 sentence summary and call
 If your agent framework pre-loads memory context at startup, use it as
 your working set. Otherwise, follow the manual flow below.
 
-Authenticate with `register_session(api_key=<your_key>)`, then after the
-first user turn derive a 1-2 sentence summary and call
-`search_memory(query=<summary>)`.
+Authenticate with `register_session(api_key=<your_key>)`, then wait until
+the user states a task or question with enough detail to form a meaningful
+search query. Derive a 1-2 sentence summary and call
+`search_memory(query=<summary>)`. If the opening turn is low-signal
+("hi", "can you help me?"), do not search yet -- wait for a follow-up
+that reveals the topic.
 
 ## During the session -- watch for pivots
 

--- a/memoryhub-cli/tests/test_project_config.py
+++ b/memoryhub-cli/tests/test_project_config.py
@@ -163,10 +163,10 @@ def test_rule_file_lazy_required_phrases():
     assert "Lazy" in out
     # Critical: do NOT call search at session start.
     assert "Do NOT" in out
-    # Drives the agent to derive intent from the first turn.
-    assert "first user turn" in out.lower() or "first user message" in out.lower()
-    # Calls out the vague-opening failure mode honestly.
-    assert "vague" in out.lower()
+    # Defers search until user provides actionable signal.
+    assert "enough detail" in out.lower() or "meaningful search query" in out.lower()
+    # Calls out low-signal openers explicitly.
+    assert "low-signal" in out.lower()
 
 
 def test_rule_file_lazy_with_rebias_specifies_three_pivot_triggers():

--- a/session-summaries/2026-07-27-cli-defer-low-signal-search.md
+++ b/session-summaries/2026-07-27-cli-defer-low-signal-search.md
@@ -1,0 +1,32 @@
+# Session Summary -- 2026-07-27 -- CLI -- Defer low-signal topic search
+
+**Plan:** User question about topic discovery mechanism, then fix.  **Commits:** 1943ab6 (`feat/defer-low-signal-search`)
+**Deployed:** none  **Model:** Opus 4.6
+
+## Plan vs. actual
+Planned: Answer user's question about how `focus_source` topic discovery works. Shipped: answered the question, identified the low-signal first-turn gap, and rewrote the instruction templates. No scope expansion -- the fix was the natural follow-up.
+
+## Shipped
+- 1943ab6 -- Rewrote lazy and lazy_with_rebias template blocks (4 total: 2 claude-code, 2 universal) to defer memory search until the user provides actionable signal instead of mechanically searching after the first turn. Removed the separate "vague opening" fallback note since the primary instruction now covers it. Updated the test assertion to match.
+
+## Verification & confidence
+- 164/164 tests pass, lint clean, CI green on main, gitleaks clean.
+- Confidence: high -- the change is purely instructional text in string templates, with a single test assertion update. No runtime code paths affected.
+
+## Judgment calls & deviations
+- Removed the "vague opening" fallback paragraph from lazy blocks entirely rather than keeping it alongside the new deferred-search instruction. The two would have been redundant and potentially confusing (one says "search then re-search if vague"; the other says "don't search until you have signal"). Single instruction is clearer.
+
+## Backlog delta
+Filed: none. Closed: none. Memory: none. Deferred: `focus_source` config field is still not wired into template selection (Q3 item per SDK comment at `client.py:528`).
+
+## Drift & forward-collisions
+- Backward: none
+- Forward: none
+
+## For the reviewer
+- Sanity-check: read the four rewritten template blocks for instruction clarity -- does "enough detail to form a meaningful search query" give agents enough guidance, or should it enumerate what counts as signal?
+- Thin verification: no live agent testing yet (branch exists for that purpose).
+- Wants guidance: none
+
+## Risks / watch-fors
+- Agents may now over-defer and never search if the user drip-feeds context across many short turns without a single "meaty" message. Worth watching during testing.


### PR DESCRIPTION
## Summary

- Rewrites lazy and lazy_with_rebias instruction templates to defer memory search until the user provides a substantive question or task, instead of mechanically searching after the first turn
- Removes the separate "vague opening" fallback paragraph since the primary instruction now covers it
- Updates test assertion to match the new wording

## Test plan

- [x] 164/164 tests pass, lint clean
- [x] No runtime code paths affected -- purely instructional text in string templates