### PR TITLE
SDK 0.15.2: logical_id field on Memory model

### DIFF
--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the `memoryhub` SDK package.
 
+## [0.15.2] -- 2026-07-29
+
+- Add `logical_id` as a proper field on `Memory` model (was only accessible via Pydantic extra fields)
+
 ## [0.15.1] -- 2026-07-29
 
 - Document that `update()` produces a new UUID; old version preserved with is_current=false (#475)

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "memoryhub"
-version = "0.15.1"
+version = "0.15.2"
 description = "Centralized, governed memory for AI agents"
 readme = "README.md"
 license = "Apache-2.0"

--- a/sdk/src/memoryhub/__init__.py
+++ b/sdk/src/memoryhub/__init__.py
@@ -22,7 +22,7 @@ from memoryhub.exceptions import (
     ValidationError,
 )
 
-__version__ = "0.15.1"
+__version__ = "0.15.2"
 
 __all__ = [
     "MemoryHubClient",


### PR DESCRIPTION
Patch release adding logical_id as a named field.