### PR TITLE
Fixes for multiple bugs in the sharing and project scope logic.

### DIFF
--- a/integrations/openclaw/package-lock.json
+++ b/integrations/openclaw/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "openclaw-memoryhub",
+  "name": "@memory-hub/openclaw-mh-plugin",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "openclaw-memoryhub",
+      "name": "@memory-hub/openclaw-mh-plugin",
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {

--- a/integrations/openclaw/package.json
+++ b/integrations/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memory-hub/openclaw-mh-plugin",
-  "version": "0.1.0",
+  "version": "0.1.3",
   "description": "MemoryHub memory backend for OpenClaw — governed, versioned, graph-aware agent memory.",
   "type": "module",
   "main": "dist/index.js",

--- a/integrations/openclaw/src/tools.ts
+++ b/integrations/openclaw/src/tools.ts
@@ -56,7 +56,6 @@ export function createTools(
       try {
         const options: Record<string, unknown> = {};
         if (params.limit) options.max_results = params.limit;
-        if (params.scope) options.scope = params.scope;
         if (params.content_type) options.content_type = params.content_type;
 
         const domains =
@@ -66,10 +65,16 @@ export function createTools(
             : undefined);
         if (domains) options.domains = domains;
 
-        const result = await mcpClient.callMemory("search", {
+        const callParams: Record<string, unknown> = {
           query: params.query,
           options,
-        });
+        };
+        if (params.scope) callParams.scope = params.scope;
+        if (config.defaults.projectId) {
+          callParams.project_id = config.defaults.projectId;
+        }
+
+        const result = await mcpClient.callMemory("search", callParams);
         return textResult(result);
       } catch (e) {
         return errorResult(
@@ -148,11 +153,16 @@ export function createTools(
       try {
         const options: Record<string, unknown> = {};
         if (params.limit) options.max_results = params.limit;
-        if (params.scope) options.scope = params.scope;
         if (params.content_type) options.content_type = params.content_type;
         if (params.cursor) options.cursor = params.cursor;
 
-        const result = await mcpClient.callMemory("list", { options });
+        const callParams: Record<string, unknown> = { options };
+        if (params.scope) callParams.scope = params.scope;
+        if (config.defaults.projectId) {
+          callParams.project_id = config.defaults.projectId;
+        }
+
+        const result = await mcpClient.callMemory("list", callParams);
         return textResult(result);
       } catch (e) {
         return errorResult(
@@ -222,15 +232,16 @@ export function createTools(
         const domains = params.domains as string[] | undefined;
         if (domains) options.domains = domains;
 
-        if (config.defaults.projectId) {
-          options.project_id = config.defaults.projectId;
-        }
-
-        const result = await mcpClient.callMemory("write", {
+        const callParams: Record<string, unknown> = {
           content: params.content,
           scope,
           options,
-        });
+        };
+        if (config.defaults.projectId) {
+          callParams.project_id = config.defaults.projectId;
+        }
+
+        const result = await mcpClient.callMemory("write", callParams);
         return textResult(result);
       } catch (e) {
         return errorResult(

--- a/integrations/openclaw/tests/tools.test.ts
+++ b/integrations/openclaw/tests/tools.test.ts
@@ -73,6 +73,28 @@ describe("tools", () => {
       });
     });
 
+    it("passes scope as top-level param not in options", async () => {
+      (mcpClient.callMemory as ReturnType<typeof vi.fn>).mockResolvedValue({ results: [] });
+
+      const tool = findTool("memoryhub_search");
+      await tool.execute("tc1", { query: "test", scope: "project" });
+
+      const callArgs = (mcpClient.callMemory as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(callArgs[1].scope).toBe("project");
+      expect(callArgs[1].options.scope).toBeUndefined();
+    });
+
+    it("includes configured projectId", async () => {
+      config.defaults.projectId = "proj-1";
+      (mcpClient.callMemory as ReturnType<typeof vi.fn>).mockResolvedValue({ results: [] });
+
+      const tool = findTool("memoryhub_search");
+      await tool.execute("tc1", { query: "test" });
+
+      const callArgs = (mcpClient.callMemory as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(callArgs[1].project_id).toBe("proj-1");
+    });
+
     it("returns error result on failure", async () => {
       (mcpClient.callMemory as ReturnType<typeof vi.fn>).mockRejectedValue(
         new Error("connection refused"),
@@ -147,8 +169,23 @@ describe("tools", () => {
       });
 
       expect(mcpClient.callMemory).toHaveBeenCalledWith("list", {
-        options: { max_results: 5, scope: "project", cursor: "abc123" },
+        options: { max_results: 5, cursor: "abc123" },
+        scope: "project",
       });
+    });
+
+    it("includes configured projectId", async () => {
+      config.defaults.projectId = "proj-1";
+      (mcpClient.callMemory as ReturnType<typeof vi.fn>).mockResolvedValue({
+        results: [],
+        count: 0,
+      });
+
+      const tool = findTool("memoryhub_list");
+      await tool.execute("tc1", {});
+
+      const callArgs = (mcpClient.callMemory as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(callArgs[1].project_id).toBe("proj-1");
     });
   });
 
@@ -197,7 +234,7 @@ describe("tools", () => {
       });
     });
 
-    it("includes configured projectId in options", async () => {
+    it("includes configured projectId as top-level param", async () => {
       config.defaults.projectId = "proj-1";
       (mcpClient.callMemory as ReturnType<typeof vi.fn>).mockResolvedValue({
         memory: { id: "new-id" },
@@ -209,7 +246,8 @@ describe("tools", () => {
 
       const callArgs = (mcpClient.callMemory as ReturnType<typeof vi.fn>).mock
         .calls[0];
-      expect(callArgs[1].options.project_id).toBe("proj-1");
+      expect(callArgs[1].project_id).toBe("proj-1");
+      expect(callArgs[1].options.project_id).toBeUndefined();
     });
   });
 

--- a/memory-hub-mcp/src/tools/list_memory.py
+++ b/memory-hub-mcp/src/tools/list_memory.py
@@ -161,13 +161,15 @@ async def list_memory(
             f"Valid scopes: {', '.join(sorted(VALID_SCOPES))}."
         )
 
+    list_owner_id = None if scope == "project" and project_ids else claims["sub"]
+
     session, gen = await get_db_session()
     try:
         results, next_cursor = await list_memories(
             session,
             tenant_id=tenant,
             scope=scope,
-            owner_id=claims["sub"],
+            owner_id=list_owner_id,
             max_results=max_results,
             cursor=cursor,
             current_only=current_only,

--- a/memory-hub-mcp/src/tools/write_memory.py
+++ b/memory-hub-mcp/src/tools/write_memory.py
@@ -37,6 +37,7 @@ from src.core.authz import (
     get_claims_from_context,
     resolve_tenant,
 )
+from src.tools.auth import get_current_user
 from src.tools._deps import (
     get_db_session,
     get_embedding_service,
@@ -404,6 +405,12 @@ async def write_memory(
                     description=project_description,
                 )
                 await session_for_project.commit()
+                if was_auto_enrolled:
+                    user = get_current_user()
+                    if user is not None:
+                        existing = set(user.get("project_memberships", []))
+                        existing.add(project_id)
+                        user["project_memberships"] = sorted(existing)
             except ProjectInviteOnlyError as exc:
                 raise ToolError(str(exc)) from exc
             finally:

--- a/memory-hub-mcp/tests/tools/test_project_scope_visibility.py
+++ b/memory-hub-mcp/tests/tools/test_project_scope_visibility.py
@@ -1,0 +1,498 @@
+"""Tests for project-scope visibility bugfixes.
+
+Covers three fixes from BUGFIX-project-scope-visibility.md:
+
+1. Bug 1 — Stale session claims after auto-enrollment (write_memory.py):
+   After ensure_project_membership() auto-enrolls a user, the in-memory
+   session claims must be updated so subsequent list/search calls see
+   the new project without re-registering.
+
+2. Bug 2 — owner_id filter blocking cross-user project visibility:
+   a) list_memory.py: passes owner_id=None for project-scoped queries
+   b) memory.py _build_search_filters: skips owner_id filter when
+      scope="project" and project_ids is set
+"""
+
+import datetime as _dt
+import uuid as _uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import src.tools.auth as auth_mod
+from memoryhub_core.models.schemas import (
+    MemoryNodeRead,
+    MemoryScope,
+    StorageType,
+)
+
+
+def _fake_project_node(
+    content: str,
+    owner_id: str = "dr_bob",
+    scope_id: str = "all_doctors",
+    weight: float = 0.8,
+):
+    """Build a MemoryNodeRead with scope=project for test fixtures."""
+    return MemoryNodeRead(
+        id=_uuid.uuid4(),
+        parent_id=None,
+        content=content,
+        stub=content[:80],
+        storage_type=StorageType.INLINE,
+        content_ref=None,
+        weight=weight,
+        scope=MemoryScope.PROJECT,
+        branch_type=None,
+        owner_id=owner_id,
+        tenant_id="default",
+        scope_id=scope_id,
+        is_current=True,
+        version=1,
+        previous_version_id=None,
+        metadata=None,
+        created_at=_dt.datetime.now(_dt.UTC),
+        updated_at=_dt.datetime.now(_dt.UTC),
+        expires_at=None,
+        has_children=False,
+        has_rationale=False,
+        branch_count=0,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Bug 1 — Session claims updated after auto-enrollment
+# ---------------------------------------------------------------------------
+
+
+class TestAutoEnrollmentClaimsUpdate:
+    """write_memory must update in-memory session claims after auto-enrollment."""
+
+    @pytest.mark.asyncio
+    async def test_session_claims_updated_after_auto_enrollment(self):
+        """After ensure_project_membership auto-enrolls, the session's
+        project_memberships list must include the new project."""
+        from src.tools.write_memory import write_memory
+
+        fake_node = _fake_project_node("test memory", owner_id="wjackson")
+        fake_curation = {
+            "blocked": False,
+            "reason": None,
+            "detail": None,
+            "similar_count": 0,
+            "nearest_id": None,
+            "nearest_score": None,
+            "flags": [],
+        }
+        fake_claims = {
+            "sub": "wjackson",
+            "identity_type": "user",
+            "tenant_id": "default",
+            "scopes": [
+                "memory:write:user",
+                "memory:write:project",
+                "memory:read:user",
+                "memory:read:project",
+            ],
+            "project_memberships": [],
+        }
+        session_user = {
+            "user_id": "wjackson",
+            "scopes": ["user", "project"],
+            "identity_type": "user",
+            "project_memberships": [],
+        }
+
+        async def _fake_get_db_session():
+            return (AsyncMock(), AsyncMock())
+
+        auth_mod._current_session = session_user
+        try:
+            with (
+                patch(
+                    "src.tools.write_memory.get_claims_from_context",
+                    return_value=fake_claims,
+                ),
+                patch(
+                    "src.tools.write_memory.get_db_session",
+                    side_effect=_fake_get_db_session,
+                ),
+                patch(
+                    "src.tools.write_memory.release_db_session",
+                    new_callable=AsyncMock,
+                ),
+                patch(
+                    "src.tools.write_memory.get_embedding_service",
+                    return_value=MagicMock(),
+                ),
+                patch(
+                    "src.tools.write_memory.create_memory",
+                    new_callable=AsyncMock,
+                    return_value=(fake_node, fake_curation),
+                ),
+                patch(
+                    "src.tools.write_memory.broadcast_after_write",
+                    new_callable=AsyncMock,
+                ),
+                patch(
+                    "src.tools.write_memory.ensure_project_membership",
+                    new_callable=AsyncMock,
+                    return_value=({"all_doctors"}, True),
+                ),
+                patch(
+                    "src.tools.write_memory.PROJECT_ISOLATION_ENABLED",
+                    True,
+                ),
+                patch(
+                    "src.tools.write_memory.ROLE_ISOLATION_ENABLED",
+                    False,
+                ),
+                patch(
+                    "src.tools.write_memory.authorize_write",
+                ),
+                patch(
+                    "src.tools.write_memory.resolve_tenant",
+                    return_value="default",
+                ),
+            ):
+                result = await write_memory(
+                    content="test memory",
+                    scope="project",
+                    project_id="all_doctors",
+                    content_type="experiential",
+                )
+
+            assert "all_doctors" in session_user["project_memberships"], (
+                "Session project_memberships must include the auto-enrolled project. "
+                f"Got: {session_user['project_memberships']}"
+            )
+        finally:
+            auth_mod._current_session = None
+
+    @pytest.mark.asyncio
+    async def test_session_claims_unchanged_without_auto_enrollment(self):
+        """When the user is already a member (was_auto_enrolled=False),
+        session claims must not be modified."""
+        from src.tools.write_memory import write_memory
+
+        fake_node = _fake_project_node("test memory", owner_id="wjackson")
+        fake_curation = {
+            "blocked": False,
+            "reason": None,
+            "detail": None,
+            "similar_count": 0,
+            "nearest_id": None,
+            "nearest_score": None,
+            "flags": [],
+        }
+        fake_claims = {
+            "sub": "wjackson",
+            "identity_type": "user",
+            "tenant_id": "default",
+            "scopes": [
+                "memory:write:user",
+                "memory:write:project",
+                "memory:read:user",
+                "memory:read:project",
+            ],
+            "project_memberships": ["all_doctors"],
+        }
+        session_user = {
+            "user_id": "wjackson",
+            "scopes": ["user", "project"],
+            "identity_type": "user",
+            "project_memberships": ["all_doctors"],
+        }
+
+        async def _fake_get_db_session():
+            return (AsyncMock(), AsyncMock())
+
+        auth_mod._current_session = session_user
+        try:
+            with (
+                patch(
+                    "src.tools.write_memory.get_claims_from_context",
+                    return_value=fake_claims,
+                ),
+                patch(
+                    "src.tools.write_memory.get_db_session",
+                    side_effect=_fake_get_db_session,
+                ),
+                patch(
+                    "src.tools.write_memory.release_db_session",
+                    new_callable=AsyncMock,
+                ),
+                patch(
+                    "src.tools.write_memory.get_embedding_service",
+                    return_value=MagicMock(),
+                ),
+                patch(
+                    "src.tools.write_memory.create_memory",
+                    new_callable=AsyncMock,
+                    return_value=(fake_node, fake_curation),
+                ),
+                patch(
+                    "src.tools.write_memory.broadcast_after_write",
+                    new_callable=AsyncMock,
+                ),
+                patch(
+                    "src.tools.write_memory.ensure_project_membership",
+                    new_callable=AsyncMock,
+                    return_value=({"all_doctors"}, False),
+                ),
+                patch(
+                    "src.tools.write_memory.PROJECT_ISOLATION_ENABLED",
+                    True,
+                ),
+                patch(
+                    "src.tools.write_memory.ROLE_ISOLATION_ENABLED",
+                    False,
+                ),
+                patch(
+                    "src.tools.write_memory.authorize_write",
+                ),
+                patch(
+                    "src.tools.write_memory.resolve_tenant",
+                    return_value="default",
+                ),
+            ):
+                result = await write_memory(
+                    content="test memory",
+                    scope="project",
+                    project_id="all_doctors",
+                    content_type="experiential",
+                )
+
+            assert session_user["project_memberships"] == ["all_doctors"], (
+                "Session project_memberships should remain unchanged when not auto-enrolled"
+            )
+        finally:
+            auth_mod._current_session = None
+
+
+# ---------------------------------------------------------------------------
+# Bug 2a — list_memory skips owner_id for project-scoped queries
+# ---------------------------------------------------------------------------
+
+
+class TestListProjectScopeOwnerBypass:
+    """list_memory must pass owner_id=None for project-scoped queries."""
+
+    @pytest.mark.asyncio
+    async def test_list_project_scope_passes_null_owner_id(self):
+        """When scope='project' and project_ids are resolved,
+        list_memories must be called with owner_id=None."""
+        from src.tools.list_memory import list_memory
+
+        items = [
+            _fake_project_node("dr_bob memory", owner_id="dr_bob"),
+            _fake_project_node("dr_alice memory", owner_id="dr_alice"),
+        ]
+        fake_claims = {
+            "sub": "dr_bob",
+            "identity_type": "user",
+            "tenant_id": "default",
+            "scopes": [
+                "memory:read:user",
+                "memory:read:project",
+            ],
+            "project_memberships": ["all_doctors"],
+        }
+
+        async def _fake_get_db_session():
+            return (AsyncMock(), AsyncMock())
+
+        with (
+            patch(
+                "src.tools.list_memory.get_claims_from_context",
+                return_value=fake_claims,
+            ),
+            patch(
+                "src.tools.list_memory.get_db_session",
+                side_effect=_fake_get_db_session,
+            ),
+            patch(
+                "src.tools.list_memory.release_db_session",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "src.tools.list_memory.list_memories",
+                new_callable=AsyncMock,
+                return_value=(items, None),
+            ) as mock_list,
+            patch(
+                "src.tools.list_memory.get_campaigns_for_project",
+                new_callable=AsyncMock,
+                return_value=set(),
+            ),
+            patch(
+                "src.tools.list_memory.build_authorized_scopes",
+                return_value={"user", "project"},
+            ),
+            patch(
+                "src.tools.list_memory.PROJECT_ISOLATION_ENABLED",
+                True,
+            ),
+            patch(
+                "src.tools.list_memory.ROLE_ISOLATION_ENABLED",
+                False,
+            ),
+            patch(
+                "src.tools.list_memory.resolve_tenant",
+                return_value="default",
+            ),
+        ):
+            result = await list_memory(scope="project", project_id="all_doctors")
+
+        _, kwargs = mock_list.call_args
+        assert kwargs.get("owner_id") is None, (
+            f"list_memories must be called with owner_id=None for project scope, "
+            f"got owner_id={kwargs.get('owner_id')!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_list_user_scope_passes_caller_owner_id(self):
+        """When scope is not 'project', list_memories must be called
+        with owner_id=claims['sub'] (the caller's user ID)."""
+        from src.tools.list_memory import list_memory
+
+        items = [_fake_project_node("user memory", owner_id="dr_bob")]
+        fake_claims = {
+            "sub": "dr_bob",
+            "identity_type": "user",
+            "tenant_id": "default",
+            "scopes": [
+                "memory:read:user",
+            ],
+            "project_memberships": [],
+        }
+
+        async def _fake_get_db_session():
+            return (AsyncMock(), AsyncMock())
+
+        with (
+            patch(
+                "src.tools.list_memory.get_claims_from_context",
+                return_value=fake_claims,
+            ),
+            patch(
+                "src.tools.list_memory.get_db_session",
+                side_effect=_fake_get_db_session,
+            ),
+            patch(
+                "src.tools.list_memory.release_db_session",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "src.tools.list_memory.list_memories",
+                new_callable=AsyncMock,
+                return_value=(items, None),
+            ) as mock_list,
+            patch(
+                "src.tools.list_memory.build_authorized_scopes",
+                return_value={"user"},
+            ),
+            patch(
+                "src.tools.list_memory.ROLE_ISOLATION_ENABLED",
+                False,
+            ),
+            patch(
+                "src.tools.list_memory.PROJECT_ISOLATION_ENABLED",
+                False,
+            ),
+            patch(
+                "src.tools.list_memory.resolve_tenant",
+                return_value="default",
+            ),
+        ):
+            result = await list_memory(scope="user")
+
+        _, kwargs = mock_list.call_args
+        assert kwargs.get("owner_id") == "dr_bob", (
+            f"list_memories must be called with owner_id='dr_bob' for user scope, "
+            f"got owner_id={kwargs.get('owner_id')!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Bug 2b — _build_search_filters skips owner_id for project scope
+# ---------------------------------------------------------------------------
+
+
+class TestSearchFiltersProjectOwnerBypass:
+    """_build_search_filters must skip the owner_id filter when
+    scope='project' and project_ids is set."""
+
+    def test_project_scope_with_project_ids_skips_owner_filter(self):
+        """When scope='project' and project_ids is provided,
+        the owner_id filter must NOT be applied."""
+        from memoryhub_core.models.memory import MemoryNode
+        from memoryhub_core.services.memory import _build_search_filters
+
+        filters = _build_search_filters(
+            scope="project",
+            owner_id="dr_bob",
+            current_only=True,
+            authorized_scopes=None,
+            tenant_id="default",
+            project_ids={"all_doctors"},
+        )
+
+        for f in filters:
+            clause_str = str(f.compile(compile_kwargs={"literal_binds": True}))
+            assert not (
+                "owner_id" in clause_str
+                and "dr_bob" in clause_str
+                and "!=" not in clause_str
+            ), (
+                f"owner_id filter must be skipped for project scope with project_ids, "
+                f"but found: {clause_str}"
+            )
+
+    def test_user_scope_applies_owner_filter(self):
+        """When scope='user', the owner_id filter must be applied."""
+        from memoryhub_core.services.memory import _build_search_filters
+
+        filters = _build_search_filters(
+            scope="user",
+            owner_id="dr_bob",
+            current_only=True,
+            authorized_scopes=None,
+            tenant_id="default",
+        )
+
+        has_owner_filter = False
+        for f in filters:
+            clause_str = str(f.compile(compile_kwargs={"literal_binds": True}))
+            if "owner_id" in clause_str and "dr_bob" in clause_str:
+                has_owner_filter = True
+                break
+
+        assert has_owner_filter, (
+            "owner_id filter must be applied for user scope"
+        )
+
+    def test_project_scope_without_project_ids_applies_owner_filter(self):
+        """When scope='project' but project_ids is None/empty,
+        the owner_id filter must still be applied as a safety fallback."""
+        from memoryhub_core.services.memory import _build_search_filters
+
+        filters = _build_search_filters(
+            scope="project",
+            owner_id="dr_bob",
+            current_only=True,
+            authorized_scopes=None,
+            tenant_id="default",
+            project_ids=None,
+        )
+
+        has_owner_filter = False
+        for f in filters:
+            clause_str = str(f.compile(compile_kwargs={"literal_binds": True}))
+            if "owner_id" in clause_str and "dr_bob" in clause_str:
+                has_owner_filter = True
+                break
+
+        assert has_owner_filter, (
+            "owner_id filter must be applied for project scope when project_ids is None"
+        )

--- a/planning/openclaw-memory-provider.md
+++ b/planning/openclaw-memory-provider.md
@@ -797,13 +797,13 @@ V1's `promptBuilder` returns static tool description lines. A future enhancement
 
 The following issues were identified during V1 code review. None are blockers for the demo path, but each represents a correctness or consistency gap that should be addressed before V2.
 
-### 1. `scope` parameter silently dropped in `memoryhub_search`
+### 1. `scope` parameter silently dropped in `memoryhub_search` — *Fixed in PR #513*
 
 **File:** `src/tools.ts` (memoryhub_search tool)
 
 The tool schema accepts a `scope` parameter, but the `execute` implementation never includes it in the `callMemory()` call. The MemoryHub MCP `memory(action="search")` action supports a top-level `scope` filter, so the user's intent to scope a search is silently ignored. The parameter should be passed through to the MCP call.
 
-### 2. `project_id` not passed in search or list tools
+### 2. `project_id` not passed in search or list tools — *Fixed in PR #513*
 
 **File:** `src/tools.ts` (memoryhub_search, memoryhub_list tools)
 

--- a/src/memoryhub_core/services/memory.py
+++ b/src/memoryhub_core/services/memory.py
@@ -827,7 +827,7 @@ def _build_search_filters(
         # memories). Exclude them from normal search unless the caller explicitly
         # requests scope="entity".
         filters.append(MemoryNode.scope != "entity")
-    if owner_id is not None:
+    if owner_id is not None and not (scope == "project" and project_ids):
         filters.append(MemoryNode.owner_id == owner_id)
 
     if authorized_scopes is not None:


### PR DESCRIPTION
Multiple bugs on both the memoryhub server side and the openclaw plugin side related to project scope and sharing. Details described in the PR note.
Assisted by: Claude Opus 4.6

## Summary

Multiple bugs related to project scope

1. Bug 1 — write_memory didn't update the in-memory session's project_memberships after auto-enrolling a user, so subsequent list/search calls in the
  same session couldn't see the new project.
  2. Bug 2a — list_memory always filtered by owner_id=caller, so project-scoped lists only returned the caller's own memories instead of all project
  members' memories.
  3. Bug 2b — _build_search_filters applied the same owner_id filter unconditionally, blocking cross-user search results even when the caller had valid
  project membership.

Openclaw plugin bugs:

4. Bug A — OpenClaw's memoryhub_search and memoryhub_list placed scope inside the options object instead of as a top-level parameter, so the MCP
  server never saw the scope filter.
  5. Bug B — OpenClaw's memoryhub_search and memoryhub_list never forwarded config.defaults.projectId, so project-scoped queries hit the server without
  a project_id even when the plugin was configured with one.

## Linked issues

Closes #

## Design reference

## Type of change

<!-- Check one. Matches the `type:*` issue labels. -->

- [ ] `type:feature` — new user-visible capability
- [x] `type:bug` — fix for incorrect behavior
- [ ] `type:infra` — build, CI, deploy, or tooling change
- [ ] `type:design` — design doc only, no code

## Subsystem

<!-- Check the primary subsystem this touches. Matches the
     `subsystem:*` issue labels. -->

- [x] `memory-tree`
- [ ] `storage`
- [ ] `curator`
- [ ] `governance`
- [ ] `mcp-server`
- [ ] `operator`
- [ ] `observability`
- [ ] `org-ingestion`
- [ ] `auth`
- [ ] `ui`
- [ ] `llamastack`

## Test plan

<!-- Which infrastructure boundaries does this PR exercise?
     Check the option that best describes your test coverage. -->

- [x] **Unit tests only** — no infrastructure boundaries touched
      (pure logic, no DB/Valkey/embedding service interaction)
- [ ] **Integration tests included for:** <!-- list subsystems -->
      `[ pgvector / Valkey / embedding service / auth / S3 ]`
- [ ] **Integration tests deferred because:**
      <!-- This should be rare. Justify why, and link the follow-up issue. -->

<!-- General verification: -->

- [ ] `pytest` passes locally (or the affected subset)
- [x] Manual verification against a running cluster (if applicable)
- [ ] New tests added for new behavior

## Reviewer checklist

- [ ] Design doc referenced or created
- [ ] No committed credentials or cluster-specific URLs
- [ ] CLAUDE.md / docs updated if behavior or conventions changed
- [ ] Commit message follows `subsystem: Imperative summary` format

## Release readiness (if this PR touches `sdk/` or `memoryhub-cli/`)

<!-- Skip this section if the PR does not modify files under sdk/ or memoryhub-cli/. -->

- [ ] `pyproject.toml` version matches `__init__.py` `__version__`
- [ ] `CHANGELOG.md` has an entry for the new version
- [ ] If breaking: CHANGELOG entry is flagged with `BREAKING` and links the tracking issue
