### PR TITLE
Fix feedback issues: resolve_current, list_projects, doc updates

### DIFF
--- a/memory-hub-mcp/src/tools/memory.py
+++ b/memory-hub-mcp/src/tools/memory.py
@@ -50,7 +50,7 @@ _LIST_OPTS = frozenset({
 })
 _READ_OPTS = frozenset({
     "include_versions", "history_offset", "history_max_versions", "hydrate",
-    "tenant_id",
+    "tenant_id", "resolve_current",
 })
 _SIMILAR_OPTS = frozenset({"threshold", "max_results", "offset"})
 _RELATIONSHIPS_OPTS = frozenset({
@@ -166,8 +166,9 @@ async def memory(
         Semantic search. Returns cache-optimized stable ordering by default.
       list([scope, project_id, options: max_results, cursor, include_branches])
         Enumerate memories without semantic ranking. Ordered by creation time.
-      read(memory_id, [project_id, options: include_versions, hydrate])
+      read(memory_id, [project_id, options: include_versions, hydrate, resolve_current])
         Retrieve memory by UUID with optional version history.
+        Set resolve_current=true to follow a superseded version to its current head.
       similar(memory_id, [project_id, options: threshold, max_results])
         Near-duplicate detection by cosine similarity.
       relationships(memory_id, [project_id, options: direction, include_provenance])
@@ -188,13 +189,18 @@ async def memory(
       write(content, [scope, project_id, options: weight, parent_id, branch_type, ...])
         Create memory node or branch. scope defaults to "user" if omitted.
       update(memory_id, [content, options: weight, metadata, domains])
-        New version; old preserved for history.
+        New version with a **new UUID**; old version preserved with is_current=false.
+        Graph edges are automatically re-pointed to the new version.
+        The stable logical_id is inherited across all versions.
       delete(memory_id, [project_id])
         Soft-delete with cascade.
       set_focus(project_id, options: {focus})
         Declare session focus for retrieval bias.
       relate(options: {source_id, target_id, relationship_type})
         Create directed graph edge between memories.
+        Valid types: derived_from, supersedes, conflicts_with, related_to.
+        (mentions is system-managed by entity extraction, not user-creatable.)
+        derived_from is used by trace_provenance; conflicts_with feeds contradiction detection.
       report(memory_id, options: {observed_behavior})
         Flag contradiction against a stored memory.
       resolve(options: {contradiction_id, resolution_action})

--- a/memory-hub-mcp/src/tools/read_memory.py
+++ b/memory-hub-mcp/src/tools/read_memory.py
@@ -91,6 +91,16 @@ async def read_memory(
             ),
         ),
     ] = None,
+    resolve_current: Annotated[
+        bool,
+        Field(
+            description=(
+                "When true and the requested memory is a superseded version "
+                "(is_current=false), automatically resolve to the current "
+                "version via logical_id and return that instead."
+            ),
+        ),
+    ] = False,
     tenant_id: Annotated[
         str | None,
         Field(
@@ -138,6 +148,25 @@ async def read_memory(
         session, gen = await get_db_session()
 
         node = await _read_memory(parsed_id, session, tenant_id=tenant)
+
+        if resolve_current and not node.is_current:
+            logical = getattr(node, "logical_id", None)
+            if logical:
+                from sqlalchemy import select
+
+                from memoryhub_core.models.memory import MemoryNode
+
+                current = (await session.execute(
+                    select(MemoryNode).where(
+                        MemoryNode.logical_id == logical,
+                        MemoryNode.is_current.is_(True),
+                        MemoryNode.tenant_id == tenant,
+                    )
+                )).scalar_one_or_none()
+                if current is not None:
+                    from memoryhub_core.services.memory import node_to_read
+                    node = node_to_read(current, has_children=False, has_rationale=False)
+                    parsed_id = current.id
 
         # Resolve campaign membership when accessing a campaign-scoped memory.
         campaign_ids: set[str] | None = None

--- a/memoryhub-local/src/memoryhub_local/services/memory.py
+++ b/memoryhub-local/src/memoryhub_local/services/memory.py
@@ -38,6 +38,7 @@ async def create_memory(
     domains: list[str] | None = None,
     content_type: str = "declarative",
     driver_id: str | None = None,
+    scope_id: str | None = None,
 ) -> MemoryNode:
     """Create a new memory node with embedding."""
     embedding = await embedding_service.embed(content)
@@ -52,6 +53,7 @@ async def create_memory(
         storage_type="inline",
         weight=weight,
         scope=scope,
+        scope_id=scope_id,
         branch_type=branch_type,
         owner_id=owner,
         actor_id=owner,

--- a/memoryhub-local/src/memoryhub_local/tools/memory.py
+++ b/memoryhub-local/src/memoryhub_local/tools/memory.py
@@ -31,7 +31,7 @@ _STUB_ACTIONS = frozenset({
     "set_focus", "resolve", "set_rule",
     "create_project", "add_member", "remove_member",
     "promote", "graduate", "checkpoint",
-    "focus_history", "list_projects", "describe_project",
+    "focus_history", "describe_project",
     "list_entities", "merge_entities", "rename_entity",
     "backfill_entities",
 })
@@ -80,8 +80,9 @@ async def memory(
         Semantic search. Returns cache-optimized stable ordering by default.
       list([scope, project_id, options: max_results, cursor, include_branches])
         Enumerate memories without semantic ranking. Ordered by creation time.
-      read(memory_id, [project_id, options: include_versions, hydrate])
+      read(memory_id, [project_id, options: include_versions, hydrate, resolve_current])
         Retrieve memory by UUID with optional version history.
+        Set resolve_current=true to follow a superseded version to its current head.
       similar(memory_id, [project_id, options: threshold, max_results])
         Near-duplicate detection by cosine similarity.
       relationships(memory_id, [project_id, options: direction, include_provenance])
@@ -102,13 +103,18 @@ async def memory(
       write(content, [scope, project_id, options: weight, parent_id, branch_type, ...])
         Create memory node or branch. scope defaults to "user" if omitted.
       update(memory_id, [content, options: weight, metadata, domains])
-        New version; old preserved for history.
+        New version with a **new UUID**; old version preserved with is_current=false.
+        Graph edges are automatically re-pointed to the new version.
+        The stable logical_id is inherited across all versions.
       delete(memory_id, [project_id])
         Soft-delete with cascade.
       set_focus(project_id, options: {focus})
         Declare session focus for retrieval bias.
       relate(options: {source_id, target_id, relationship_type})
         Create directed graph edge between memories.
+        Valid types: derived_from, supersedes, conflicts_with, related_to.
+        (mentions is system-managed by entity extraction, not user-creatable.)
+        derived_from is used by trace_provenance; conflicts_with feeds contradiction detection.
       report(memory_id, options: {observed_behavior})
         Flag contradiction against a stored memory.
       resolve(options: {contradiction_id, resolution_action})
@@ -158,7 +164,7 @@ async def memory(
     if action == "status":
         return await _do_status()
     if action == "write":
-        return await _do_write(content, scope, opts)
+        return await _do_write(content, scope, project_id, opts)
     if action == "update":
         return await _do_update(memory_id, content, opts)
     if action == "delete":
@@ -167,6 +173,8 @@ async def memory(
         return await _do_relate(opts)
     if action == "report":
         return await _do_report(memory_id, opts)
+    if action == "list_projects":
+        return await _do_list_projects()
 
     return _stub_response(action)
 
@@ -207,6 +215,28 @@ def _stub_response(action: str) -> dict[str, Any]:
     }
 
 
+async def _do_list_projects():
+    """Return distinct project_ids seen in stored memories (#474)."""
+    from sqlalchemy import distinct, select
+
+    from memoryhub_local.identity import TENANT_ID
+    from memoryhub_local.models.memory import MemoryNode
+
+    state = get_state()
+    async with state.session_factory() as session:
+        result = await session.execute(
+            select(distinct(MemoryNode.scope_id))
+            .where(
+                MemoryNode.scope == "project",
+                MemoryNode.tenant_id == TENANT_ID,
+                MemoryNode.status == "active",
+                MemoryNode.is_current.is_(True),
+            )
+        )
+        project_ids = [row[0] for row in result if row[0] is not None]
+        return {"projects": project_ids, "count": len(project_ids)}
+
+
 async def _do_search(query, scope, opts):
     from memoryhub_local.services.memory import search_memories
 
@@ -236,6 +266,9 @@ async def _do_list(scope, opts):
 
 
 async def _do_read(memory_id, opts):
+    from sqlalchemy import select
+
+    from memoryhub_local.models.memory import MemoryNode
     from memoryhub_local.services.memory import get_memory_history, read_memory
 
     _require("read", "memory_id", memory_id)
@@ -245,6 +278,16 @@ async def _do_read(memory_id, opts):
         node = await read_memory(session, memory_id)
         if node is None:
             raise ToolError(f"Memory {memory_id} not found.")
+
+        if opts.get("resolve_current") and not node.is_current and node.logical_id:
+            current = (await session.execute(
+                select(MemoryNode).where(
+                    MemoryNode.logical_id == node.logical_id,
+                    MemoryNode.is_current.is_(True),
+                )
+            )).scalar_one_or_none()
+            if current is not None:
+                node = current
 
         result = {
             "id": str(node.id),
@@ -331,7 +374,7 @@ async def _do_status():
     }
 
 
-async def _do_write(content, scope, opts):
+async def _do_write(content, scope, project_id, opts):
     from memoryhub_local.services.memory import create_memory
 
     _require("write", "content", content)
@@ -341,6 +384,7 @@ async def _do_write(content, scope, opts):
         node = await create_memory(
             session, content, state.embedding_service,
             scope=scope,
+            scope_id=project_id if scope == "project" else None,
             weight=opts.get("weight", 0.7),
             parent_id=opts.get("parent_id"),
             branch_type=opts.get("branch_type"),

--- a/sdk/src/memoryhub/client.py
+++ b/sdk/src/memoryhub/client.py
@@ -864,7 +864,11 @@ class MemoryHubClient:
         domains: list[str] | None = None,
         tenant_id: str | None = None,
     ) -> Memory:
-        """Update an existing memory (creates a new version).
+        """Update an existing memory (creates a new version with a new UUID).
+
+        The old version is preserved with is_current=false. Graph edges are
+        automatically re-pointed to the new version. The stable logical_id
+        is inherited across all versions.
 
         At least one of content, weight, or metadata must be provided.
 
@@ -1284,7 +1288,9 @@ class MemoryHubClient:
         Args:
             source_id: ID of the source memory node.
             target_id: ID of the target memory node.
-            relationship_type: Relationship label (e.g., "related", "supersedes").
+            relationship_type: One of: derived_from, supersedes, conflicts_with,
+                related_to. The mentions type is system-managed by entity
+                extraction and cannot be created manually.
             metadata: Arbitrary metadata for the relationship edge.
             project_id: Project identifier for campaign enrollment verification.
         """


### PR DESCRIPTION
## Summary

- **#473**: `resolve_current` option on read -- follows logical_id to current version when reading a superseded node
- **#474**: Ungate `list_projects` for personal edition -- returns distinct scope_ids; also wires `project_id` through write so `scope_id` is set
- **#475**: Document that update produces a new UUID in tool docstrings and SDK
- **#476**: Document valid relationship types and their semantic roles

Closes #473, closes #474, closes #475, closes #476

## Test plan

- [ ] 77 cluster service tests pass
- [ ] 47 local edition tests pass
- [ ] Exercise: write project-scoped memory, list_projects returns it
- [ ] Exercise: write, update, read old ID with resolve_current=true returns current version