### PR TITLE
sdk: Add logical_id field to Memory model

### DIFF
--- a/sdk/src/memoryhub/models.py
+++ b/sdk/src/memoryhub/models.py
@@ -14,6 +14,7 @@ class Memory(BaseModel):
     model_config = ConfigDict(extra="allow")
 
     id: str
+    logical_id: str | None = None
     content: str = ""
     stub: str | None = None
     weight: float = 0.7


### PR DESCRIPTION
## Summary

The server sends `logical_id` in responses but the SDK `Memory` model only captured it via Pydantic `extra="allow"`. Adding it as a proper field.

## Test plan

- [ ] SDK tests pass
- [ ] `mem.logical_id` accessible without going through `model_extra`