### PR TITLE
memoryhub-local: Add logical_id to tool responses

### DIFF
--- a/memoryhub-local/src/memoryhub_local/tools/memory.py
+++ b/memoryhub-local/src/memoryhub_local/tools/memory.py
@@ -248,6 +248,7 @@ async def _do_read(memory_id, opts):
 
         result = {
             "id": str(node.id),
+            "logical_id": str(node.logical_id) if node.logical_id else None,
             "content": node.content,
             "scope": node.scope,
             "weight": node.weight,
@@ -351,6 +352,7 @@ async def _do_write(content, scope, opts):
         return {
             "memory": {
                 "id": str(node.id),
+                "logical_id": str(node.logical_id) if node.logical_id else None,
                 "scope": node.scope,
                 "weight": node.weight,
                 "version": node.version,
@@ -385,6 +387,7 @@ async def _do_update(memory_id, content, opts):
             raise ToolError(f"Memory {memory_id} not found or not active.")
         return {
             "id": str(node.id),
+            "logical_id": str(node.logical_id) if node.logical_id else None,
             "content": node.content,
             "scope": node.scope,
             "weight": node.weight,


### PR DESCRIPTION
## Summary

- Add `logical_id` to read, write, and update tool response dicts
- The 0.2.0 PyPI release stores `logical_id` correctly in the DB but the tool layer wasn't returning it in responses
- Caught during end-to-end exercise of the installed package

## Test plan

- [ ] `pytest memoryhub-local/tests/` passes (47 tests)
- [ ] End-to-end exercise: write, read logical_id, update, verify propagation