### PR TITLE
planning: Refresh stakeholder issues and add milestones roadmap

### DIFF
--- a/planning/milestones-roadmap.md
+++ b/planning/milestones-roadmap.md
@@ -1,0 +1,338 @@
+# MemoryHub Milestones Roadmap
+
+*Updated 2026-08-12*
+
+## Overview
+
+MemoryHub's work is organized into six milestones that sequence the path from reliable retrieval through platform maturity. Each milestone gates on the one before it: you can't curate what you can't retrieve, and you can't integrate what you haven't curated. Fifty issues are open across the backlog; 30 have been closed.
+
+| Milestone | Progress | Status |
+|-----------|----------|--------|
+| v0.2 - Retrieval Quality | 5/8 (63%) | In progress |
+| v0.3 - Multi-Harness & Onboarding | 1/6 (17%) | In progress |
+| v0.4 - Curation & Governance | 10/16 (63%) | In progress |
+| v0.5 - Platform Integrations | 8/9 (89%) | Nearly complete |
+| v0.6 - UI & Dashboard | 6/6 (100%) | Complete |
+| Unassigned | 37 open | Needs triage |
+
+---
+
+## v0.2 - Retrieval Quality (5/8 complete)
+
+What this delivers: The foundation -- search results that are accurate, fast, and trustworthy enough to build agent workflows on.
+
+### Completed
+
+- #311 -- Default content_type for memory writes
+- #305 -- Keyword and hybrid search
+- #304 -- Benchmark retrieval accuracy
+- #271 -- Retrieval latency at scale
+- #41 -- Structured event logging
+
+### Remaining
+
+| Issue | Title | Blocker? |
+|-------|-------|----------|
+| #272 | Measure entity extraction throughput | No -- independent measurement work |
+| #273 | Graph-traversal vs flat vector search comparison | No -- but answers "why not just pgvector?" for marketing |
+| #306 | Time-decay recency bias in search scoring | No -- scoring refinement |
+
+### What blocks completion
+
+Nothing blocks the remaining three issues from each other. They are independent work items that require benchmark infrastructure and scoring changes. #273 has marketing implications (the "why not just pgvector?" question) but is technically straightforward.
+
+---
+
+## v0.3 - Multi-Harness & Onboarding (1/6 complete)
+
+What this delivers: MemoryHub works beyond Claude Code -- framework-agnostic onboarding, turn-level hooks, and at least two additional agent harness integrations.
+
+### Completed
+
+- #307 -- IDE auto-save hooks
+
+### Remaining
+
+| Issue | Title | Blocker? |
+|-------|-------|----------|
+| #310 | Framework-agnostic agent onboarding | Yes -- gates all harness integrations; needs-design |
+| #312 | Multi-harness support (tracking) | Depends on #310 |
+| #313 | Turn-level hooks (automatic rebias and extraction) | Independent |
+| #489 | OpenClaw integration | Depends on #310 |
+| #509 | OpenCode integration | Depends on #310 |
+
+### What blocks completion
+
+#310 is the critical path. It requires a design document (flagged needs-design) before implementation can start. Every harness integration (#489, #509) and the tracking system (#312) depend on the framework-agnostic onboarding pattern it defines. #313 (turn-level hooks) is independent and could land in parallel.
+
+Note: OpenClaw has three open bugs (#494, #495, #496) that are unassigned but will need fixing alongside the v0.3 integration work.
+
+---
+
+## v0.4 - Curation & Governance (10/16 complete)
+
+What this delivers: Memory doesn't just accumulate -- it gets curated, promoted, audited, and governed. This is the milestone that separates MemoryHub from a dumb vector store.
+
+### Completed
+
+- #291 -- Training data collection
+- #285 -- Curator Agent
+- #281 -- Epic tracker
+- #277 -- Audit trail schema
+- #171 -- Knowledge compilation design
+- #169 -- Context compaction design
+- #92 -- Emergency-response patterns
+- #91 -- Agriculture patterns
+- #90 -- Public-safety patterns
+- #89 -- Cybersecurity patterns
+
+### Remaining
+
+| Issue | Title | Blocker? |
+|-------|-------|----------|
+| #40 | Curation rule versioning and edit tracking | No |
+| #68 | HIPAA/PHI detection in curation pipeline | No -- but hard gate for healthcare customers |
+| #70 | Persist audit log to durable store | Yes -- blocks #71 (intersection auth); table stakes for regulated customers |
+| #239 | Convergent learning (consolidate duplicates across users) | No -- future |
+| #289 | Statistician Agent (population-level patterns) | No |
+| #290 | Five-stage promotion pipeline | No |
+
+### What blocks completion
+
+#70 (durable audit log) is the most critical: it's table stakes for regulated customers and blocks intersection authorization (#71). #68 (HIPAA/PHI detection) is a hard gate for healthcare verticals. The remaining items are independent features that can land in any order.
+
+---
+
+## v0.5 - Platform Integrations (8/9 complete)
+
+What this delivers: MemoryHub integrates with external agent platforms (LlamaStack, Kagenti, fips-agents).
+
+### Completed
+
+- #309 -- fips-agents OGX demo
+- #33 -- LlamaStack Phase 3
+- #32 -- LlamaStack Phase 2
+- #31 -- LlamaStack Phase 1
+- #30 -- Kagenti Phase 3
+- #29 -- Kagenti Phase 2
+- #28 -- Kagenti Phase 1
+- #27 -- LlamaStack integration
+
+### Remaining
+
+| Issue | Title | Blocker? |
+|-------|-------|----------|
+| #82 | LibreChat integration | No -- standalone integration work |
+
+### What blocks completion
+
+Only #82 remains. LibreChat integration is self-contained and doesn't depend on other milestones.
+
+---
+
+## v0.6 - UI & Dashboard (COMPLETE)
+
+All 6 issues closed. The UI and dashboard milestone is fully delivered.
+
+---
+
+## Proposed: Unassigned Issue Triage
+
+37 open issues have no milestone. Grouped by theme with triage recommendations:
+
+### Retrieval and search improvements (7 issues)
+
+| Issue | Title | Recommended milestone |
+|-------|-------|----------------------|
+| #389 | S3 hydration for large-content tail | v0.2 -- retrieval quality |
+| #397 | Hard-stop mode (truncate vs stubs) | v0.2 -- retrieval quality |
+| #404 | Effective-k observability (**Bug**) | v0.2 -- retrieval quality |
+| #453 | Reimplement disabled_signals | Defer -- future |
+| #454 | Reimplement entity-aware search | Defer -- future |
+| #511 | embedding_max_tokens config mismatch (**Bug**) | Unblocked -- fix independently |
+| #270 | Semantic search over conversation threads | Defer -- future |
+
+### Curation and memory hygiene (7 issues)
+
+| Issue | Title | Recommended milestone |
+|-------|-------|----------------------|
+| #350 | Curator scaffold | v0.4 -- blocks #352, #353 |
+| #351 | Labeled dedup pair set | v0.4 -- blocks #352 |
+| #352 | Deep-dedup sweep | v0.4 -- depends on #350, #351 |
+| #353 | Staleness sweep | v0.4 -- depends on #350 |
+| #345 | Provenance-driven reflection (Layer 3) | v0.4 -- curation |
+| #346 | Domain ontology refinement | v0.4 -- curation |
+| #512 | Chunk/fact node creation fails (**Bug**) | Unblocked -- fix independently |
+
+### Agent resilience and sessions (4 issues)
+
+| Issue | Title | Recommended milestone |
+|-------|-------|----------------------|
+| #491 | Memory rewind/rollback | Needs design first |
+| #104 | Persist session state across pod restarts | v0.3 -- onboarding quality |
+| #431 | Session-close memory capture | v0.3 -- hooks |
+| #87 | Typed SDK push notifications | Defer -- future |
+
+### CLI, SDK, and developer tooling (5 issues)
+
+| Issue | Title | Recommended milestone |
+|-------|-------|----------------------|
+| #492 | Per-project identity selection | v0.3 -- developer experience |
+| #493 | delete-agent command | v0.3 -- depends on #492 |
+| #497 | Surface last_updated_by | v0.3 -- depends on #492 |
+| #458 | create-agent table output omits api_key (**Bug**) | Unblocked -- fix independently |
+| #459 | Add rotate-api-key subcommand | v0.3 -- developer experience |
+
+### Benchmarks and evaluation (6 issues)
+
+| Issue | Title | Recommended milestone |
+|-------|-------|----------------------|
+| #330 | LongMemEval_S full-haystack | v0.2 -- validates retrieval |
+| #331 | Answer-quality with LLM judge | v0.2 -- depends on #330 |
+| #370 | Ablation Matrix B | Post-v0.2 |
+| #400 | Evaluate AutoRAG | Post-v0.2 |
+| #334 | Adversarial write resistance | v0.4 -- governance |
+| #337 | Platform-level benchmark design | v0.4 -- depends on #334 |
+
+### Security and authorization (3 issues)
+
+| Issue | Title | Recommended milestone |
+|-------|-------|----------------------|
+| #514 | Validate project membership in list/search (**Bug**) | Unblocked -- security fix, high priority |
+| #71 | Intersection authorization | Defer -- depends on #70 (v0.4) |
+| #72 | driver_id redaction | Defer -- future |
+
+### Compliance (Trust Bricks) (2 issues)
+
+| Issue | Title | Recommended milestone |
+|-------|-------|----------------------|
+| #516 | PTC-aligned provenance and taint metadata | v0.4 -- governance |
+| #517 | GAL-aligned memory trust lifecycle | v0.4 -- governance |
+
+### Competitive analysis (2 issues)
+
+| Issue | Title | Recommended milestone |
+|-------|-------|----------------------|
+| #505 | Create test deployment of Hindsight | Stay unassigned -- research/spike |
+| #506 | Create test deployment of GBrain | Stay unassigned -- research/spike |
+
+### Marketing and design (2 issues)
+
+| Issue | Title | Recommended milestone |
+|-------|-------|----------------------|
+| #507 | Demo: quantitative benefits of memory sharing | Stay unassigned until design exists |
+| #508 | "Building the case for agent memory" design doc | Stay unassigned -- planning |
+
+### Infrastructure and bugs (4 issues)
+
+| Issue | Title | Recommended milestone |
+|-------|-------|----------------------|
+| #375 | Full local test suite hang (**Bug**) | Unblocked -- fix independently |
+| #395 | MinIO content doesn't survive uninstall (**Bug**) | Unblocked -- fix independently |
+| #383 | Capability-claim sweep | Post-milestone -- meta-task |
+| #241 | Evaluate pluggable storage backend | Defer -- future |
+
+### Client bugs (OpenClaw) (3 issues)
+
+| Issue | Title | Recommended milestone |
+|-------|-------|----------------------|
+| #494 | OpenClaw: scope/project_id placement (**Bug**) | v0.3 -- client bugs |
+| #495 | OpenClaw: connection leak (**Bug**) | v0.3 -- client bugs |
+| #496 | OpenClaw: remove as-never casts (**Bug**) | v0.3 -- client bugs |
+
+### Other (1 issue)
+
+| Issue | Title | Recommended milestone |
+|-------|-------|----------------------|
+| #426 | EvalHub sidecar result-drain retry | Stay unassigned -- infra improvement |
+| #518 | UI deploy script hard-fails without RHOAI (**Bug**) | Unblocked -- fix independently |
+
+### Highest-priority unassigned items
+
+1. **#514** -- Authorization bug allowing cross-project memory access. Security issue, should be fixed immediately.
+2. **#511** -- Embedding config mismatch blocks writes. Breaks basic functionality on CPU deployments.
+3. **#512** -- Chunk/fact node creation completely non-functional. Foundational storage bug.
+4. **#404** -- Effective-k silent capping. Agent silently gets fewer results than requested.
+5. **#395** -- MinIO data loss on reinstall. Data integrity risk.
+
+---
+
+## Critical Path
+
+### Dependency chains that span milestones
+
+```
+v0.2                              v0.4
+#330 LongMemEval full-haystack ──► #331 answer-quality with judge
+
+v0.4 (internal chain)
+#350 Curator scaffold ──► #352 Deep-dedup sweep
+#351 Labeled dedup set ──► #352
+#350 ──────────────────► #353 Staleness sweep
+
+v0.4 → future
+#334 Adversarial resistance ──► #337 Platform benchmark
+#70 Durable audit log ──────► #71 Intersection authorization
+
+Developer tooling (unassigned chain)
+#492 Identity selection ──► #493 delete-agent
+                       └──► #497 last_updated_by
+```
+
+### Sequencing priorities
+
+1. **Fix security and storage bugs first** (#514, #511, #512) -- these undermine trust in the deployed system regardless of milestone work.
+
+2. **Close v0.5** -- only #82 (LibreChat) remains. Getting a milestone to 100% is a marketing win and removes tracking overhead.
+
+3. **Close v0.2** -- three independent issues remain (#272, #273, #306). All are scoped and unblocked. Add #330/#331 (LongMemEval) and #404 (effective-k bug) for a stronger completion story.
+
+4. **Design-gate v0.3** -- #310 (framework-agnostic onboarding) needs a design document before implementation. Start design work now so v0.3 implementation can begin once v0.2 wraps.
+
+5. **Advance v0.4 curation chain** -- #350 (Curator scaffold) blocks two high-leverage features (#352 dedup, #353 staleness). This is the longest dependency chain in the backlog.
+
+### Key blockers across milestones
+
+| Blocker | What it blocks | Impact |
+|---------|---------------|--------|
+| #310 needs-design | All v0.3 harness integrations | Can't onboard OpenClaw, OpenCode, or any new harness |
+| #350 Curator scaffold | #352 dedup, #353 staleness | Memory quality degrades as store grows |
+| #330 LongMemEval run | #331 answer-quality eval | No provable retrieval quality claims |
+| #334 Adversarial resistance | #337 Platform benchmark | No security benchmark story |
+| #70 Durable audit log | #71 Intersection auth | No audit trail for regulated customers |
+
+---
+
+## Bug Triage
+
+11 open bugs across the backlog, ordered by severity:
+
+### Critical (security or data integrity)
+
+| Issue | Title | Milestone | Assessment |
+|-------|-------|-----------|------------|
+| #514 | Project membership not validated in list/search | Unassigned | **Security** -- callers can see memories in projects they don't belong to. Fix immediately. |
+| #395 | MinIO content lost on uninstall --skip-db | Unassigned | **Data loss** -- object storage silently lost during what should be a safe reinstall. |
+| #512 | Chunk/fact node creation fails (logical_id NOT NULL) | Unassigned | **Feature non-functional** -- chunk and fact nodes have never worked. Zero rows exist. |
+| #511 | embedding_max_tokens config mismatch | Unassigned | **Write failures** -- memories over ~1000 chars fail with HTTP 413 on CPU embedding model. |
+
+### High (degrades developer or agent experience)
+
+| Issue | Title | Milestone | Assessment |
+|-------|-------|-----------|------------|
+| #404 | Effective-k silent capping | Unassigned | Agent silently gets fewer results than requested. Hard to diagnose. |
+| #375 | Full local test suite hang | Unassigned | Developers stop running tests. Corrosive to code quality. |
+| #518 | UI deploy script fails without RHOAI | Unassigned | Blocks UI deployment on clusters without RHOAI installed. |
+
+### Medium (papercuts and client bugs)
+
+| Issue | Title | Milestone | Assessment |
+|-------|-------|-----------|------------|
+| #494 | OpenClaw: scope/project_id placement | Unassigned | Client-side bug; blocks correct OpenClaw usage. |
+| #495 | OpenClaw: connection leak in resetSession | Unassigned | Resource leak; may cause issues under load. |
+| #496 | OpenClaw: remove as-never casts | Unassigned | Code quality; TypeScript type safety gap. |
+| #458 | create-agent output omits api_key | Unassigned | Papercut; user can't see the key they just created. |
+
+### Bugs that block milestone completion
+
+None of the 11 bugs are assigned to milestones, so none technically block milestone completion. However, #514 (authorization bypass) and #511/#512 (storage bugs) should be fixed before claiming any milestone is production-ready, since they undermine the system's reliability and security regardless of feature completeness.

--- a/planning/milestones-roadmap.md
+++ b/planning/milestones-roadmap.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-MemoryHub's work is organized into six milestones that sequence the path from reliable retrieval through platform maturity. Each milestone gates on the one before it: you can't curate what you can't retrieve, and you can't integrate what you haven't curated. Fifty issues are open across the backlog; 30 have been closed.
+MemoryHub's work is organized into six milestones that sequence the path from reliable retrieval through platform maturity. Each milestone gates on the one before it: you can't curate what you can't retrieve, and you can't integrate what you haven't curated. Sixty-two issues are open across the backlog; 30 have been closed across milestones.
 
 | Milestone | Progress | Status |
 |-----------|----------|--------|
@@ -13,7 +13,7 @@ MemoryHub's work is organized into six milestones that sequence the path from re
 | v0.4 - Curation & Governance | 10/16 (63%) | In progress |
 | v0.5 - Platform Integrations | 8/9 (89%) | Nearly complete |
 | v0.6 - UI & Dashboard | 6/6 (100%) | Complete |
-| Unassigned | 37 open | Needs triage |
+| Unassigned | 47 open | Needs triage |
 
 ---
 
@@ -138,7 +138,7 @@ All 6 issues closed. The UI and dashboard milestone is fully delivered.
 
 ## Proposed: Unassigned Issue Triage
 
-37 open issues have no milestone. Grouped by theme with triage recommendations:
+47 open issues have no milestone. Grouped by theme with triage recommendations:
 
 ### Retrieval and search improvements (7 issues)
 
@@ -240,7 +240,7 @@ All 6 issues closed. The UI and dashboard milestone is fully delivered.
 | #495 | OpenClaw: connection leak (**Bug**) | v0.3 -- client bugs |
 | #496 | OpenClaw: remove as-never casts (**Bug**) | v0.3 -- client bugs |
 
-### Other (1 issue)
+### Other (2 issues)
 
 | Issue | Title | Recommended milestone |
 |-------|-------|----------------------|

--- a/planning/open-issues-by-stakeholder.md
+++ b/planning/open-issues-by-stakeholder.md
@@ -1,6 +1,6 @@
 # MemoryHub Open Issues by Stakeholder Dimension
 
-*Generated 2026-08-05 -- 51 open issues*
+*Updated 2026-08-12 -- 50 open issues*
 
 This document arranges the open issue backlog by who cares and why, across five stakeholder dimensions: the AI agent consuming MemoryHub, the developer integrating it, marketing/positioning, the customer's cybersecurity team, and the end user whose interactions are remembered.
 
@@ -22,8 +22,9 @@ These issues directly affect what the agent retrieves, how accurately it recalls
 | #404 | Effective-k observability -- kill the silent capping funnel | **Bug** -- agent silently gets fewer results than requested |
 | #453 | Reimplement disabled_signals for RRF signal toggling | future |
 | #454 | Reimplement entity-aware search | future |
+| #511 | embedding_max_tokens config mismatches deployed model limit | **Bug** -- config hardcoded to 8192 (GPU model) but CPU variant maxes at 256 tokens; memories exceeding ~1000 chars fail with HTTP 413 |
 
-Bad retrieval means the agent hallucinates or ignores what it should know. #404 is the scariest: the agent silently gets fewer results than it asked for, and nobody knows.
+Bad retrieval means the agent hallucinates or ignores what it should know. #404 is the scariest: the agent silently gets fewer results than it asked for, and nobody knows. #511 blocks writes entirely for longer memories when the CPU embedding model is active.
 
 ### Memory hygiene -- keeping the memory store trustworthy over time
 
@@ -42,8 +43,9 @@ Bad retrieval means the agent hallucinates or ignores what it should know. #404 
 | #345 | Provenance-driven reflection (Layer 3) | |
 | #346 | Domain ontology refinement | |
 | #239 | Convergent learning (consolidate duplicates across users) | v0.4, future |
+| #512 | Chunk and fact node creation fails: logical_id NOT NULL violation | **Bug** -- three MemoryNode construction sites omit logical_id; zero chunk or fact nodes exist in the database. These features have never worked end-to-end |
 
-Without curation, memory accumulates noise. The agent's recall degrades as the store grows. #352 and #353 are the highest-leverage: dedup and staleness are the two ways memory rots.
+Without curation, memory accumulates noise. The agent's recall degrades as the store grows. #352 and #353 are the highest-leverage: dedup and staleness are the two ways memory rots. #512 reveals that chunk/fact node creation is completely non-functional -- a foundational storage bug.
 
 ### Agent autonomy and resilience
 
@@ -94,12 +96,13 @@ Without curation, memory accumulates noise. The agent's recall degrades as the s
 | #312 | Multi-harness support (tracking) | v0.3 |
 | #313 | Turn-level hooks | v0.3 |
 | #489 | OpenClaw integration | v0.3 |
+| #509 | OpenCode integration | v0.3 |
 | #494 | OpenClaw: Fix scope/project_id placement | **Bug** |
 | #495 | OpenClaw: Connection leak in resetSession | **Bug** |
 | #496 | OpenClaw: Remove as-never casts, cleanup | **Bug** |
 | #82 | LibreChat integration | v0.5 |
 
-Today MemoryHub works well with Claude Code. #310 is the gate for every other harness. The OpenClaw bugs (#494-496) are the lived proof that onboarding a second client surfaces rough edges.
+Today MemoryHub works well with Claude Code. #310 is the gate for every other harness. The OpenClaw bugs (#494-496) are the lived proof that onboarding a second client surfaces rough edges. #509 adds OpenCode as a third harness target.
 
 ### Developer confidence
 
@@ -108,6 +111,11 @@ Today MemoryHub works well with Claude Code. #310 is the gate for every other ha
 | #375 | Full local test suite hang | **Bug** -- corrosive; devs stop running tests |
 | #383 | Capability-claim sweep of agent-facing documents | Catches docs that promise features that don't exist yet |
 | #426 | EvalHub sidecar result-drain retry | |
+| #505 | Create test deployment of Hindsight | Competitive analysis -- hands-on comparison |
+| #506 | Create test deployment of GBrain | Competitive analysis -- hands-on comparison |
+| #511 | embedding_max_tokens config mismatches deployed model limit | **Bug** -- blocks writes for longer memories on CPU |
+| #512 | Chunk and fact node creation fails: logical_id NOT NULL | **Bug** -- chunk/fact features completely non-functional |
+| #518 | UI deploy script hard-fails without RHOAI installed | **Bug** -- RHOAI is optional but deploy.sh treats it as required |
 
 ---
 
@@ -131,8 +139,9 @@ Today MemoryHub works well with Claude Code. #310 is the gate for every other ha
 | #400 | Evaluate AutoRAG for pipeline optimization | |
 | #337 | Platform-level benchmark design | Depends on #334 |
 | #334 | Adversarial write / poisoning resistance | Feeds #337 |
+| #507 | Demo: quantitative benefits of agent memory sharing | needs-design -- a demo scenario showing clear quantitative gains from cross-user memory sharing |
 
-Marketing can't claim "better recall" without #330/#331. #273 is the "why not just use pgvector?" question every prospect asks. #337 is the benchmark that positions MemoryHub as a platform, not just a vector store.
+Marketing can't claim "better recall" without #330/#331. #273 is the "why not just use pgvector?" question every prospect asks. #337 is the benchmark that positions MemoryHub as a platform, not just a vector store. #507 provides the tangible demo for the memory-sharing value proposition.
 
 ### Differentiation features
 
@@ -142,8 +151,19 @@ Marketing can't claim "better recall" without #330/#331. #273 is the "why not ju
 | #289 | Statistician Agent (population-level patterns) | v0.4 |
 | #290 | Five-stage promotion pipeline | v0.4 |
 | #270 | Semantic search over conversation threads | future -- demo crowd-pleaser |
+| #516 | PTC-aligned provenance and taint metadata | compliance -- Trust Bricks PTC standard for provenance envelopes |
+| #517 | GAL-aligned memory trust lifecycle (promotion/demotion) | compliance -- Trust Bricks GAL standard for authority lifecycle |
 
-Dreaming (#345), population statistics (#289), and governed promotion (#290) are the curation story that separates MemoryHub from "just another RAG database."
+Dreaming (#345), population statistics (#289), and governed promotion (#290) are the curation story that separates MemoryHub from "just another RAG database." #516 and #517 add formal compliance standards (Trust Bricks PTC/GAL) that strengthen the governance narrative for regulated industries.
+
+### Competitive landscape
+
+| Issue | Title | Notes |
+|-------|-------|-------|
+| #505 | Create test deployment of Hindsight | Hands-on comparison with competing agent memory service |
+| #506 | Create test deployment of GBrain | Hands-on comparison with competing agent memory service |
+
+Understanding what competitors offer strengthens positioning and identifies gaps worth closing.
 
 ### Integration breadth
 
@@ -151,9 +171,16 @@ Dreaming (#345), population statistics (#289), and governed promotion (#290) are
 |-------|-------|-------|
 | #82 | LibreChat integration | v0.5 |
 | #489 | OpenClaw integration | v0.3 |
+| #509 | OpenCode integration | v0.3 |
 | #310 | Framework-agnostic onboarding | v0.3 |
 
 "Works with X" is a marketing checkbox. Each integration widens the addressable market.
+
+### Design documents
+
+| Issue | Title | Notes |
+|-------|-------|-------|
+| #508 | "Building the case for agent memory" design document | subsystem: memory-tree, target: planning/ folder |
 
 ---
 
@@ -173,8 +200,9 @@ Dreaming (#345), population statistics (#289), and governed promotion (#290) are
 | #71 | Intersection authorization (actor + driver permissions) | future, references #70 |
 | #497 | Surface last_updated_by in responses | Complements #492 |
 | #492 | Per-project identity selection | Makes identity legible |
+| #514 | Validate project membership before owner_id bypass in list/search | **Bug** -- PR #513 removed the owner_id safety net; callers can now see other members' memories in projects they don't belong to |
 
-#70 is table stakes for any regulated customer. Today audit events exist in-memory but don't survive restarts. Without it, "who did what when" is unanswerable after a pod recycle.
+#70 is table stakes for any regulated customer. Today audit events exist in-memory but don't survive restarts. Without it, "who did what when" is unanswerable after a pod recycle. #514 is an authorization bug with immediate security implications -- project membership is not enforced on list/search.
 
 ### Data protection and privacy
 
@@ -183,8 +211,10 @@ Dreaming (#345), population statistics (#289), and governed promotion (#290) are
 | #72 | driver_id redaction on read for sensitive contexts | future |
 | #68 | HIPAA/PHI detection in curation pipeline | v0.4 -- hard gate for healthcare |
 | #40 | Versioning and edit tracking for curation rules | v0.4 |
+| #516 | PTC-aligned provenance and taint metadata | Trust Bricks PTC standard for memory provenance envelopes |
+| #517 | GAL-aligned memory trust lifecycle (promotion/demotion) | Trust Bricks GAL standard for authority lifecycle |
 
-#68 is a hard gate for healthcare customers. #72 addresses "the agent remembers who asked, but the next reader shouldn't see that."
+#68 is a hard gate for healthcare customers. #72 addresses "the agent remembers who asked, but the next reader shouldn't see that." #516 and #517 formalize provenance and trust lifecycle using Trust Bricks standards -- relevant for any customer with data classification requirements.
 
 ### Adversarial resistance
 
@@ -251,6 +281,9 @@ Issues at the intersection of multiple stakeholders are the highest-leverage ite
 | **#68** HIPAA/PHI detection | | | healthcare gate | primary | protected |
 | **#334** Adversarial resistance | | | proof point | primary | protected |
 | **#404** Effective-k bug | primary | | | | feels it |
+| **#514** AuthZ project membership | | primary | | primary | |
+| **#511/#512** Storage bugs | primary | primary | | | |
+| **#516/#517** Trust Bricks compliance | | | differentiator | primary | |
 
 ---
 
@@ -258,10 +291,10 @@ Issues at the intersection of multiple stakeholders are the highest-leverage ite
 
 | Stakeholder | Issue count | Biggest gap |
 |-------------|-------------|-------------|
-| Agent | ~20 | Retrieval quality + curation pipeline |
-| Developer | ~15 | Multi-harness onboarding (#310) |
-| Marketing | ~12 | No provable benchmark numbers yet (#330 -> #331) |
-| Security | ~10 | No durable audit log (#70) |
+| Agent | ~22 | Retrieval quality + curation pipeline |
+| Developer | ~18 | Multi-harness onboarding (#310) |
+| Marketing | ~16 | No provable benchmark numbers yet (#330 -> #331) |
+| Security | ~13 | No durable audit log (#70); authorization bug (#514) |
 | End User | ~8 | No rollback/undo capability (#491) |
 
 Counts overlap because many issues serve multiple stakeholders. The "biggest gap" column is the single most painful absence for each audience today.
@@ -271,19 +304,19 @@ Counts overlap because many issues serve multiple stakeholders. The "biggest gap
 | Milestone | Count | Issues |
 |-----------|-------|--------|
 | v0.2 - Retrieval Quality | 3 | #272, #273, #306 |
-| v0.3 - Multi-Harness & Onboarding | 4 | #310, #312, #313, #489 |
+| v0.3 - Multi-Harness & Onboarding | 5 | #310, #312, #313, #489, #509 |
 | v0.4 - Curation & Governance | 5 | #40, #68, #70, #239, #290 |
 | v0.5 - Platform Integrations | 1 | #82 |
-| Unassigned | 38 | |
+| Unassigned | 47 | |
 
 ### By type
 
 | Type | Count |
 |------|-------|
-| Bugs | 7 (#375, #395, #404, #458, #494, #495, #496) |
+| Bugs | 11 (#375, #395, #404, #458, #494, #495, #496, #511, #512, #514, #518) |
 | Features | 24 |
-| Design | 4 (#104, #270, #337, #383) |
-| Enhancement | 7 |
+| Design | 5 (#104, #270, #337, #383, #508) |
+| Enhancement | 9 |
 | Tracking | 1 (#312) |
 | Investigation | 1 (#400) |
 | Flagged future/deferred | 7 (#71, #72, #87, #241, #270, #453, #454) |

--- a/planning/open-issues-by-stakeholder.md
+++ b/planning/open-issues-by-stakeholder.md
@@ -1,6 +1,6 @@
 # MemoryHub Open Issues by Stakeholder Dimension
 
-*Updated 2026-08-12 -- 50 open issues*
+*Updated 2026-08-12 -- 62 open issues*
 
 This document arranges the open issue backlog by who cares and why, across five stakeholder dimensions: the AI agent consuming MemoryHub, the developer integrating it, marketing/positioning, the customer's cybersecurity team, and the end user whose interactions are remembered.
 
@@ -305,7 +305,7 @@ Counts overlap because many issues serve multiple stakeholders. The "biggest gap
 |-----------|-------|--------|
 | v0.2 - Retrieval Quality | 3 | #272, #273, #306 |
 | v0.3 - Multi-Harness & Onboarding | 5 | #310, #312, #313, #489, #509 |
-| v0.4 - Curation & Governance | 5 | #40, #68, #70, #239, #290 |
+| v0.4 - Curation & Governance | 6 | #40, #68, #70, #239, #289, #290 |
 | v0.5 - Platform Integrations | 1 | #82 |
 | Unassigned | 47 | |
 


### PR DESCRIPTION
## Summary

- **Refreshed `planning/open-issues-by-stakeholder.md`**: Added 12 new issues (#505-#518) across all stakeholder sections. Updated header to 50 open issues. Bug count increased from 7 to 11 (added #511, #512, #514, #518). Unassigned count updated to 47. Added cross-cutting dependency map rows for authorization (#514), storage bugs (#511/#512), and Trust Bricks compliance (#516/#517). New "Competitive landscape" subsection under Marketing for #505/#506. Stakeholder summary counts updated.

- **Created `planning/milestones-roadmap.md`**: New document sequencing all six milestones with progress fractions, completed/remaining breakdowns, dependency chains, and blocker analysis. Includes unassigned issue triage (37 issues grouped into 12 themes with milestone recommendations), critical path analysis, and severity-ordered bug triage of all 11 open bugs.

## Test plan

- [ ] Verify issue numbers reference correct titles
- [ ] Verify milestone counts match GitHub milestone data
- [ ] Verify no duplicate issue entries across sections
- [ ] Confirm dependency chains are accurate