### PR TITLE
Release SDK 0.15.1 and CLI 0.12.1

### DIFF
--- a/memoryhub-cli/CHANGELOG.md
+++ b/memoryhub-cli/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the `memoryhub-cli` package.
 
+## [0.12.1] -- 2026-07-29
+
+- Defer topic search until user provides actionable signal (#471)
+
 ## [0.12.0] -- 2026-07-28
 
 - **`memoryhub mcp`**: Start a local MCP server (personal edition, stdio).

--- a/memoryhub-cli/pyproject.toml
+++ b/memoryhub-cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "memoryhub-cli"
-version = "0.12.0"
+version = "0.12.1"
 description = "CLI client for MemoryHub — centralized, governed memory for AI agents"
 readme = "README.md"
 license = "Apache-2.0"

--- a/memoryhub-cli/src/memoryhub_cli/__init__.py
+++ b/memoryhub-cli/src/memoryhub_cli/__init__.py
@@ -1,3 +1,3 @@
 """MemoryHub CLI client."""
 
-__version__ = "0.12.0"
+__version__ = "0.12.1"

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the `memoryhub` SDK package.
 
+## [0.15.1] -- 2026-07-29
+
+- Document that `update()` produces a new UUID; old version preserved with is_current=false (#475)
+- Document valid relationship types in `create_relationship()` docstring (#476)
+
 ## [0.15.0] -- 2026-07-28
 
 - **`[local]` extra**: `pip install "memoryhub[local]"` pulls in memoryhub-cli

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "memoryhub"
-version = "0.15.0"
+version = "0.15.1"
 description = "Centralized, governed memory for AI agents"
 readme = "README.md"
 license = "Apache-2.0"

--- a/sdk/src/memoryhub/__init__.py
+++ b/sdk/src/memoryhub/__init__.py
@@ -22,7 +22,7 @@ from memoryhub.exceptions import (
     ValidationError,
 )
 
-__version__ = "0.15.0"
+__version__ = "0.15.1"
 
 __all__ = [
     "MemoryHubClient",


### PR DESCRIPTION
## Summary

- SDK 0.15.1: docstring improvements for update() and create_relationship() (#475, #476)
- CLI 0.12.1: defer topic search until actionable signal (#471)

## Test plan

- [ ] Version consistency check passes