### PR TITLE
governance: Add maintainers, require peer review, document issue workflow

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,4 @@
-# Code Owners — all PRs require approval from @rdwj
-#
-# As collaborators join the redhat-ai-americas/memory-hub team,
-# add them here either globally or per-path. For now, @rdwj is the
-# single reviewer required on all changes.
+# Code Owners — PRs require approval from at least one maintainer.
+# Keep in sync with MAINTAINERS.md.
 
-*       @rdwj
+*       @rdwj @srampal @KatyaRomashko @raycarroll

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,6 +96,18 @@ Use the issue templates (`bug_report`, `feature_request`, `design_proposal`) —
 - **File issues under your own GitHub identity.** Do NOT add AI attribution to issue authors. Other developers need to know who to contact about an issue, and the human owner is the point of contact, not the AI assistant that helped draft the body.
 - **No internal-tooling issues on this public repo.** If something internal to your dev environment is broken, mention it in conversation rather than filing a public issue that reveals private infrastructure details.
 
+## Working on issues
+
+Any collaborator can pick up an open issue. Here's the workflow:
+
+1. **Find an issue.** Browse the [MemoryHub project board](https://github.com/orgs/redhat-ai-americas/projects/1) Backlog column, or filter the issue list by label (`good first issue` is a good starting point). The [stakeholder analysis](planning/open-issues-by-stakeholder.md) groups issues by who they serve if you want to pick something aligned with your interests.
+2. **Assign yourself.** Click "assign yourself" on the issue page. If you want to discuss approach before committing, leave a comment first. Do not start work on an issue that is already assigned to someone else without coordinating with them.
+3. **Move it to In Progress** on the project board when you start work.
+4. **Open a PR** that links the issue (`Closes #NN` in the PR description).
+5. **When the PR merges**, the issue moves to Done automatically (GitHub handles this via the `Closes` keyword).
+
+If you can't finish an issue you've claimed, unassign yourself and leave a comment summarizing what you learned and where you got stuck. This saves the next person from repeating your work.
+
 ## Submitting pull requests
 
 1. **Read the relevant design doc first.** Most subsystems have one in `docs/`. If you're touching the agent-memory-ergonomics work, read [`docs/agent-memory-ergonomics/design.md`](docs/agent-memory-ergonomics/design.md). If you're touching auth, read [`docs/design/governance.md`](docs/design/governance.md). If you're touching the package layout, see the repo-layout section above (historical record of the #55 rename: [`planning/archive/package-layout.md`](planning/archive/package-layout.md)).
@@ -105,7 +117,7 @@ Use the issue templates (`bug_report`, `feature_request`, `design_proposal`) —
 5. **CI must pass before merge.** GitHub Actions runs the test matrix (`.github/workflows/test.yml`), version-consistency checks, and secret scanning on every PR. Local green is not a substitute — a PR with failing CI will not be merged.
 6. **Don't commit secrets.** CI runs [gitleaks](https://github.com/gitleaks/gitleaks) on every PR; running it locally before pushing (`gitleaks detect --source .`) saves you a round-trip. We don't depend on git pre-commit hooks. (Maintainers with the project agent tooling can use the `/pre-commit` slash command.)
 7. **Open the PR with a clear description** that links the issue number and references the design doc. Fill in the PR template. Reviewers check the design first, then the diff.
-8. **Expect review from a maintainer.** Review and merge rules (approval count, maintainer self-merge policy) are in [`MAINTAINERS.md`](MAINTAINERS.md).
+8. **Expect review from a maintainer.** Every PR requires approval from at least one maintainer who is not the author. The current maintainer list is in [`MAINTAINERS.md`](MAINTAINERS.md).
 9. **Update `CHANGELOG.md`** in the same PR for any user-visible change to a released component (SDK, CLI, MCP server). Releases are cut by tagging (`sdk/vX.Y.Z`, `mcp/vX.Y.Z`, `memoryhub-cli/vX.Y.Z`); `.github/workflows/version-check.yml` enforces version consistency and `release.yml` publishes.
 10. **Be ready to iterate.** We optimize for the right design, not the fastest merge.
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,15 +4,17 @@
 
 | Name | GitHub | Areas |
 |---|---|---|
-| Wes Jackson | [@rdwj](https://github.com/rdwj) | All (interim — see bus factor note) |
+| Wes Jackson | [@rdwj](https://github.com/rdwj) | All |
+| Sanjay Rampal | [@srampal](https://github.com/srampal) | All |
+| Katya Romashko | [@KatyaRomashko](https://github.com/KatyaRomashko) | All |
+| Ray Carroll | [@raycarroll](https://github.com/raycarroll) | All |
 
 Maintainers have merge rights, deploy access to the shared demo cluster, and own project-board triage. `.github/CODEOWNERS` mirrors this list and must be updated in the same PR as any change here.
 
 ## Review and merge rules
 
 - Every PR requires approval from at least **one maintainer** who is not the PR author, plus green CI (`.github/workflows/test.yml`, version-check, secret scanning).
-- **Maintainer self-merge:** while the project has a single maintainer, maintainer-authored PRs may be self-merged after CI passes, with a minimum 24-hour open window for non-trivial changes so contributors can comment. Once a second maintainer joins, self-merge is retired and maintainer PRs require review from another maintainer like everyone else's.
-- Trivial changes (typos, doc formatting, CI config fixes) may be merged by any maintainer without the waiting period.
+- Trivial changes (typos, doc formatting, CI config fixes) still require one approval but reviewers should not block on them.
 - Disagreements are resolved by discussion on the PR/issue; if consensus isn't reached, the maintainer who owns the affected area decides. Design-level disputes should go through a `design_proposal` issue rather than being settled in a PR thread.
 
 ## Becoming a maintainer
@@ -29,6 +31,3 @@ Nomination happens in a GitHub Discussion; existing maintainers decide by consen
 
 Maintainers may step down at any time by PR to this file. A maintainer inactive for 6+ months may be moved to an "emeritus" section by consensus of the remaining maintainers. Conduct-related removal follows the [Code of Conduct](CODE_OF_CONDUCT.md) enforcement process.
 
-## Bus factor note
-
-The project currently has one maintainer. Growing this list is an explicit goal — if you're a regular contributor and interested, say so in a Discussion.


### PR DESCRIPTION
## Summary

- Add @srampal, @KatyaRomashko, and @raycarroll as maintainers in CODEOWNERS and MAINTAINERS.md
- Retire the single-maintainer self-merge policy (branch protection already updated to require 1 approval)
- Add "Working on issues" section to CONTRIBUTING.md covering self-assignment, issue lifecycle, and handoff etiquette

## Linked issues

No issue -- repo governance setup.

## Design reference

N/A (process change, not a feature).

## Type of change

- [ ] New feature
- [ ] Bug fix
- [x] Infrastructure / process
- [ ] Design document

## Test plan

- [x] Verified branch protection via `gh api`: `required_approving_review_count: 1`, `require_code_owner_reviews: true`, `enforce_admins: true`
- [x] Confirmed CODEOWNERS lists all four maintainers
- [x] Confirmed MAINTAINERS.md has no self-merge language or bus-factor note
- [x] Read through CONTRIBUTING.md issue workflow section for clarity