### PR TITLE
memoryhub-local: Release 0.2.1

### DIFF
--- a/memoryhub-local/CHANGELOG.md
+++ b/memoryhub-local/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the `memoryhub-local` package.
 
+## [0.2.1] -- 2026-07-29
+
+- Fix: include `logical_id` in read, write, and update tool responses
+
 ## [0.2.0] -- 2026-07-29
 
 - Fix: graph edges now follow version chain on memory update (#472)

--- a/memoryhub-local/pyproject.toml
+++ b/memoryhub-local/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "memoryhub-local"
-version = "0.2.0"
+version = "0.2.1"
 description = "SQLite backend and local runtime for MemoryHub — agent memory without infrastructure"
 readme = "README.md"
 license = "Apache-2.0"

--- a/memoryhub-local/src/memoryhub_local/__init__.py
+++ b/memoryhub-local/src/memoryhub_local/__init__.py
@@ -1,3 +1,3 @@
 """MemoryHub Local -- SQLite backend and local runtime for MemoryHub."""
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"


### PR DESCRIPTION
## Summary

Patch release bumping version to 0.2.1 after the tool response fix (#479) landed.

## Test plan

- [ ] Version consistency check passes