### PR TITLE
infra: Move MinIO to dedicated memoryhub-storage namespace (#395)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,7 @@ Where credentials live and how to use them. This eliminates "secrets archaeology
 | Secret | Namespace | Keys | Used by |
 |--------|-----------|------|---------|
 | `memoryhub-pg-credentials` | `memoryhub-db` | `POSTGRES_PASSWORD` | DB access across all services |
+| `memoryhub-minio-credentials` | `memoryhub-storage` | `MINIO_ROOT_USER`, `MINIO_ROOT_PASSWORD` | MinIO S3 auth; copied to `memory-hub-mcp` by deploy-full.sh |
 | `gemini-api-key` | `memory-hub-mcp` | `api-key` | MCP server extraction LLM auth |
 | `gemini-api-key` | `memoryhub-eval` | `api-key` | EvalHub adapter answer/judge LLM auth |
 | `evalhub-db-credentials` | `memoryhub-eval` | `db-url` | EvalHub PostgreSQL connection |
@@ -156,11 +157,12 @@ Every change must be deployable from code without manual steps. When implementin
 
 **SCC grants** — MinIO and Valkey require `anyuid` SCC on their ServiceAccounts. The deploy script must grant this after applying the kustomize manifests. Without it, pods fail with SCC validation errors on fresh namespaces.
 
-**The golden test** — There are two variants, both must pass with zero manual intervention:
-- **Preserve-DB** (most common): `scripts/uninstall-full.sh --skip-db --yes && scripts/deploy-full.sh`
+**The golden test** — There are three variants; the first two must pass with zero manual intervention:
+- **Preserve-data** (recommended): `scripts/uninstall-full.sh --skip-data --yes && scripts/deploy-full.sh`
+- **Preserve-DB** (legacy, DB only): `scripts/uninstall-full.sh --skip-db --yes && scripts/deploy-full.sh`
 - **Full fresh**: `scripts/uninstall-full.sh --yes && scripts/deploy-full.sh`
 
-The preserve-DB variant is the default smoke test after infrastructure changes. The full-fresh variant tests first-install password generation and DB bootstrap. If either fails, `deploy-full.sh` is incomplete. Run the preserve-DB variant before marking any infrastructure change as done.
+The preserve-data variant is the default smoke test after infrastructure changes — it preserves both PostgreSQL and MinIO object storage. The preserve-DB variant preserves only the database (MinIO data is lost). The full-fresh variant tests first-install password generation and DB bootstrap. If any fails, `deploy-full.sh` is incomplete. Run the preserve-data variant before marking any infrastructure change as done.
 
 **The checklist** — Before marking a feature as deployed, verify:
 - [ ] Schema changes have an Alembic migration
@@ -170,7 +172,7 @@ The preserve-DB variant is the default smoke test after infrastructure changes. 
 - [ ] Cross-namespace Secrets are copied by deploy-full.sh, not created manually
 - [ ] Admin/management APIs expose all user-facing model fields
 - [ ] requirements.txt matches pyproject.toml dependencies (container builds use requirements.txt)
-- [ ] Golden test (preserve-DB): `scripts/uninstall-full.sh --skip-db --yes && scripts/deploy-full.sh` succeeds
+- [ ] Golden test (preserve-data): `scripts/uninstall-full.sh --skip-data --yes && scripts/deploy-full.sh` succeeds and S3-spilled content is retrievable
 - [ ] Golden test (full fresh): `scripts/uninstall-full.sh --yes && scripts/deploy-full.sh` succeeds on a new cluster
 
 ## Deploy Safety

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,12 +157,11 @@ Every change must be deployable from code without manual steps. When implementin
 
 **SCC grants** — MinIO and Valkey require `anyuid` SCC on their ServiceAccounts. The deploy script must grant this after applying the kustomize manifests. Without it, pods fail with SCC validation errors on fresh namespaces.
 
-**The golden test** — There are three variants; the first two must pass with zero manual intervention:
-- **Preserve-data** (recommended): `scripts/uninstall-full.sh --skip-data --yes && scripts/deploy-full.sh`
-- **Preserve-DB** (legacy, DB only): `scripts/uninstall-full.sh --skip-db --yes && scripts/deploy-full.sh`
+**The golden test** — Two variants; both must pass with zero manual intervention:
+- **Preserve-data**: `scripts/uninstall-full.sh --skip-data --yes && scripts/deploy-full.sh`
 - **Full fresh**: `scripts/uninstall-full.sh --yes && scripts/deploy-full.sh`
 
-The preserve-data variant is the default smoke test after infrastructure changes — it preserves both PostgreSQL and MinIO object storage. The preserve-DB variant preserves only the database (MinIO data is lost). The full-fresh variant tests first-install password generation and DB bootstrap. If any fails, `deploy-full.sh` is incomplete. Run the preserve-data variant before marking any infrastructure change as done.
+The preserve-data variant is the default smoke test after infrastructure changes — it preserves both PostgreSQL and MinIO object storage. `--skip-db` is a deprecated alias for `--skip-data`. The full-fresh variant tests first-install password generation and DB bootstrap. If either fails, `deploy-full.sh` is incomplete. Run the preserve-data variant before marking any infrastructure change as done. Use `scripts/test-golden-s3.sh` to verify S3-spilled content survives the preserve-data cycle.
 
 **The checklist** — Before marking a feature as deployed, verify:
 - [ ] Schema changes have an Alembic migration
@@ -179,7 +178,7 @@ The preserve-data variant is the default smoke test after infrastructure changes
 
 **Never delegate deploy or uninstall scripts to sub-agents.** `deploy-full.sh` and `uninstall-full.sh` can destroy the database and all stored memories. Run them in the main conversation context where the operator sees each command and can intervene. A terminal-worker sub-agent misinterpreted "run the full deployment" as "clean-slate install" and destroyed the production database (2026-05-19; recovered from backup).
 
-When deploying, always use `deploy-full.sh` directly (it preserves the existing DB by default). The golden test variants (`uninstall --skip-db` or full `uninstall`) are for verification, not routine deploys.
+When deploying, always use `deploy-full.sh` directly (it preserves the existing DB by default). The golden test variants (`uninstall --skip-data` or full `uninstall`) are for verification, not routine deploys.
 
 After restoring from backup, verify `alembic_version` matches the actual schema before running `upgrade head`. Backup dumps can have stale version markers that cause migrations to fail on duplicate columns.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,7 +161,7 @@ Every change must be deployable from code without manual steps. When implementin
 - **Preserve-data**: `scripts/uninstall-full.sh --skip-data --yes && scripts/deploy-full.sh`
 - **Full fresh**: `scripts/uninstall-full.sh --yes && scripts/deploy-full.sh`
 
-The preserve-data variant is the default smoke test after infrastructure changes — it preserves both PostgreSQL and MinIO object storage. `--skip-db` is a deprecated alias for `--skip-data`. The full-fresh variant tests first-install password generation and DB bootstrap. If either fails, `deploy-full.sh` is incomplete. Run the preserve-data variant before marking any infrastructure change as done. Use `scripts/test-golden-s3.sh` to verify S3-spilled content survives the preserve-data cycle.
+The preserve-data variant is the default smoke test after infrastructure changes — it preserves both PostgreSQL and MinIO object storage. `--skip-db` is a deprecated alias for `--skip-data`. The full-fresh variant tests first-install password generation and DB bootstrap. If either fails, `deploy-full.sh` is incomplete. Run the preserve-data variant before marking any infrastructure change as done. Use `scripts/test-golden-s3-preserve.sh` to verify S3-spilled content survives the preserve-data cycle.
 
 **The checklist** — Before marking a feature as deployed, verify:
 - [ ] Schema changes have an Alembic migration

--- a/deploy/minio/README.md
+++ b/deploy/minio/README.md
@@ -1,13 +1,13 @@
 # MemoryHub MinIO Deployment
 
 Single-instance MinIO for MemoryHub S3-compatible object storage. Stores
-memory content that exceeds the 1 KB inline threshold. Deployed into the
-existing `memory-hub-mcp` namespace so the MCP server can reach it via
-plain in-namespace service discovery.
+memory content that exceeds the 1 KB inline threshold. Deployed into its
+own `memoryhub-storage` namespace so that object data survives MCP server
+reinstalls (see #395).
 
 ## What This Deploys
 
-- **Namespace**: `memory-hub-mcp` (shared with the MCP server)
+- **Namespace**: `memoryhub-storage` (dedicated storage namespace)
 - **Deployment**: Single MinIO pod (`quay.io/minio/minio:latest`)
 - **PVC**: 10Gi persistent volume for object data
 - **Service**: ClusterIP service on port 9000 (S3 API)
@@ -20,7 +20,7 @@ SCC assigns a random UID, which breaks the image. Grant `anyuid` to the
 dedicated `memoryhub-minio` ServiceAccount only:
 
 ```bash
-oc adm policy add-scc-to-user anyuid -z memoryhub-minio -n memory-hub-mcp
+oc adm policy add-scc-to-user anyuid -z memoryhub-minio -n memoryhub-storage
 ```
 
 You need cluster-admin (or equivalent) privileges to run this command.
@@ -28,35 +28,42 @@ You need cluster-admin (or equivalent) privileges to run this command.
 ## Deploy
 
 ```bash
-oc apply -k deploy/minio/ -n memory-hub-mcp
+oc apply -k deploy/minio/
 ```
+
+The kustomization sets `namespace: memoryhub-storage` and includes
+`namespace.yaml`, so no `-n` flag is needed.
 
 Then wait for the pod:
 
 ```bash
 oc wait --for=condition=ready pod -l app.kubernetes.io/name=memoryhub-minio \
-  -n memory-hub-mcp --timeout=120s
+  -n memoryhub-storage --timeout=120s
 ```
 
 ## Verify
 
 ```bash
-oc get pods -n memory-hub-mcp -l app.kubernetes.io/name=memoryhub-minio
+oc get pods -n memoryhub-storage -l app.kubernetes.io/name=memoryhub-minio
 ```
 
 ## Connect From Within the Cluster
 
-Other pods in `memory-hub-mcp` can connect using:
+Pods in the `memoryhub-storage` namespace can use the short service name:
 
 ```
 endpoint: memoryhub-minio:9000
 ```
 
-Cross-namespace connection string:
+Cross-namespace consumers (MCP server, retention cronjob) use the FQDN:
 
 ```
-memoryhub-minio.memory-hub-mcp.svc.cluster.local:9000
+memoryhub-minio.memoryhub-storage.svc.cluster.local:9000
 ```
+
+Cross-namespace consumers also need a copy of the `memoryhub-minio-credentials`
+secret in their namespace. `deploy-full.sh` handles this automatically via
+`copy_secret`.
 
 ## Bucket Creation
 
@@ -69,7 +76,7 @@ Configure the MCP server deployment with these env vars to connect to MinIO:
 
 | Variable | Value |
 |----------|-------|
-| `MEMORYHUB_S3_ENDPOINT` | `memoryhub-minio:9000` |
+| `MEMORYHUB_S3_ENDPOINT` | `memoryhub-minio.memoryhub-storage.svc.cluster.local:9000` |
 | `MEMORYHUB_S3_ACCESS_KEY` | `memoryhub` |
 | `MEMORYHUB_S3_SECRET_KEY` | `memoryhub-dev-password` |
 | `MEMORYHUB_S3_BUCKET` | `memoryhub` |
@@ -78,9 +85,10 @@ Configure the MCP server deployment with these env vars to connect to MinIO:
 ## Tear Down
 
 ```bash
-oc delete -k deploy/minio/ -n memory-hub-mcp
+oc delete -k deploy/minio/
 ```
 
-The PVC is deleted along with the kustomization, so data is not preserved
-across a tear-down. For hardening this, either switch to a `Retain` reclaim
-policy on the storage class or externalize the PVC from the kustomization.
+The PVC is deleted along with the kustomization. To preserve MinIO data
+across reinstalls, use `uninstall-full.sh --skip-data` which skips deletion
+of the `memoryhub-storage` namespace entirely (same pattern as `--skip-db`
+for PostgreSQL).

--- a/deploy/minio/kustomization.yaml
+++ b/deploy/minio/kustomization.yaml
@@ -1,7 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: memory-hub-mcp
+namespace: memoryhub-storage
 resources:
+  - namespace.yaml
   - serviceaccount.yaml
   - secret.yaml
   - pvc.yaml

--- a/deploy/minio/namespace.yaml
+++ b/deploy/minio/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: memoryhub-storage
+  labels:
+    app.kubernetes.io/part-of: memoryhub
+    app.kubernetes.io/component: storage

--- a/deploy/retention/cronjob.yaml
+++ b/deploy/retention/cronjob.yaml
@@ -60,7 +60,7 @@ spec:
                       name: memoryhub-db-credentials
                       key: MEMORYHUB_DB_PASSWORD
                 - name: MEMORYHUB_S3_ENDPOINT
-                  value: "memoryhub-minio:9000"
+                  value: "memoryhub-minio.memoryhub-storage.svc.cluster.local:9000"
                 - name: MEMORYHUB_S3_ACCESS_KEY
                   valueFrom:
                     secretKeyRef:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -88,7 +88,7 @@ graph TB
         PG[(PostgreSQL<br/>pgvector + graph)]
     end
 
-    subgraph "memory-hub-mcp namespace (cont.)"
+    subgraph "memoryhub-storage namespace"
         MINIO[MinIO<br/>S3 object storage]
     end
 
@@ -127,7 +127,7 @@ Every memory operation flows through the MCP server. The server applies authoriz
 
 The OAuth 2.1 authorization server runs in a separate namespace and never touches PostgreSQL. The MCP server validates incoming JWTs against the auth server's JWKS endpoint; the dashboard BFF brokers admin client management calls. SDK consumers fetch tokens via `client_credentials` and refresh transparently. Token rotation, JWKS caching, and signature validation are all handled by FastMCP 3's built-in `JWTVerifier`.
 
-PostgreSQL with pgvector handles relational data, vector similarity search, and graph relationships in a single database -- no separate vector store, no separate graph database. The `all-MiniLM-L6-v2` embedding model and the optional `ms-marco-MiniLM-L12-v2` cross-encoder reranker run on HuggingFace Text Embeddings Inference (TEI) in their own namespaces (`embedding-model` and `reranker-model`) and are reached over the cluster network. The reranker is only invoked on the focus path of `search_memory` and gracefully degrades to plain cosine recall when unreachable, so the system stays usable if the reranker pod is unhealthy. MinIO provides S3-compatible object storage in the `memory-hub-mcp` namespace for oversized memory content (>100KB); the service layer stores a prefix in PostgreSQL and spills the full content to S3, hydrating on demand at read time.
+PostgreSQL with pgvector handles relational data, vector similarity search, and graph relationships in a single database -- no separate vector store, no separate graph database. The `all-MiniLM-L6-v2` embedding model and the optional `ms-marco-MiniLM-L12-v2` cross-encoder reranker run on HuggingFace Text Embeddings Inference (TEI) in their own namespaces (`embedding-model` and `reranker-model`) and are reached over the cluster network. The reranker is only invoked on the focus path of `search_memory` and gracefully degrades to plain cosine recall when unreachable, so the system stays usable if the reranker pod is unhealthy. MinIO provides S3-compatible object storage in the `memoryhub-storage` namespace for oversized memory content (>100KB); the service layer stores a prefix in PostgreSQL and spills the full content to S3, hydrating on demand at read time.
 
 ## Data flow
 
@@ -246,8 +246,11 @@ graph TB
             MCP_POD[memory-hub-mcp pod<br/>FastMCP 3]
             UI_POD[memoryhub-ui pod<br/>BFF + oauth-proxy sidecar]
             VK_POD[memoryhub-valkey pod<br/>Valkey 8.0]
-            MINIO_POD[memoryhub-minio pod<br/>S3 object storage]
             FC_JOB[fact-checker CronJob<br/>daily 01:00 UTC]
+        end
+
+        subgraph "memoryhub-storage namespace"
+            MINIO_POD[memoryhub-minio pod<br/>S3 object storage]
         end
 
         subgraph "memoryhub-agents namespace"
@@ -291,7 +294,7 @@ graph TB
     PROM -. future .-> MCP_POD & UI_POD & AUTH_POD
 ```
 
-The MCP server pod, dashboard, Valkey, MinIO, and the Fact Checker CronJob share the `memory-hub-mcp` namespace so they can communicate over the cluster network without crossing namespace boundaries. The Trace Reviewer runs in a separate `memoryhub-agents` namespace because it has a different scaling profile (HPA-eligible, continuous) and accesses Valkey cross-namespace via DNS (`memoryhub-valkey.memory-hub-mcp.svc:6379`). The auth server lives in its own namespace because it has a different release cadence and a smaller blast radius for security incidents. PostgreSQL lives in its own namespace because the OOTB PostgreSQL operator that ships with OpenShift expects it there and because future replica scaling does not need to touch the application namespaces. The embedding and reranker models each run in their own namespace (`embedding-model`, `reranker-model`) on HuggingFace TEI containers.
+The MCP server pod, dashboard, Valkey, and the Fact Checker CronJob share the `memory-hub-mcp` namespace so they can communicate over the cluster network without crossing namespace boundaries. MinIO lives in its own `memoryhub-storage` namespace so that object storage data survives MCP server reinstalls — the same isolation pattern used for PostgreSQL in `memoryhub-db` (#395). The MCP server reaches MinIO cross-namespace via FQDN (`memoryhub-minio.memoryhub-storage.svc:9000`). The Trace Reviewer runs in a separate `memoryhub-agents` namespace because it has a different scaling profile (HPA-eligible, continuous) and accesses Valkey cross-namespace via DNS (`memoryhub-valkey.memory-hub-mcp.svc:6379`). The auth server lives in its own namespace because it has a different release cadence and a smaller blast radius for security incidents. PostgreSQL lives in its own namespace because the OOTB PostgreSQL operator that ships with OpenShift expects it there and because future replica scaling does not need to touch the application namespaces. The embedding and reranker models each run in their own namespace (`embedding-model`, `reranker-model`) on HuggingFace TEI containers.
 
 All containers use Red Hat UBI9 base images. FIPS compliance is inherited from the cluster's FIPS mode -- PostgreSQL delegates crypto to OS-level OpenSSL, the auth server's RSA signing uses the OS crypto provider, and end-to-end FIPS validation is on the roadmap but not yet completed.
 
@@ -314,7 +317,7 @@ External cluster routes:
 - *Surfaces.* MCP as the primary interface with action-dispatch tool profiles (#201/#202); published SDK and CLI at feature parity (#199/#200), including trace-driven extraction (#240) and Obsidian export (#245); dashboard behind oauth-proxy.
 - *Background agents.* Shared curation-agent framework on Valkey queues with leader election (#286); Fact Checker (#287) and Trace Reviewer (#288) deployed.
 - *Storage.* S3-compatible object storage (MinIO) for oversized memory content with prefix-in-PostgreSQL / full-in-S3 split and on-demand hydration; Valkey-backed session focus vectors for cross-encoder reranking.
-- *Deployment.* Six-namespace OpenShift topology (`memory-hub-mcp`, `memoryhub-agents`, `memoryhub-auth`, `memoryhub-db`, `embedding-model`, `reranker-model`), reproducible from `deploy-full.sh`, with backup/restore tooling (#191).
+- *Deployment.* Seven-namespace OpenShift topology (`memory-hub-mcp`, `memoryhub-agents`, `memoryhub-auth`, `memoryhub-db`, `memoryhub-storage`, `embedding-model`, `reranker-model`), reproducible from `deploy-full.sh`, with backup/restore tooling (#191).
 - *Personal edition.* Zero-infrastructure local variant (`memoryhub-local`) backed by SQLite + sqlite-vec + FTS5 with local ONNX embeddings (IBM Granite), exposing the same 4-tool MCP surface as the cluster edition.
 
 **Decided, not yet implemented.** Kubernetes Operator with CRDs (skeleton only). FIPS end-to-end validation. Campaign promotion pipeline (Phase 3+) -- curator-driven cross-project knowledge promotion with HITL approval queue (the promote/graduate service-layer primitives shipped, but the automated curator-driven pipeline with approval queue has not). Emergent domain ontology -- automatic synonym detection and normalization of domain tags. Curator agent (#285) -- deep dedup, staleness, conflict detection. Statistician agent (#289) -- population-level pattern aggregation with SDC safeguards.

--- a/docs/SYSTEMS.md
+++ b/docs/SYSTEMS.md
@@ -87,11 +87,12 @@ The agent-memory-ergonomics subsystem is cross-cutting rather than load-bearing 
 
 ## Deployment topology
 
-The deployed system spans four OpenShift namespaces:
+The deployed system spans five OpenShift namespaces:
 
 | Namespace | Pods | Purpose |
 |---|---|---|
-| `memory-hub-mcp` | `memory-hub-mcp` (FastMCP server), `memoryhub-ui` (BFF + oauth-proxy sidecar), `memoryhub-valkey` (Valkey 8.0), `fact-checker` (CronJob, daily), MinIO | Agent-facing MCP server, the dashboard, job queues/push, and object storage. Co-located so the BFF and agents can call MCP over the cluster network with low latency. |
+| `memory-hub-mcp` | `memory-hub-mcp` (FastMCP server), `memoryhub-ui` (BFF + oauth-proxy sidecar), `memoryhub-valkey` (Valkey 8.0), `fact-checker` (CronJob, daily) | Agent-facing MCP server, the dashboard, and job queues/push. Co-located so the BFF and agents can call MCP over the cluster network with low latency. |
+| `memoryhub-storage` | `memoryhub-minio` (MinIO) | S3-compatible object storage for oversized memory content. Isolated in its own namespace so data survives MCP server reinstalls (#395). |
 | `memoryhub-agents` | `trace-reviewer` (Deployment) | Background curation agents with a different scaling profile (HPA-eligible, continuous); reaches Valkey cross-namespace via `memoryhub-valkey.memory-hub-mcp.svc:6379`. |
 | `memoryhub-auth` | `auth-server` | Standalone OAuth 2.1 authorization server. Issues JWTs consumed by the MCP server's `JWTVerifier` and by the BFF's admin proxy. |
 | `memoryhub-db` | `memoryhub-pg-0` | PostgreSQL with the pgvector extension. Backs all relational, vector, and graph queries. |

--- a/docs/guides/cluster-install.md
+++ b/docs/guides/cluster-install.md
@@ -75,7 +75,7 @@ make install ARGS="--skip-ui --skip-tile"          # headless (no dashboard)
 ```bash
 make uninstall                                     # prompts for confirmation
 make uninstall ARGS="--yes"                        # non-interactive (CI)
-make uninstall ARGS="--skip-db"                    # preserve database across reinstall
+make uninstall ARGS="--skip-data"                   # preserve database + storage across reinstall
 make uninstall ARGS="--skip-models"                # keep embedding/reranker models running
 ```
 
@@ -84,7 +84,7 @@ make uninstall ARGS="--skip-models"                # keep embedding/reranker mod
 **Image digest mismatch.** If the MCP deploy fails with `running digest does not match imagestream :latest`, the OpenShift deployment cached a stale image. Re-run the install and it will pick up the correct digest:
 
 ```bash
-make install ARGS="--skip-db --skip-migrations --skip-auth"
+make install ARGS="--skip-data --skip-migrations --skip-auth"
 ```
 
 **Reranker timeout with `--gpu-models`.** On single-GPU clusters, the embedding model takes the GPU. The reranker runs on CPU (with a GPU node toleration for scheduling). If the reranker times out, check for PVC contention -- the CPU model variant may still be running and holding the shared PVC. The deploy script scales down CPU models automatically, but leftover deployments from a prior install can interfere. Delete them manually: `oc delete deployment <cpu-model-name> -n reranker-model`.

--- a/memory-hub-mcp/deploy/deploy-minimal.sh
+++ b/memory-hub-mcp/deploy/deploy-minimal.sh
@@ -2,7 +2,7 @@
 # Deploy the minimal-profile MCP server instance for small model testing.
 #
 # This creates a SEPARATE deployment alongside the primary memory-hub-mcp.
-# Same namespace, shared DB/Valkey/MinIO, but different name and route.
+# Same namespace, shared DB/Valkey, cross-namespace MinIO, but different name and route.
 # Sets MEMORYHUB_TOOL_PROFILE=minimal (4 tools: register_session +
 # search_memory + write_memory + read_memory).
 set -euo pipefail

--- a/memory-hub-mcp/deploy/deploy.sh
+++ b/memory-hub-mcp/deploy/deploy.sh
@@ -234,11 +234,11 @@ oc create secret generic memoryhub-db-credentials \
     --dry-run=client -o json | oc apply --context "$CONTEXT" -f - -n "$NAMESPACE"
 echo "OK: memoryhub-db-credentials Secret created/updated in $NAMESPACE"
 
-# Verify MinIO credentials exist (copied from memoryhub-storage by deploy-full.sh)
+# Verify MinIO credentials exist (copied cross-namespace by deploy-full.sh)
 if ! oc get secret --context "$CONTEXT" memoryhub-minio-credentials -n "$NAMESPACE" &>/dev/null; then
     echo "  WARNING: Secret memoryhub-minio-credentials not found in $NAMESPACE."
-    echo "  MinIO credentials must be copied from memoryhub-storage namespace."
-    echo "  Run scripts/deploy-full.sh or manually copy the secret."
+    echo "  Run scripts/deploy-full.sh to deploy MinIO and copy credentials,"
+    echo "  or see deploy/minio/README.md for manual setup."
     echo "  S3 storage will not work until this secret is present."
 fi
 

--- a/memory-hub-mcp/deploy/deploy.sh
+++ b/memory-hub-mcp/deploy/deploy.sh
@@ -233,6 +233,15 @@ oc create secret generic memoryhub-db-credentials \
     $RERANKER_ARGS \
     --dry-run=client -o json | oc apply --context "$CONTEXT" -f - -n "$NAMESPACE"
 echo "OK: memoryhub-db-credentials Secret created/updated in $NAMESPACE"
+
+# Verify MinIO credentials exist (copied from memoryhub-storage by deploy-full.sh)
+if ! oc get secret --context "$CONTEXT" memoryhub-minio-credentials -n "$NAMESPACE" &>/dev/null; then
+    echo "  WARNING: Secret memoryhub-minio-credentials not found in $NAMESPACE."
+    echo "  MinIO credentials must be copied from memoryhub-storage namespace."
+    echo "  Run scripts/deploy-full.sh or manually copy the secret."
+    echo "  S3 storage will not work until this secret is present."
+fi
+
 apply_manifest
 
 # Step 4: Start binary build

--- a/memory-hub-mcp/deploy/openshift-minimal.yaml
+++ b/memory-hub-mcp/deploy/openshift-minimal.yaml
@@ -91,7 +91,7 @@ spec:
         - name: MEMORYHUB_VALKEY_URL
           value: "redis://memoryhub-valkey.memory-hub-mcp.svc.cluster.local:6379/0"
         - name: MEMORYHUB_S3_ENDPOINT
-          value: "memoryhub-minio:9000"
+          value: "memoryhub-minio.memoryhub-storage.svc.cluster.local:9000"
         - name: MEMORYHUB_S3_ACCESS_KEY
           valueFrom:
             secretKeyRef:

--- a/memory-hub-mcp/deploy/openshift.yaml
+++ b/memory-hub-mcp/deploy/openshift.yaml
@@ -105,7 +105,7 @@ spec:
         # threshold is uploaded to MinIO with semantic chunks for search.
         # When unset, oversized content stays inline with chunks only.
         - name: MEMORYHUB_S3_ENDPOINT
-          value: "memoryhub-minio:9000"
+          value: "memoryhub-minio.memoryhub-storage.svc.cluster.local:9000"
         - name: MEMORYHUB_S3_ACCESS_KEY
           valueFrom:
             secretKeyRef:

--- a/scripts/deploy-full.sh
+++ b/scripts/deploy-full.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Full MemoryHub stack deployment to OpenShift.
-# Usage: scripts/deploy-full.sh [--skip-prereqs] [--skip-db] [--skip-storage]
+# Usage: scripts/deploy-full.sh [--skip-prereqs] [--skip-data]
 #                                [--skip-migrations] [--skip-mcp] [--skip-auth]
 #                                [--skip-ui] [--skip-tile] [--skip-models] [--gpu-models]
 set -euo pipefail
@@ -21,7 +21,7 @@ STORAGE_NAMESPACE="memoryhub-storage"
 DB_POD_LABEL="app.kubernetes.io/name=memoryhub-pg"
 
 SKIP_PREREQS=false
-SKIP_DB=false
+SKIP_DATA=false
 SKIP_MIGRATIONS=false
 SKIP_MCP=false
 SKIP_AUTH=false
@@ -29,7 +29,6 @@ SKIP_UI=false
 SKIP_TILE=false
 SKIP_MODELS=false
 GPU_MODELS=false
-SKIP_STORAGE=false
 SKIP_SMOKE_TEST=false
 RESTORE_FROM=""
 
@@ -108,14 +107,14 @@ parse_args() {
     while [[ $# -gt 0 ]]; do
         case "$1" in
             --skip-prereqs)    SKIP_PREREQS=true ;;
-            --skip-db)         SKIP_DB=true ;;
+            --skip-data)       SKIP_DATA=true ;;
+            --skip-db)         SKIP_DATA=true ;;
             --skip-migrations) SKIP_MIGRATIONS=true ;;
             --skip-mcp)        SKIP_MCP=true ;;
             --skip-auth)       SKIP_AUTH=true ;;
             --skip-ui)         SKIP_UI=true ;;
             --skip-tile)       SKIP_TILE=true ;;
             --skip-models)     SKIP_MODELS=true ;;
-            --skip-storage)    SKIP_STORAGE=true ;;
             --gpu-models)      GPU_MODELS=true ;;
             --skip-smoke-test) SKIP_SMOKE_TEST=true ;;
             --restore-from)
@@ -132,14 +131,14 @@ parse_args() {
                 echo "Usage: $SCRIPT_NAME [OPTIONS]"
                 echo ""
                 echo "  --skip-prereqs     Skip check-prereqs.sh (for known-good environments)"
-                echo "  --skip-db          Skip PostgreSQL deployment"
+                echo "  --skip-data        Skip PostgreSQL and MinIO deployment (data already present)"
+                echo "  --skip-db          Deprecated alias for --skip-data"
                 echo "  --skip-migrations  Skip Alembic migrations"
                 echo "  --skip-mcp         Skip MCP server deployment"
                 echo "  --skip-auth        Skip Auth server deployment"
                 echo "  --skip-ui          Skip UI deployment"
                 echo "  --skip-tile        Skip RHOAI OdhApplication tile"
                 echo "  --skip-models      Skip embedding + reranker model deployment"
-                echo "  --skip-storage     Skip MinIO object storage deployment"
                 echo "  --gpu-models       Use GPU model manifests instead of CPU (default: CPU)"
                 echo "  --skip-smoke-test  Skip post-deploy write/search/read verification"
                 echo "  --restore-from F   Restore database from a pg_dump file after DB deploy"
@@ -202,10 +201,10 @@ preflight() {
     echo -e "  ${GREEN}Preflight OK${RESET}"
     echo ""
     echo "  Deployment plan:"
-    echo "    PostgreSQL:  $([ "$SKIP_DB" = true ] && echo "skip" || echo "deploy")"
+    echo "    PostgreSQL:  $([ "$SKIP_DATA" = true ] && echo "skip" || echo "deploy")"
     echo "    Migrations:  $([ "$SKIP_MIGRATIONS" = true ] && echo "skip" || echo "run")"
     echo "    MCP server:  $([ "$SKIP_MCP" = true ] && echo "skip" || echo "deploy")"
-    echo "    MinIO:       $([ "$SKIP_STORAGE" = true ] && echo "skip" || echo "deploy")"
+    echo "    MinIO:       $([ "$SKIP_DATA" = true ] && echo "skip" || echo "deploy")"
     echo "    Valkey:      $([ "$SKIP_MCP" = true ] && echo "skip" || echo "deploy")"
     echo "    Models:      $([ "$SKIP_MODELS" = true ] && echo "skip" || ([ "$GPU_MODELS" = true ] && echo "deploy (GPU)" || echo "deploy (CPU)"))"
     echo "    Auth server: $([ "$SKIP_AUTH" = true ] && echo "skip" || echo "deploy")"
@@ -219,8 +218,8 @@ preflight() {
 deploy_postgresql() {
     banner "2. PostgreSQL"
 
-    if [ "$SKIP_DB" = true ]; then
-        skipped "PostgreSQL (--skip-db)"
+    if [ "$SKIP_DATA" = true ]; then
+        skipped "PostgreSQL (--skip-data)"
         return 0
     fi
 
@@ -342,8 +341,8 @@ run_migrations() {
 deploy_storage() {
     banner "3b. MinIO Object Storage"
 
-    if [ "$SKIP_STORAGE" = true ]; then
-        skipped "MinIO (--skip-storage)"
+    if [ "$SKIP_DATA" = true ]; then
+        skipped "MinIO (--skip-data)"
         return 0
     fi
 
@@ -482,8 +481,8 @@ deploy_models() {
 deploy_retention_cronjob() {
     banner "3c. Retention Enforcement CronJob"
 
-    if [ "$SKIP_DB" = true ]; then
-        skipped "Retention CronJob (DB skipped)"
+    if [ "$SKIP_DATA" = true ]; then
+        skipped "Retention CronJob (--skip-data)"
         return 0
     fi
 

--- a/scripts/deploy-full.sh
+++ b/scripts/deploy-full.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 # Full MemoryHub stack deployment to OpenShift.
-# Usage: scripts/deploy-full.sh [--skip-prereqs] [--skip-db] [--skip-migrations]
-#                                [--skip-mcp] [--skip-auth] [--skip-ui] [--skip-tile]
-#                                [--skip-models] [--gpu-models]
+# Usage: scripts/deploy-full.sh [--skip-prereqs] [--skip-db] [--skip-storage]
+#                                [--skip-migrations] [--skip-mcp] [--skip-auth]
+#                                [--skip-ui] [--skip-tile] [--skip-models] [--gpu-models]
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -17,6 +17,7 @@ UI_NAMESPACE="memoryhub-ui"
 RHOAI_NAMESPACE="redhat-ods-applications"
 EMBEDDING_MODEL_NAMESPACE="embedding-model"
 RERANKER_MODEL_NAMESPACE="reranker-model"
+STORAGE_NAMESPACE="memoryhub-storage"
 DB_POD_LABEL="app.kubernetes.io/name=memoryhub-pg"
 
 SKIP_PREREQS=false
@@ -28,6 +29,7 @@ SKIP_UI=false
 SKIP_TILE=false
 SKIP_MODELS=false
 GPU_MODELS=false
+SKIP_STORAGE=false
 SKIP_SMOKE_TEST=false
 RESTORE_FROM=""
 
@@ -113,6 +115,7 @@ parse_args() {
             --skip-ui)         SKIP_UI=true ;;
             --skip-tile)       SKIP_TILE=true ;;
             --skip-models)     SKIP_MODELS=true ;;
+            --skip-storage)    SKIP_STORAGE=true ;;
             --gpu-models)      GPU_MODELS=true ;;
             --skip-smoke-test) SKIP_SMOKE_TEST=true ;;
             --restore-from)
@@ -136,6 +139,7 @@ parse_args() {
                 echo "  --skip-ui          Skip UI deployment"
                 echo "  --skip-tile        Skip RHOAI OdhApplication tile"
                 echo "  --skip-models      Skip embedding + reranker model deployment"
+                echo "  --skip-storage     Skip MinIO object storage deployment"
                 echo "  --gpu-models       Use GPU model manifests instead of CPU (default: CPU)"
                 echo "  --skip-smoke-test  Skip post-deploy write/search/read verification"
                 echo "  --restore-from F   Restore database from a pg_dump file after DB deploy"
@@ -201,7 +205,7 @@ preflight() {
     echo "    PostgreSQL:  $([ "$SKIP_DB" = true ] && echo "skip" || echo "deploy")"
     echo "    Migrations:  $([ "$SKIP_MIGRATIONS" = true ] && echo "skip" || echo "run")"
     echo "    MCP server:  $([ "$SKIP_MCP" = true ] && echo "skip" || echo "deploy")"
-    echo "    MinIO:       $([ "$SKIP_MCP" = true ] && echo "skip" || echo "deploy")"
+    echo "    MinIO:       $([ "$SKIP_STORAGE" = true ] && echo "skip" || echo "deploy")"
     echo "    Valkey:      $([ "$SKIP_MCP" = true ] && echo "skip" || echo "deploy")"
     echo "    Models:      $([ "$SKIP_MODELS" = true ] && echo "skip" || ([ "$GPU_MODELS" = true ] && echo "deploy (GPU)" || echo "deploy (CPU)"))"
     echo "    Auth server: $([ "$SKIP_AUTH" = true ] && echo "skip" || echo "deploy")"
@@ -333,35 +337,63 @@ run_migrations() {
 }
 
 # ---------------------------------------------------------------------------
-# Section 3b: MinIO + Valkey infrastructure (MCP dependencies)
+# Section 3b: MinIO object storage (memoryhub-storage namespace)
 # ---------------------------------------------------------------------------
-deploy_infra() {
-    banner "3b. MinIO + Valkey"
+deploy_storage() {
+    banner "3b. MinIO Object Storage"
 
-    if [ "$SKIP_MCP" = true ]; then
-        skipped "Infrastructure (MCP skipped)"
+    if [ "$SKIP_STORAGE" = true ]; then
+        skipped "MinIO (--skip-storage)"
         return 0
     fi
 
-    # Ensure MCP namespace exists (MCP deploy script also does this, but we
-    # need it now for MinIO/Valkey which must be ready before MCP starts)
+    # The kustomization includes namespace.yaml, but we need the namespace
+    # to exist before we can grant SCCs, so create it imperatively first.
+    if ! oc get namespace --context "$CONTEXT" "$STORAGE_NAMESPACE" &>/dev/null; then
+        info "Creating namespace $STORAGE_NAMESPACE..."
+        oc create namespace --context "$CONTEXT" "$STORAGE_NAMESPACE"
+    fi
+
+    info "Deploying MinIO..."
+    oc apply --context "$CONTEXT" -k "$REPO_ROOT/deploy/minio/"
+    oc adm policy --context "$CONTEXT" add-scc-to-user anyuid -z memoryhub-minio -n "$STORAGE_NAMESPACE"
+
+    info "Waiting for MinIO rollout..."
+    if ! oc rollout --context "$CONTEXT" status deployment/memoryhub-minio -n "$STORAGE_NAMESPACE" --timeout=120s; then
+        die "MinIO did not become ready. Check: oc describe deployment/memoryhub-minio -n $STORAGE_NAMESPACE"
+    fi
+
+    # Copy MinIO credentials to the MCP namespace so the MCP server and
+    # retention cronjob can reference the secret locally.
+    if ! oc get namespace --context "$CONTEXT" "$MCP_PROJECT" &>/dev/null; then
+        info "Creating namespace $MCP_PROJECT (for cross-namespace secret copy)..."
+        oc create namespace --context "$CONTEXT" "$MCP_PROJECT"
+    fi
+    copy_secret memoryhub-minio-credentials "$STORAGE_NAMESPACE" memoryhub-minio-credentials "$MCP_PROJECT"
+
+    echo ""
+    echo -e "  ${GREEN}MinIO ready${RESET}"
+}
+
+# ---------------------------------------------------------------------------
+# Section 3b2: Valkey (MCP namespace, ephemeral cache)
+# ---------------------------------------------------------------------------
+deploy_valkey() {
+    banner "3b2. Valkey"
+
+    if [ "$SKIP_MCP" = true ]; then
+        skipped "Valkey (MCP skipped)"
+        return 0
+    fi
+
     if ! oc get namespace --context "$CONTEXT" "$MCP_PROJECT" &>/dev/null; then
         info "Creating namespace $MCP_PROJECT..."
         oc create namespace --context "$CONTEXT" "$MCP_PROJECT"
     fi
 
-    info "Deploying MinIO..."
-    oc apply --context "$CONTEXT" -k "$REPO_ROOT/deploy/minio/" -n "$MCP_PROJECT"
-    oc adm policy --context "$CONTEXT" add-scc-to-user anyuid -z memoryhub-minio -n "$MCP_PROJECT"
-
     info "Deploying Valkey..."
     oc apply --context "$CONTEXT" -k "$REPO_ROOT/deploy/valkey/" -n "$MCP_PROJECT"
     oc adm policy --context "$CONTEXT" add-scc-to-user anyuid -z memoryhub-valkey -n "$MCP_PROJECT"
-
-    info "Waiting for MinIO rollout..."
-    if ! oc rollout --context "$CONTEXT" status deployment/memoryhub-minio -n "$MCP_PROJECT" --timeout=120s; then
-        die "MinIO did not become ready. Check: oc describe deployment/memoryhub-minio -n $MCP_PROJECT"
-    fi
 
     info "Waiting for Valkey rollout..."
     if ! oc rollout --context "$CONTEXT" status deployment/memoryhub-valkey -n "$MCP_PROJECT" --timeout=120s; then
@@ -369,7 +401,7 @@ deploy_infra() {
     fi
 
     echo ""
-    echo -e "  ${GREEN}MinIO + Valkey ready${RESET}"
+    echo -e "  ${GREEN}Valkey ready${RESET}"
 }
 
 # ---------------------------------------------------------------------------
@@ -923,7 +955,8 @@ main() {
     deploy_postgresql
     restore_from_backup
     run_migrations
-    deploy_infra              # MinIO + Valkey before MCP
+    deploy_storage            # MinIO in memoryhub-storage namespace
+    deploy_valkey             # Valkey in MCP namespace (ephemeral)
     deploy_models             # Embedding + Reranker before MCP
     deploy_retention_cronjob  # Retention sweep after DB
     prepare_auth_infra        # Secrets before auth

--- a/scripts/test-golden-s3-preserve.sh
+++ b/scripts/test-golden-s3-preserve.sh
@@ -196,17 +196,33 @@ verify_memory() {
         die "Read failed — memory may have been lost"
     }
 
-    local has_tag storage_type full_available
-    eval "$(echo "$read_output" | python3 -c "
+    local has_tag storage_type full_available content_len
+    has_tag=$(echo "$read_output" | python3 -c "
 import json, sys
 d = json.load(sys.stdin)
 mem = d.get('data', d)
 c = mem.get('content') or ''
-print(f'has_tag={\"true\" if \"golden-s3-test\" in c else \"false\"}')
-print(f'storage_type={mem.get(\"storage_type\", \"inline\")}')
-print(f'full_available={str(mem.get(\"full_available\", False)).lower()}')
-print(f'content_len={len(c)}')
-")"
+print('true' if 'golden-s3-test' in c else 'false')
+")
+    storage_type=$(echo "$read_output" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+mem = d.get('data', d)
+print(mem.get('storage_type', 'inline'))
+")
+    full_available=$(echo "$read_output" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+mem = d.get('data', d)
+print(str(mem.get('full_available', False)).lower())
+")
+    content_len=$(echo "$read_output" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+mem = d.get('data', d)
+c = mem.get('content') or ''
+print(len(c))
+")
 
     if [ "$has_tag" != "true" ]; then
         die "Memory content does not contain test tag — content may be corrupted or truncated"
@@ -262,8 +278,9 @@ run_golden_test() {
     info "Uninstall complete"
 
     info "Waiting for namespace termination..."
-    local ns wait_secs=0
+    local ns wait_secs total_wait=0
     for ns in memory-hub-mcp memoryhub-auth memoryhub-ui; do
+        wait_secs=0
         while oc get namespace --context "$CONTEXT" "$ns" &>/dev/null 2>&1; do
             if [ $wait_secs -ge 120 ]; then
                 die "Namespace $ns still terminating after 120s"
@@ -271,8 +288,9 @@ run_golden_test() {
             sleep 5
             wait_secs=$((wait_secs + 5))
         done
+        total_wait=$((total_wait + wait_secs))
     done
-    info "All namespaces terminated (${wait_secs}s)"
+    info "All namespaces terminated (${total_wait}s)"
 
     banner "Reinstall"
 

--- a/scripts/test-golden-s3-preserve.sh
+++ b/scripts/test-golden-s3-preserve.sh
@@ -6,7 +6,7 @@
 # content is fully retrievable afterward.
 #
 # Usage:
-#   scripts/test-golden-s3.sh [--write-only] [--verify-only MEMORY_ID]
+#   scripts/test-golden-s3-preserve.sh [--write-only] [--verify-only MEMORY_ID]
 #
 #   --write-only      Write the test memory and print its ID, then exit.
 #                     Use this before manually running the golden test.
@@ -19,6 +19,13 @@
 #   - memoryhub CLI or SDK installed (checks .venv/bin/memoryhub)
 #   - MEMORYHUB_URL and MEMORYHUB_API_KEY set, or ~/.config/memoryhub/credentials
 #   - OpenShift login active (for the golden test cycle)
+#   - MEMORYHUB_EMBEDDING_MAX_TOKENS must be set high enough on the MCP server
+#     deployment to accept >100KB content without validation rejection. The
+#     config default (8192) is wrong for the CPU embedding model (#511).
+#     Workaround until #511 is fixed:
+#       oc set env deployment/memory-hub-mcp MEMORYHUB_EMBEDDING_MAX_TOKENS=500000 \
+#         --context <context> -n memory-hub-mcp
+#     Note: deploy-full.sh wipes this — re-apply after every deploy.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -43,10 +50,36 @@ else
     BOLD="" GREEN="" YELLOW="" RED="" CYAN="" RESET=""
 fi
 
+WRITTEN_MEMORY_ID=""
+CLEANUP_MEMORY_ID=""
+SKIP_CLEANUP=false
+TEST_PASSED=false
+
+cleanup() {
+    local id="${CLEANUP_MEMORY_ID:-$WRITTEN_MEMORY_ID}"
+    if [ -z "$id" ] || [ "$SKIP_CLEANUP" = "true" ]; then
+        return
+    fi
+    local cli
+    cli=$(command -v memoryhub 2>/dev/null || echo "$REPO_ROOT/.venv/bin/memoryhub")
+    echo ""
+    if [ "$TEST_PASSED" = "true" ]; then
+        echo -e "  ${GREEN}→${RESET} Cleaning up test memory $id..."
+    else
+        echo -e "  ${YELLOW}!${RESET} Test did not pass — cleaning up test memory $id..."
+    fi
+    $cli delete "$id" -f -o quiet 2>/dev/null && \
+        echo -e "  ${GREEN}→${RESET} Deleted" || \
+        echo -e "  ${YELLOW}!${RESET} Delete failed (non-fatal)"
+}
+trap cleanup EXIT
+
+STEP=0
 banner() {
+    STEP=$((STEP + 1))
     echo ""
     echo -e "${BOLD}${CYAN}=========================================${RESET}"
-    echo -e "${BOLD}${CYAN}  $1${RESET}"
+    echo -e "${BOLD}${CYAN}  Step ${STEP}: $1${RESET}"
     echo -e "${BOLD}${CYAN}=========================================${RESET}"
 }
 info()  { echo -e "  ${GREEN}→${RESET} $*"; }
@@ -72,7 +105,7 @@ resolve_cli() {
 write_test_memory() {
     local memoryhub_bin=$1
 
-    banner "1. Write S3-spilled test memory"
+    banner "Write test memory"
 
     info "Generating ${TEST_CONTENT_SIZE}-byte test content..."
     local content
@@ -86,7 +119,7 @@ write_test_memory() {
     done
     info "Content size: ${#content} bytes (threshold: 102400)"
 
-    info "Writing memory..."
+    info "Writing memory via CLI..."
     local write_output
     write_output=$(echo "$content" | $memoryhub_bin write --scope user --weight 0.1 -o json) || {
         die "Write failed: $write_output"
@@ -113,7 +146,7 @@ else:
 
     info "Written: $memory_id"
 
-    banner "2. Verify S3 spill"
+    banner "Verify S3 spill"
 
     info "Reading memory back to check storage type..."
     local read_output
@@ -145,7 +178,7 @@ print(len(c))
         warn "survival but won't exercise the S3 spill path."
     fi
 
-    echo "$memory_id"
+    WRITTEN_MEMORY_ID="$memory_id"
 }
 
 # ---------------------------------------------------------------------------
@@ -155,7 +188,7 @@ verify_memory() {
     local memoryhub_bin=$1
     local memory_id=$2
 
-    banner "4. Verify memory retrieval after golden test"
+    banner "Verify memory retrieval"
 
     info "Reading memory $memory_id..."
     local read_output
@@ -195,12 +228,7 @@ print(f'content_len={len(c)}')
 
     info "Test tag present: yes"
 
-    banner "5. Cleanup"
-
-    info "Deleting test memory $memory_id..."
-    $memoryhub_bin delete "$memory_id" -f -o quiet 2>/dev/null || warn "Delete failed (non-fatal)"
-    info "Cleanup complete"
-
+    TEST_PASSED=true
     echo ""
     echo -e "  ${GREEN}${BOLD}PASS: S3-spilled memory survived the --skip-data golden test${RESET}"
     echo ""
@@ -210,10 +238,14 @@ print(f'content_len={len(c)}')
 # Run the full golden test cycle
 # ---------------------------------------------------------------------------
 run_golden_test() {
-    banner "3. Golden test: uninstall --skip-data && deploy"
+    local uninstall_args="--skip-data --skip-tile --yes"
+    local deploy_args="--skip-prereqs --skip-tile --skip-ui --skip-models --skip-smoke-test"
 
-    warn "This will take the entire MemoryHub stack down and redeploy it."
+    banner "Uninstall (preserving data)"
+
+    warn "This will take the MemoryHub stack down."
     warn "The --skip-data flag preserves both DB and storage namespaces."
+    info "Args: $uninstall_args"
     echo ""
 
     if [ -t 0 ]; then
@@ -223,17 +255,33 @@ run_golden_test() {
         fi
     fi
 
-    info "Running: uninstall-full.sh --skip-data --yes"
-    "$SCRIPT_DIR/uninstall-full.sh" --skip-data --yes || {
+    # shellcheck disable=SC2086
+    "$SCRIPT_DIR/uninstall-full.sh" $uninstall_args || {
         die "Uninstall failed"
     }
+    info "Uninstall complete"
 
-    info "Running: deploy-full.sh --skip-models --skip-smoke-test"
-    "$SCRIPT_DIR/deploy-full.sh" --skip-models --skip-smoke-test || {
+    info "Waiting for namespace termination..."
+    local ns wait_secs=0
+    for ns in memory-hub-mcp memoryhub-auth memoryhub-ui; do
+        while oc get namespace --context "$CONTEXT" "$ns" &>/dev/null 2>&1; do
+            if [ $wait_secs -ge 120 ]; then
+                die "Namespace $ns still terminating after 120s"
+            fi
+            sleep 5
+            wait_secs=$((wait_secs + 5))
+        done
+    done
+    info "All namespaces terminated (${wait_secs}s)"
+
+    banner "Reinstall"
+
+    info "Args: $deploy_args"
+    # shellcheck disable=SC2086
+    "$SCRIPT_DIR/deploy-full.sh" $deploy_args || {
         die "Deploy failed"
     }
-
-    info "Golden test cycle complete"
+    info "Reinstall complete"
 }
 
 # ---------------------------------------------------------------------------
@@ -271,24 +319,36 @@ while [[ $# -gt 0 ]]; do
 done
 
 MEMORYHUB_BIN=$(resolve_cli)
-info "Using CLI: $MEMORYHUB_BIN"
+
+echo ""
+echo -e "${BOLD}MemoryHub S3 Golden Test${RESET}"
+echo -e "CLI: $MEMORYHUB_BIN"
 
 case "$MODE" in
     write)
-        MEMORY_ID=$(write_test_memory "$MEMORYHUB_BIN" | tail -1)
+        SKIP_CLEANUP=true
+        echo -e "Mode: ${CYAN}write-only${RESET} (write test memory, then exit)"
+        echo -e "Steps: Write test memory → Verify S3 spill"
+        write_test_memory "$MEMORYHUB_BIN"
         echo ""
-        echo "Memory ID: $MEMORY_ID"
+        echo -e "${BOLD}Memory ID: $WRITTEN_MEMORY_ID${RESET}"
         echo ""
         echo "Next steps:"
-        echo "  1. Run the golden test: scripts/uninstall-full.sh --skip-data --yes && scripts/deploy-full.sh"
-        echo "  2. Verify:              scripts/test-golden-s3.sh --verify-only $MEMORY_ID"
+        echo "  1. Run the golden test: scripts/uninstall-full.sh --skip-data --skip-tile --yes && scripts/deploy-full.sh --skip-prereqs --skip-tile"
+        echo "  2. Verify:              scripts/test-golden-s3-preserve.sh --verify-only $WRITTEN_MEMORY_ID"
         ;;
     verify)
+        CLEANUP_MEMORY_ID="$VERIFY_MEMORY_ID"
+        echo -e "Mode: ${CYAN}verify-only${RESET} (check memory survived golden test)"
+        echo -e "Steps: Verify memory retrieval → Cleanup"
+        echo -e "Memory ID: $VERIFY_MEMORY_ID"
         verify_memory "$MEMORYHUB_BIN" "$VERIFY_MEMORY_ID"
         ;;
     full)
-        MEMORY_ID=$(write_test_memory "$MEMORYHUB_BIN" | tail -1)
+        echo -e "Mode: ${CYAN}full cycle${RESET} (write → uninstall → deploy → verify)"
+        echo -e "Steps: Write test memory → Verify S3 spill → Golden test → Verify retrieval → Cleanup"
+        write_test_memory "$MEMORYHUB_BIN"
         run_golden_test
-        verify_memory "$MEMORYHUB_BIN" "$MEMORY_ID"
+        verify_memory "$MEMORYHUB_BIN" "$WRITTEN_MEMORY_ID"
         ;;
 esac

--- a/scripts/test-golden-s3.sh
+++ b/scripts/test-golden-s3.sh
@@ -1,0 +1,287 @@
+#!/usr/bin/env bash
+# Verify that S3-spilled memory content survives the --skip-data golden test.
+#
+# Exit predicate for issue #395: Write a >100KB memory, verify it's S3-spilled,
+# run uninstall-full.sh --skip-data && deploy-full.sh, then verify the memory
+# content is fully retrievable afterward.
+#
+# Usage:
+#   scripts/test-golden-s3.sh [--write-only] [--verify-only MEMORY_ID]
+#
+#   --write-only      Write the test memory and print its ID, then exit.
+#                     Use this before manually running the golden test.
+#   --verify-only ID  Verify an existing memory is retrievable with full
+#                     content after a golden test cycle. Use after --write-only.
+#   (no flags)        Run the full cycle: write, uninstall --skip-data, deploy,
+#                     verify. DESTRUCTIVE — takes the stack down and back up.
+#
+# Prerequisites:
+#   - memoryhub CLI or SDK installed (checks .venv/bin/memoryhub)
+#   - MEMORYHUB_URL and MEMORYHUB_API_KEY set, or ~/.config/memoryhub/credentials
+#   - OpenShift login active (for the golden test cycle)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+CONTEXT="${MEMORYHUB_CONTEXT:-mcp-rhoai}"
+
+# S3 spill threshold is 102400 bytes (100KB) — generate content above this.
+TEST_CONTENT_SIZE=110000
+TEST_TAG="golden-s3-test-$$-$(date -u +%Y%m%dT%H%M%SZ)"
+
+# ---------------------------------------------------------------------------
+# Color support
+# ---------------------------------------------------------------------------
+if [ -t 1 ]; then
+    BOLD="\033[1m"
+    GREEN="\033[0;32m"
+    YELLOW="\033[0;33m"
+    RED="\033[0;31m"
+    CYAN="\033[0;36m"
+    RESET="\033[0m"
+else
+    BOLD="" GREEN="" YELLOW="" RED="" CYAN="" RESET=""
+fi
+
+banner() {
+    echo ""
+    echo -e "${BOLD}${CYAN}=========================================${RESET}"
+    echo -e "${BOLD}${CYAN}  $1${RESET}"
+    echo -e "${BOLD}${CYAN}=========================================${RESET}"
+}
+info()  { echo -e "  ${GREEN}→${RESET} $*"; }
+warn()  { echo -e "  ${YELLOW}!${RESET} $*"; }
+die()   { echo -e "  ${RED}✗${RESET} $*" >&2; exit 1; }
+
+# ---------------------------------------------------------------------------
+# Resolve memoryhub CLI
+# ---------------------------------------------------------------------------
+resolve_cli() {
+    if command -v memoryhub &>/dev/null; then
+        echo "memoryhub"
+    elif "$REPO_ROOT/.venv/bin/memoryhub" --version &>/dev/null 2>&1; then
+        echo "$REPO_ROOT/.venv/bin/memoryhub"
+    else
+        die "memoryhub CLI not found. Install with: pip install memoryhub-cli"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Write a >100KB test memory and verify it's S3-spilled
+# ---------------------------------------------------------------------------
+write_test_memory() {
+    local memoryhub_bin=$1
+
+    banner "1. Write S3-spilled test memory"
+
+    info "Generating ${TEST_CONTENT_SIZE}-byte test content..."
+    local content
+    content="[golden-s3-test ${TEST_TAG}] "
+    content+="This is a test memory for issue #395 — verifying that S3-spilled "
+    content+="content survives the --skip-data golden test. "
+    while [ ${#content} -lt "$TEST_CONTENT_SIZE" ]; do
+        content+="The quick brown fox jumps over the lazy dog. "
+    done
+    info "Content size: ${#content} bytes (threshold: 102400)"
+
+    info "Writing memory..."
+    local write_output
+    write_output=$(echo "$content" | $memoryhub_bin write --scope user --weight 0.1 -o json) || {
+        die "Write failed: $write_output"
+    }
+
+    local memory_id
+    memory_id=$(echo "$write_output" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+mem = (d.get('data') or {}).get('memory')
+if mem:
+    print(mem['id'])
+else:
+    cur = (d.get('data') or {}).get('curation') or {}
+    if cur.get('blocked'):
+        print('BLOCKED:' + (cur.get('reason') or 'unknown'), file=sys.stderr)
+        sys.exit(1)
+    print('')
+" 2>&1) || die "Write blocked by curation: $memory_id"
+
+    if [ -z "$memory_id" ]; then
+        die "Could not parse memory ID from write response"
+    fi
+
+    info "Written: $memory_id"
+
+    banner "2. Verify S3 spill"
+
+    info "Reading memory back to check storage type..."
+    local read_output
+    read_output=$($memoryhub_bin read "$memory_id" -o json) || {
+        die "Read failed"
+    }
+
+    local storage_type content_len
+    storage_type=$(echo "$read_output" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+mem = d.get('data', d)
+print(mem.get('storage_type', 'inline'))
+")
+    content_len=$(echo "$read_output" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+mem = d.get('data', d)
+c = mem.get('content') or ''
+print(len(c))
+")
+
+    if [ "$storage_type" = "s3" ]; then
+        info "Storage type: s3 (S3-spilled as expected)"
+    else
+        warn "Storage type: $storage_type (content_len=$content_len)"
+        warn "Memory may not be S3-spilled. If MinIO is not configured,"
+        warn "content is stored inline. The test can still verify data"
+        warn "survival but won't exercise the S3 spill path."
+    fi
+
+    echo "$memory_id"
+}
+
+# ---------------------------------------------------------------------------
+# Verify a memory is fully retrievable after golden test
+# ---------------------------------------------------------------------------
+verify_memory() {
+    local memoryhub_bin=$1
+    local memory_id=$2
+
+    banner "4. Verify memory retrieval after golden test"
+
+    info "Reading memory $memory_id..."
+    local read_output
+    read_output=$($memoryhub_bin read "$memory_id" -o json) || {
+        die "Read failed — memory may have been lost"
+    }
+
+    local content_len has_tag
+    content_len=$(echo "$read_output" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+mem = d.get('data', d)
+c = mem.get('content') or ''
+print(len(c))
+")
+    has_tag=$(echo "$read_output" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+mem = d.get('data', d)
+c = mem.get('content') or ''
+print('true' if 'golden-s3-test' in c else 'false')
+")
+
+    if [ "$has_tag" != "true" ]; then
+        die "Memory content does not contain test tag — content may be corrupted or truncated"
+    fi
+
+    if [ "$content_len" -lt "$TEST_CONTENT_SIZE" ]; then
+        die "Content length ($content_len) is less than expected ($TEST_CONTENT_SIZE) — content truncated"
+    fi
+
+    info "Content length: $content_len bytes (expected >= $TEST_CONTENT_SIZE)"
+    info "Test tag present: yes"
+
+    banner "5. Cleanup"
+
+    info "Deleting test memory $memory_id..."
+    $memoryhub_bin delete "$memory_id" -f -o quiet 2>/dev/null || warn "Delete failed (non-fatal)"
+    info "Cleanup complete"
+
+    echo ""
+    echo -e "  ${GREEN}${BOLD}PASS: S3-spilled memory survived the --skip-data golden test${RESET}"
+    echo ""
+}
+
+# ---------------------------------------------------------------------------
+# Run the full golden test cycle
+# ---------------------------------------------------------------------------
+run_golden_test() {
+    banner "3. Golden test: uninstall --skip-data && deploy"
+
+    warn "This will take the entire MemoryHub stack down and redeploy it."
+    warn "The --skip-data flag preserves both DB and storage namespaces."
+    echo ""
+
+    if [ -t 0 ]; then
+        read -r -p "  Continue? [y/N] " confirm
+        if [[ ! "$confirm" =~ ^[Yy]$ ]]; then
+            die "Aborted by user"
+        fi
+    fi
+
+    info "Running: uninstall-full.sh --skip-data --yes"
+    "$SCRIPT_DIR/uninstall-full.sh" --skip-data --yes || {
+        die "Uninstall failed"
+    }
+
+    info "Running: deploy-full.sh --skip-models --skip-smoke-test"
+    "$SCRIPT_DIR/deploy-full.sh" --skip-models --skip-smoke-test || {
+        die "Deploy failed"
+    }
+
+    info "Golden test cycle complete"
+}
+
+# ---------------------------------------------------------------------------
+# Parse args and run
+# ---------------------------------------------------------------------------
+MODE="full"
+VERIFY_MEMORY_ID=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --write-only)
+            MODE="write"
+            shift
+            ;;
+        --verify-only)
+            MODE="verify"
+            VERIFY_MEMORY_ID="${2:-}"
+            if [ -z "$VERIFY_MEMORY_ID" ]; then
+                die "--verify-only requires a memory ID argument"
+            fi
+            shift 2
+            ;;
+        -h|--help)
+            echo "Usage: $0 [--write-only] [--verify-only MEMORY_ID]"
+            echo ""
+            echo "  --write-only        Write test memory, print ID, exit"
+            echo "  --verify-only ID    Verify memory survived golden test"
+            echo "  (no flags)          Full cycle: write → uninstall → deploy → verify"
+            exit 0
+            ;;
+        *)
+            die "Unknown argument: $1"
+            ;;
+    esac
+done
+
+MEMORYHUB_BIN=$(resolve_cli)
+info "Using CLI: $MEMORYHUB_BIN"
+
+case "$MODE" in
+    write)
+        MEMORY_ID=$(write_test_memory "$MEMORYHUB_BIN" | tail -1)
+        echo ""
+        echo "Memory ID: $MEMORY_ID"
+        echo ""
+        echo "Next steps:"
+        echo "  1. Run the golden test: scripts/uninstall-full.sh --skip-data --yes && scripts/deploy-full.sh"
+        echo "  2. Verify:              scripts/test-golden-s3.sh --verify-only $MEMORY_ID"
+        ;;
+    verify)
+        verify_memory "$MEMORYHUB_BIN" "$VERIFY_MEMORY_ID"
+        ;;
+    full)
+        MEMORY_ID=$(write_test_memory "$MEMORYHUB_BIN" | tail -1)
+        run_golden_test
+        verify_memory "$MEMORYHUB_BIN" "$MEMORY_ID"
+        ;;
+esac

--- a/scripts/test-golden-s3.sh
+++ b/scripts/test-golden-s3.sh
@@ -79,8 +79,10 @@ write_test_memory() {
     content="[golden-s3-test ${TEST_TAG}] "
     content+="This is a test memory for issue #395 — verifying that S3-spilled "
     content+="content survives the --skip-data golden test. "
+    local line_num=0
     while [ ${#content} -lt "$TEST_CONTENT_SIZE" ]; do
-        content+="The quick brown fox jumps over the lazy dog. "
+        content+="[${TEST_TAG} line ${line_num}] The quick brown fox jumps over the lazy dog. "
+        line_num=$((line_num + 1))
     done
     info "Content size: ${#content} bytes (threshold: 102400)"
 
@@ -161,31 +163,36 @@ verify_memory() {
         die "Read failed — memory may have been lost"
     }
 
-    local content_len has_tag
-    content_len=$(echo "$read_output" | python3 -c "
+    local has_tag storage_type full_available
+    eval "$(echo "$read_output" | python3 -c "
 import json, sys
 d = json.load(sys.stdin)
 mem = d.get('data', d)
 c = mem.get('content') or ''
-print(len(c))
-")
-    has_tag=$(echo "$read_output" | python3 -c "
-import json, sys
-d = json.load(sys.stdin)
-mem = d.get('data', d)
-c = mem.get('content') or ''
-print('true' if 'golden-s3-test' in c else 'false')
-")
+print(f'has_tag={\"true\" if \"golden-s3-test\" in c else \"false\"}')
+print(f'storage_type={mem.get(\"storage_type\", \"inline\")}')
+print(f'full_available={str(mem.get(\"full_available\", False)).lower()}')
+print(f'content_len={len(c)}')
+")"
 
     if [ "$has_tag" != "true" ]; then
         die "Memory content does not contain test tag — content may be corrupted or truncated"
     fi
 
-    if [ "$content_len" -lt "$TEST_CONTENT_SIZE" ]; then
-        die "Content length ($content_len) is less than expected ($TEST_CONTENT_SIZE) — content truncated"
+    if [ "$storage_type" = "s3" ]; then
+        info "Storage type: s3 (S3-spilled)"
+        if [ "$full_available" = "true" ]; then
+            info "Full content available: yes (S3 object intact)"
+        else
+            die "S3-spilled memory exists but full content NOT available — S3 data may be lost"
+        fi
+    else
+        if [ "$content_len" -lt "$TEST_CONTENT_SIZE" ]; then
+            die "Inline content length ($content_len) is less than expected ($TEST_CONTENT_SIZE)"
+        fi
+        info "Storage type: inline (content_len=$content_len)"
     fi
 
-    info "Content length: $content_len bytes (expected >= $TEST_CONTENT_SIZE)"
     info "Test tag present: yes"
 
     banner "5. Cleanup"

--- a/scripts/uninstall-full.sh
+++ b/scripts/uninstall-full.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 # WARNING: This script is destructive. It removes all MemoryHub
 # resources, including the database and all stored memories.
-# Use --skip-db to preserve the database.
+# Use --skip-db to preserve the database, --skip-data to preserve both
+# the database and object storage.
 #
 # CREDENTIAL DRIFT: When the DB namespace is deleted and recreated,
 # deploy-full.sh generates a new random password for memoryhub-pg-credentials.
@@ -12,7 +13,7 @@
 # also reads from the DB namespace, so credentials stay in sync even without
 # deploy-full.sh.
 #
-# Usage: scripts/uninstall-full.sh [--yes] [--skip-db] [--skip-tile] [--skip-models] [--no-backup]
+# Usage: scripts/uninstall-full.sh [--yes] [--skip-db] [--skip-data] [--skip-tile] [--skip-models] [--no-backup]
 set -euo pipefail
 
 SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}")"
@@ -25,9 +26,11 @@ UI_NAMESPACE="memoryhub-ui"
 RHOAI_NAMESPACE="redhat-ods-applications"
 EMBEDDING_MODEL_NAMESPACE="embedding-model"
 RERANKER_MODEL_NAMESPACE="reranker-model"
+STORAGE_NAMESPACE="memoryhub-storage"
 
 YES=false
 SKIP_DB=false
+SKIP_STORAGE=false
 SKIP_TILE=false
 SKIP_MODELS=false
 NO_BACKUP=false
@@ -77,14 +80,16 @@ parse_args() {
         case "$arg" in
             --yes)        YES=true ;;
             --skip-db)    SKIP_DB=true ;;
+            --skip-data)  SKIP_DB=true; SKIP_STORAGE=true ;;
             --skip-tile)  SKIP_TILE=true ;;
             --skip-models) SKIP_MODELS=true ;;
             --no-backup)  NO_BACKUP=true ;;
             -h|--help)
-                echo "Usage: $SCRIPT_NAME [--yes] [--skip-db] [--skip-tile] [--skip-models] [--no-backup]"
+                echo "Usage: $SCRIPT_NAME [--yes] [--skip-db] [--skip-data] [--skip-tile] [--skip-models] [--no-backup]"
                 echo ""
                 echo "  --yes           Skip all confirmation prompts (non-interactive / CI mode)"
                 echo "  --skip-db       Preserve the database namespace and its PVC (no memory loss)"
+                echo "  --skip-data     Preserve BOTH database AND object storage (no data loss)"
                 echo "  --skip-tile     Leave RHOAI tile artifacts in redhat-ods-applications"
                 echo "  --skip-models   Preserve embedding + reranker model namespaces"
                 echo "  --no-backup     Skip automatic pre-uninstall database backup"
@@ -136,7 +141,12 @@ confirm() {
     echo "      - ImageStream/memoryhub-ui"
     echo "      - BuildConfig/memoryhub-ui"
     echo "      - ServiceAccount/memoryhub-ui"
-    echo "    Namespace: $MCP_PROJECT  (MCP server + MinIO + Valkey)"
+    echo "    Namespace: $MCP_PROJECT  (MCP server + Valkey)"
+    if [ "$SKIP_STORAGE" = true ]; then
+        echo "    Object storage: PRESERVED  (--skip-data)"
+    else
+        echo "    Namespace: $STORAGE_NAMESPACE  (MinIO object storage — S3-SPILLED DATA LOSS)"
+    fi
     if [ "$SKIP_MODELS" = true ]; then
         echo "    Models: PRESERVED  (--skip-models)"
     else
@@ -322,6 +332,26 @@ remove_mcp_namespace() {
 }
 
 # ---------------------------------------------------------------------------
+# Step 4a: Storage namespace
+# ---------------------------------------------------------------------------
+remove_storage_namespace() {
+    banner "4a. Storage Namespace ($STORAGE_NAMESPACE)"
+
+    if [ "$SKIP_STORAGE" = true ]; then
+        skipped "Storage namespace (--skip-data). S3-spilled content preserved."
+        return 0
+    fi
+
+    warn "Deleting $STORAGE_NAMESPACE — S3-SPILLED MEMORY CONTENT WILL BE LOST."
+    oc delete namespace --context "$CONTEXT" "$STORAGE_NAMESPACE" \
+        --ignore-not-found \
+        --wait=false
+
+    echo ""
+    echo -e "  ${GREEN}Namespace $STORAGE_NAMESPACE deletion initiated${RESET}"
+}
+
+# ---------------------------------------------------------------------------
 # Step 4b: Model namespaces
 # ---------------------------------------------------------------------------
 remove_model_namespaces() {
@@ -402,6 +432,11 @@ summary() {
     echo "    ${GREEN}✓${RESET} Namespace $UI_NAMESPACE"
     echo "    ${GREEN}✓${RESET} Legacy UI artifacts in $MCP_PROJECT"
     echo "    ${GREEN}✓${RESET} Namespace $MCP_PROJECT"
+    if [ "$SKIP_STORAGE" = false ]; then
+        echo "    ${GREEN}✓${RESET} Namespace $STORAGE_NAMESPACE (S3 data deleted)"
+    else
+        echo "    ${YELLOW}-${RESET} Namespace $STORAGE_NAMESPACE (preserved)"
+    fi
     if [ "$SKIP_MODELS" = false ]; then
         echo "    ${GREEN}✓${RESET} Namespace $EMBEDDING_MODEL_NAMESPACE"
         echo "    ${GREEN}✓${RESET} Namespace $RERANKER_MODEL_NAMESPACE"
@@ -439,6 +474,7 @@ main() {
     remove_ui_namespace
     remove_legacy_ui
     remove_mcp_namespace
+    remove_storage_namespace
     remove_model_namespaces
     remove_auth_namespace
     remove_db_namespace

--- a/scripts/uninstall-full.sh
+++ b/scripts/uninstall-full.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 # WARNING: This script is destructive. It removes all MemoryHub
 # resources, including the database and all stored memories.
-# Use --skip-db to preserve the database, --skip-data to preserve both
-# the database and object storage.
+# Use --skip-data to preserve the database and object storage.
+# (--skip-db is a deprecated alias for --skip-data.)
 #
 # CREDENTIAL DRIFT: When the DB namespace is deleted and recreated,
 # deploy-full.sh generates a new random password for memoryhub-pg-credentials.
@@ -29,8 +29,7 @@ RERANKER_MODEL_NAMESPACE="reranker-model"
 STORAGE_NAMESPACE="memoryhub-storage"
 
 YES=false
-SKIP_DB=false
-SKIP_STORAGE=false
+SKIP_DATA=false
 SKIP_TILE=false
 SKIP_MODELS=false
 NO_BACKUP=false
@@ -79,8 +78,8 @@ parse_args() {
     for arg in "$@"; do
         case "$arg" in
             --yes)        YES=true ;;
-            --skip-db)    SKIP_DB=true ;;
-            --skip-data)  SKIP_DB=true; SKIP_STORAGE=true ;;
+            --skip-data)  SKIP_DATA=true ;;
+            --skip-db)    SKIP_DATA=true ;;
             --skip-tile)  SKIP_TILE=true ;;
             --skip-models) SKIP_MODELS=true ;;
             --no-backup)  NO_BACKUP=true ;;
@@ -88,8 +87,8 @@ parse_args() {
                 echo "Usage: $SCRIPT_NAME [--yes] [--skip-db] [--skip-data] [--skip-tile] [--skip-models] [--no-backup]"
                 echo ""
                 echo "  --yes           Skip all confirmation prompts (non-interactive / CI mode)"
-                echo "  --skip-db       Preserve the database namespace and its PVC (no memory loss)"
-                echo "  --skip-data     Preserve BOTH database AND object storage (no data loss)"
+                echo "  --skip-data     Preserve database AND object storage namespaces (no data loss)"
+                echo "  --skip-db       Deprecated alias for --skip-data"
                 echo "  --skip-tile     Leave RHOAI tile artifacts in redhat-ods-applications"
                 echo "  --skip-models   Preserve embedding + reranker model namespaces"
                 echo "  --no-backup     Skip automatic pre-uninstall database backup"
@@ -142,7 +141,7 @@ confirm() {
     echo "      - BuildConfig/memoryhub-ui"
     echo "      - ServiceAccount/memoryhub-ui"
     echo "    Namespace: $MCP_PROJECT  (MCP server + Valkey)"
-    if [ "$SKIP_STORAGE" = true ]; then
+    if [ "$SKIP_DATA" = true ]; then
         echo "    Object storage: PRESERVED  (--skip-data)"
     else
         echo "    Namespace: $STORAGE_NAMESPACE  (MinIO object storage — S3-SPILLED DATA LOSS)"
@@ -154,8 +153,8 @@ confirm() {
         echo "    Namespace: $RERANKER_MODEL_NAMESPACE  (Reranker model)"
     fi
     echo "    Namespace: $AUTH_PROJECT  (Auth server)"
-    if [ "$SKIP_DB" = true ]; then
-        echo "    Database: PRESERVED  (--skip-db)"
+    if [ "$SKIP_DATA" = true ]; then
+        echo "    Database: PRESERVED  (--skip-data)"
     else
         echo "    Namespace: $DB_NAMESPACE  (PostgreSQL + ALL STORED MEMORIES — DATA LOSS)"
     fi
@@ -179,7 +178,7 @@ confirm() {
 # ---------------------------------------------------------------------------
 backup_before_uninstall() {
     # Skip backup when DB is preserved (no data loss) or explicitly opted out.
-    if [ "$SKIP_DB" = true ]; then
+    if [ "$SKIP_DATA" = true ]; then
         return 0
     fi
     if [ "$NO_BACKUP" = true ]; then
@@ -337,7 +336,7 @@ remove_mcp_namespace() {
 remove_storage_namespace() {
     banner "4a. Storage Namespace ($STORAGE_NAMESPACE)"
 
-    if [ "$SKIP_STORAGE" = true ]; then
+    if [ "$SKIP_DATA" = true ]; then
         skipped "Storage namespace (--skip-data). S3-spilled content preserved."
         return 0
     fi
@@ -397,8 +396,8 @@ remove_auth_namespace() {
 remove_db_namespace() {
     banner "6. Database Namespace ($DB_NAMESPACE)"
 
-    if [ "$SKIP_DB" = true ]; then
-        skipped "Database namespace (--skip-db). Stored memories preserved."
+    if [ "$SKIP_DATA" = true ]; then
+        skipped "Database namespace (--skip-data). Stored memories preserved."
         return 0
     fi
 
@@ -432,7 +431,7 @@ summary() {
     echo "    ${GREEN}✓${RESET} Namespace $UI_NAMESPACE"
     echo "    ${GREEN}✓${RESET} Legacy UI artifacts in $MCP_PROJECT"
     echo "    ${GREEN}✓${RESET} Namespace $MCP_PROJECT"
-    if [ "$SKIP_STORAGE" = false ]; then
+    if [ "$SKIP_DATA" = false ]; then
         echo "    ${GREEN}✓${RESET} Namespace $STORAGE_NAMESPACE (S3 data deleted)"
     else
         echo "    ${YELLOW}-${RESET} Namespace $STORAGE_NAMESPACE (preserved)"
@@ -444,7 +443,7 @@ summary() {
         echo "    ${YELLOW}-${RESET} Model namespaces (skipped)"
     fi
     echo "    ${GREEN}✓${RESET} Namespace $AUTH_PROJECT"
-    if [ "$SKIP_DB" = false ]; then
+    if [ "$SKIP_DATA" = false ]; then
         echo "    ${GREEN}✓${RESET} Namespace $DB_NAMESPACE (data deleted)"
     else
         echo "    ${YELLOW}-${RESET} Namespace $DB_NAMESPACE (preserved)"


### PR DESCRIPTION
## Summary

Move MinIO to a dedicated `memoryhub-storage` namespace so S3-spilled content survives the preserve-data golden test (`uninstall --skip-data && deploy`). Previously MinIO lived in `memory-hub-mcp`, which was unconditionally deleted on uninstall — any memory >100KB had content pointers to S3 keys that no longer existed. Also unifies `--skip-db` and `--skip-storage` into a single `--skip-data` flag and adds a scripted acceptance test.

## Linked issues

Closes #395

## Design reference

- `docs/ARCHITECTURE.md` (updated — seven-namespace topology, MinIO moved to `memoryhub-storage`)
- `docs/SYSTEMS.md` (updated — new namespace row)

## Type of change

- [ ] `type:feature` — new user-visible capability
- [ ] `type:bug` — fix for incorrect behavior
- [x] `type:infra` — build, CI, deploy, or tooling change
- [ ] `type:design` — design doc only, no code

## Subsystem

- [ ] `memory-tree`
- [x] `storage`
- [ ] `curator`
- [ ] `governance`
- [ ] `mcp-server`
- [ ] `operator`
- [ ] `observability`
- [ ] `org-ingestion`
- [ ] `auth`
- [ ] `ui`
- [ ] `llamastack`

## Changes

**Namespace isolation (`79e90fe`)**
- New `deploy/minio/namespace.yaml` creates `memoryhub-storage`
- `deploy/minio/kustomization.yaml` targets `memoryhub-storage` instead of `memory-hub-mcp`
- Cross-namespace FQDN (`memoryhub-minio.memoryhub-storage.svc.cluster.local:9000`) in MCP deploy manifests and retention cronjob
- `deploy-full.sh`: split `deploy_infra()` into `deploy_storage()` + `deploy_valkey()`, copy MinIO credentials cross-namespace
- `uninstall-full.sh`: new `remove_storage_namespace()` with `--skip-data` guard

**Flag unification (`75c7a05`)**
- `--skip-data` is the canonical flag in both scripts (sets single `SKIP_DATA` variable)
- `--skip-db` is a deprecated alias (identical behavior)
- Removed standalone `--skip-storage` flag — no scenario exists where preserving MinIO without DB makes sense

**Acceptance test (`75c7a05`, `1a50fa3`, `2b70dcf`)**
- `scripts/test-golden-s3-preserve.sh`: scripted exit predicate for #395
- Three modes: `--write-only`, `--verify-only <ID>`, full cycle
- Verifies `storage_type: s3` and `full_available: true` after preserve-data golden test
- EXIT trap cleans up test memory on failure (prevents orphans)
- Waits for namespace termination before reinstall

**Known blockers for the acceptance test (pre-existing, not introduced here):**
- #511 — `embedding_max_tokens` config mismatch requires `MEMORYHUB_EMBEDDING_MAX_TOKENS=500000` workaround
- #512 — `logical_id` NOT NULL violation prevents chunking (bypassed by the workaround above)
- #518 — UI deploy script hard-fails without RHOAI (test uses `--skip-ui`)

## Test plan

- [ ] **Unit tests only** — no infrastructure boundaries touched
- [ ] **Integration tests included for:**
- [x] **Integration tests deferred because:**
      This is an infrastructure change to deploy/uninstall scripts and K8s manifests. The acceptance test (`test-golden-s3-preserve.sh`) exercises the real cluster. Python tests are unaffected (they mock S3 with localhost).

- [ ] `pytest` passes locally (or the affected subset)
- [x] Manual verification against a running cluster (if applicable)
- [x] New tests added for new behavior

**Cluster verification performed:**
1. Wrote >110KB memory via CLI → confirmed `storage_type: s3`
2. Ran `uninstall-full.sh --skip-data --yes` → `memoryhub-db` and `memoryhub-storage` namespaces preserved
3. Ran `deploy-full.sh` → stack reconnected to preserved data
4. Ran `test-golden-s3-preserve.sh --verify-only <ID>` → PASS: S3 content intact, `full_available: true`

## Reviewer checklist

- [x] Design doc referenced or created
- [x] No committed credentials or cluster-specific URLs
- [x] CLAUDE.md / docs updated if behavior or conventions changed
- [x] Commit message follows `subsystem: Imperative summary` format