### PR TITLE
Fix integration tests for logical_id NOT NULL constraint

### DIFF
--- a/tests/integration/test_backfill.py
+++ b/tests/integration/test_backfill.py
@@ -36,8 +36,9 @@ async def test_count_candidates_finds_unextracted(async_session):
     now = datetime.now(UTC)
 
     # Create memory with no metadata
+    _id = uuid.uuid4()
     async_session.add(MemoryNode(
-        id=uuid.uuid4(),
+        id=_id, logical_id=_id,
         content="No metadata memory",
         stub="No metadata...",
         scope="user",
@@ -52,8 +53,9 @@ async def test_count_candidates_finds_unextracted(async_session):
     ))
 
     # Create memory with extraction_status="complete"
+    _id = uuid.uuid4()
     async_session.add(MemoryNode(
-        id=uuid.uuid4(),
+        id=_id, logical_id=_id,
         content="Completed extraction memory",
         stub="Completed...",
         scope="user",
@@ -69,8 +71,9 @@ async def test_count_candidates_finds_unextracted(async_session):
     ))
 
     # Create memory with extraction_status="failed"
+    _id = uuid.uuid4()
     async_session.add(MemoryNode(
-        id=uuid.uuid4(),
+        id=_id, logical_id=_id,
         content="Failed extraction memory",
         stub="Failed...",
         scope="user",
@@ -102,8 +105,9 @@ async def test_count_candidates_excludes_entities_and_deleted(async_session):
     now = datetime.now(UTC)
 
     # Create entity-scoped memory
+    _id = uuid.uuid4()
     async_session.add(MemoryNode(
-        id=uuid.uuid4(),
+        id=_id, logical_id=_id,
         content="Entity memory",
         stub="Entity...",
         scope="entity",
@@ -119,8 +123,9 @@ async def test_count_candidates_excludes_entities_and_deleted(async_session):
     ))
 
     # Create soft-deleted memory
+    _id = uuid.uuid4()
     async_session.add(MemoryNode(
-        id=uuid.uuid4(),
+        id=_id, logical_id=_id,
         content="Deleted memory",
         stub="Deleted...",
         scope="user",
@@ -136,8 +141,9 @@ async def test_count_candidates_excludes_entities_and_deleted(async_session):
     ))
 
     # Create valid candidate
+    _id = uuid.uuid4()
     async_session.add(MemoryNode(
-        id=uuid.uuid4(),
+        id=_id, logical_id=_id,
         content="Valid memory",
         stub="Valid...",
         scope="user",
@@ -168,7 +174,7 @@ async def test_scan_returns_oldest_first(async_session):
         memory_id = uuid.uuid4()
         ids.append(memory_id)
         async_session.add(MemoryNode(
-            id=memory_id,
+            id=memory_id, logical_id=memory_id,
             content=f"Memory {i}",
             stub=f"Memory {i}...",
             scope="user",
@@ -200,8 +206,9 @@ async def test_scan_respects_limit(async_session):
 
     # Create 5 candidate memories
     for i in range(5):
+        _id = uuid.uuid4()
         async_session.add(MemoryNode(
-            id=uuid.uuid4(),
+            id=_id, logical_id=_id,
             content=f"Memory {i}",
             stub=f"Memory {i}...",
             scope="user",
@@ -230,7 +237,7 @@ async def test_update_extraction_status_sets_metadata(async_session):
     memory_id = uuid.uuid4()
 
     async_session.add(MemoryNode(
-        id=memory_id,
+        id=memory_id, logical_id=memory_id,
         content="Test memory",
         stub="Test...",
         scope="user",
@@ -270,7 +277,7 @@ async def test_update_extraction_status_preserves_existing_metadata(async_sessio
     memory_id = uuid.uuid4()
 
     async_session.add(MemoryNode(
-        id=memory_id,
+        id=memory_id, logical_id=memory_id,
         content="Test memory",
         stub="Test...",
         scope="user",

--- a/tests/integration/test_pgvector.py
+++ b/tests/integration/test_pgvector.py
@@ -788,8 +788,9 @@ async def test_memory_domains_server_default_is_empty_array(
     from memoryhub_core.models.memory import MemoryNode
 
     embedding = await embedding_service.embed("memory for array default test")
+    _nid = _uuid.uuid4()
     node = MemoryNode(
-        id=_uuid.uuid4(),
+        id=_nid, logical_id=_nid,
         content="memory for array default test",
         stub="memory for array default test",
         scope="user",
@@ -845,7 +846,7 @@ async def test_transaction_rollback_preserves_prior_commit(
 
     # Step 2: Attempt a raw ORM insert with a duplicate primary key.
     duplicate = MemoryNode(
-        id=good_memory.id,  # intentional duplicate
+        id=good_memory.id, logical_id=good_memory.id,  # intentional duplicate
         content="this should fail",
         stub="this should fail",
         scope="user",
@@ -895,7 +896,7 @@ async def test_session_usable_after_rollback(
     await async_session.commit()
 
     bad_node = MemoryNode(
-        id=first.id,
+        id=first.id, logical_id=first.id,
         content="duplicate pk",
         stub="duplicate pk",
         scope="user",


### PR DESCRIPTION
## Summary

- Add `logical_id` to all direct `MemoryNode()` constructions in integration tests
- Migration 027 makes `logical_id` NOT NULL on PostgreSQL, but test fixtures were creating nodes without it

## Test plan

- [ ] Integration tests pass (test_backfill, test_pgvector)