### PR TITLE
embeddings: Discover max_tokens from TEI /info instead of hardcoding (#511)

### DIFF
--- a/memory-hub-mcp/src/tools/write_memory.py
+++ b/memory-hub-mcp/src/tools/write_memory.py
@@ -12,7 +12,6 @@ from fastmcp import Context
 from fastmcp.exceptions import ToolError
 from pydantic import BaseModel, Field, ValidationError
 
-from memoryhub_core.config import AppSettings
 from memoryhub_core.models.schemas import MemoryNodeCreate
 from memoryhub_core.services.campaign import get_campaigns_for_project
 from memoryhub_core.services.exceptions import (
@@ -589,8 +588,7 @@ async def write_memory(
         # Eager fact extraction via MCP sampling. Non-fatal -- the write
         # never fails on extraction failure.
         facts_extracted = None
-        app_settings = AppSettings()
-        embedding_max_chars = app_settings.embedding_max_tokens * 4
+        embedding_max_chars = embedding_service.max_tokens * 4
         is_oversized = len(content) > embedding_max_chars
 
         valid_extract_modes = {"eager", "off", "background", None}

--- a/src/memoryhub_core/config.py
+++ b/src/memoryhub_core/config.py
@@ -71,7 +71,7 @@ class AppSettings(BaseSettings):
     version_retention_days: int = 90
     s3_threshold_bytes: int = 102400  # Content above this goes to S3 (if configured)
     s3_prefix_chars: int = 1000       # Chars stored in DB when content is in S3
-    embedding_max_tokens: int = 8192  # Embedding model context window (granite-embedding-small-english-r2)
+    embedding_max_tokens: int = 8192  # Fallback; runtime value comes from TEI /info (see EmbeddingService.max_tokens)
     session_ttl_seconds: int = 3600   # API-key session lifetime; auto-extends on activity
 
     # Conversation thread persistence (#168)

--- a/src/memoryhub_core/services/embeddings.py
+++ b/src/memoryhub_core/services/embeddings.py
@@ -17,10 +17,17 @@ from memoryhub_core.services.exceptions import (
 logger = logging.getLogger(__name__)
 
 EMBEDDING_DIM = 384
+_DEFAULT_MAX_TOKENS = 8192
 
 
 class EmbeddingService(ABC):
     """Interface for generating text embeddings."""
+
+    @property
+    @abstractmethod
+    def max_tokens(self) -> int:
+        """Max input tokens the embedding model accepts."""
+        ...
 
     @abstractmethod
     async def embed(self, text: str) -> list[float]:
@@ -39,6 +46,13 @@ class MockEmbeddingService(EmbeddingService):
     Generates consistent 384-dim vectors from content hashes.
     Similar content produces similar vectors (via shared word hashes).
     """
+
+    def __init__(self, max_tokens: int = _DEFAULT_MAX_TOKENS):
+        self._max_tokens = max_tokens
+
+    @property
+    def max_tokens(self) -> int:
+        return self._max_tokens
 
     async def embed(self, text: str) -> list[float]:
         return self._hash_embed(text)
@@ -73,6 +87,11 @@ class HttpEmbeddingService(EmbeddingService):
 
     Compatible with TEI-served models (granite-embedding-small-english-r2,
     all-MiniLM-L6-v2, etc.): POST {"inputs": "text"} -> [[float, ...]]
+
+    Queries TEI's ``GET /info`` endpoint on first use to discover the
+    model's actual ``max_input_length``.  Falls back to the env var
+    ``MEMORYHUB_EMBEDDING_MAX_TOKENS`` or ``_DEFAULT_MAX_TOKENS`` if
+    ``/info`` is unreachable.
     """
 
     def __init__(self, url: str | None = None):
@@ -82,13 +101,78 @@ class HttpEmbeddingService(EmbeddingService):
         )
         timeout = float(os.environ.get("MEMORYHUB_EMBEDDING_TIMEOUT", "120"))
         self._client = httpx.AsyncClient(timeout=timeout)
+        self._max_tokens: int | None = None
+        self._info_fetched = False
+
+    @property
+    def max_tokens(self) -> int:
+        if self._max_tokens is not None:
+            return self._max_tokens
+        return self._fallback_max_tokens()
+
+    async def _fetch_info(self) -> None:
+        """Query TEI /info once to discover max_input_length."""
+        if self._info_fetched:
+            return
+        self._info_fetched = True
+
+        # /info lives at the TEI server root, not under /embed
+        base_url = self.url.rsplit("/", 1)[0]
+        info_url = f"{base_url}/info"
+        try:
+            resp = await self._client.get(info_url, timeout=10)
+            resp.raise_for_status()
+            info = resp.json()
+            max_input = info.get("max_input_length")
+            if max_input is not None:
+                self._max_tokens = int(max_input)
+                logger.info(
+                    "Embedding model max_input_length: %d tokens (from TEI /info)",
+                    self._max_tokens,
+                )
+            else:
+                logger.warning(
+                    "TEI /info response missing max_input_length; "
+                    "falling back to %d tokens",
+                    self._fallback_max_tokens(),
+                )
+        except httpx.ConnectError:
+            logger.warning(
+                "Could not connect to TEI /info at %s; "
+                "using fallback max_tokens=%d",
+                info_url,
+                self._fallback_max_tokens(),
+            )
+        except httpx.TimeoutException:
+            logger.warning(
+                "TEI /info request timed out (%s); "
+                "using fallback max_tokens=%d",
+                info_url,
+                self._fallback_max_tokens(),
+            )
+        except Exception:
+            logger.warning(
+                "Failed to query TEI /info at %s; "
+                "using fallback max_tokens=%d",
+                info_url,
+                self._fallback_max_tokens(),
+                exc_info=True,
+            )
+
+    @staticmethod
+    def _fallback_max_tokens() -> int:
+        env = os.environ.get("MEMORYHUB_EMBEDDING_MAX_TOKENS")
+        if env is not None:
+            return int(env)
+        return _DEFAULT_MAX_TOKENS
 
     async def embed(self, text: str) -> list[float]:
+        await self._fetch_info()
         try:
             response = await self._client.post(self.url, json={"inputs": text})
             response.raise_for_status()
         except httpx.HTTPStatusError as exc:
-            if exc.response.status_code == 413:
+            if exc.response.status_code in (413, 422):
                 raise EmbeddingContentTooLargeError(
                     content_length=len(text),
                     detail="Reduce content length or split into smaller memories.",

--- a/src/memoryhub_core/services/memory.py
+++ b/src/memoryhub_core/services/memory.py
@@ -107,7 +107,7 @@ async def create_memory(
     """
     app_settings = AppSettings()
     content_bytes = len(data.content.encode("utf-8"))
-    embedding_max_chars = app_settings.embedding_max_tokens * 4
+    embedding_max_chars = embedding_service.max_tokens * 4
     needs_chunking = len(data.content) > embedding_max_chars
     use_s3 = content_bytes > app_settings.s3_threshold_bytes and s3_adapter is not None
 
@@ -525,7 +525,7 @@ async def update_memory(
     # Determine storage and chunking strategy for the new version
     if content_changed:
         content_bytes = len(new_content.encode("utf-8"))
-        embedding_max_chars = app_settings.embedding_max_tokens * 4
+        embedding_max_chars = embedding_service.max_tokens * 4
         needs_chunking = len(new_content) > embedding_max_chars
         use_s3 = content_bytes > app_settings.s3_threshold_bytes and s3_adapter is not None
         embed_text = new_content[:embedding_max_chars] if needs_chunking else new_content

--- a/tests/test_services/test_embedding_errors.py
+++ b/tests/test_services/test_embedding_errors.py
@@ -1,16 +1,24 @@
-"""Tests for HttpEmbeddingService error translation (#119).
+"""Tests for HttpEmbeddingService error translation and /info discovery (#119, #511).
 
 Verifies that httpx-level failures are caught and re-raised as the appropriate
-domain exception: EmbeddingContentTooLargeError (413), EmbeddingServiceError
+domain exception: EmbeddingContentTooLargeError (413/422), EmbeddingServiceError
 (other HTTP errors), and EmbeddingServiceUnavailableError (connect/timeout).
+
+Also verifies that max_tokens is discovered from TEI /info and that failures
+fall back gracefully.
 """
 
+import json
 from unittest.mock import AsyncMock, patch
 
 import httpx
 import pytest
 
-from memoryhub_core.services.embeddings import HttpEmbeddingService
+from memoryhub_core.services.embeddings import (
+    HttpEmbeddingService,
+    MockEmbeddingService,
+    _DEFAULT_MAX_TOKENS,
+)
 from memoryhub_core.services.exceptions import (
     EmbeddingContentTooLargeError,
     EmbeddingServiceError,
@@ -20,17 +28,23 @@ from memoryhub_core.services.exceptions import (
 _URL = "http://test-embedder/embed"
 
 
-def _http_response(status_code: int) -> httpx.Response:
+def _http_response(status_code: int, body: bytes = b"") -> httpx.Response:
     """Build a minimal httpx.Response for a given status code."""
     return httpx.Response(
         status_code,
         request=httpx.Request("POST", _URL),
+        content=body,
     )
 
 
 @pytest.fixture
 def service() -> HttpEmbeddingService:
-    return HttpEmbeddingService(url=_URL)
+    svc = HttpEmbeddingService(url=_URL)
+    svc._info_fetched = True
+    return svc
+
+
+# -- Error translation --
 
 
 @pytest.mark.asyncio
@@ -48,6 +62,18 @@ async def test_413_raises_content_too_large(service: HttpEmbeddingService):
     assert exc_info.value.content_length == len(text), (
         f"Expected content_length={len(text)}, got {exc_info.value.content_length}"
     )
+
+
+@pytest.mark.asyncio
+async def test_422_raises_content_too_large(service: HttpEmbeddingService):
+    """A 422 response (TEI with auto_truncate=false) must also raise
+    EmbeddingContentTooLargeError."""
+    response = _http_response(422)
+    mock_post = AsyncMock(return_value=response)
+
+    with patch.object(service._client, "post", mock_post):
+        with pytest.raises(EmbeddingContentTooLargeError):
+            await service.embed("x" * 1000)
 
 
 @pytest.mark.asyncio
@@ -97,3 +123,108 @@ async def test_embed_batch_propagates_413(service: HttpEmbeddingService):
 
     with patch.object(service._client, "post", mock_post), pytest.raises(EmbeddingContentTooLargeError):
         await service.embed_batch(["a", "b"])
+
+
+# -- TEI /info discovery (#511) --
+
+
+@pytest.mark.asyncio
+async def test_info_sets_max_tokens_from_tei():
+    """HttpEmbeddingService reads max_input_length from TEI /info on first embed."""
+    svc = HttpEmbeddingService(url=_URL)
+
+    info_body = json.dumps({"max_input_length": 256, "model_id": "all-MiniLM-L6-v2"}).encode()
+    info_response = httpx.Response(200, request=httpx.Request("GET", "http://test-embedder/info"), content=info_body)
+    embed_response = httpx.Response(200, request=httpx.Request("POST", _URL), content=b"[[0.1, 0.2]]")
+
+    mock_get = AsyncMock(return_value=info_response)
+    mock_post = AsyncMock(return_value=embed_response)
+
+    with patch.object(svc._client, "get", mock_get), patch.object(svc._client, "post", mock_post):
+        await svc.embed("hello")
+
+    assert svc.max_tokens == 256
+    mock_get.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_info_fallback_on_connect_error():
+    """When /info is unreachable, max_tokens falls back to the default."""
+    svc = HttpEmbeddingService(url=_URL)
+
+    embed_response = httpx.Response(200, request=httpx.Request("POST", _URL), content=b"[[0.1, 0.2]]")
+    mock_get = AsyncMock(side_effect=httpx.ConnectError("refused"))
+    mock_post = AsyncMock(return_value=embed_response)
+
+    with patch.object(svc._client, "get", mock_get), patch.object(svc._client, "post", mock_post):
+        await svc.embed("hello")
+
+    assert svc.max_tokens == _DEFAULT_MAX_TOKENS
+    assert svc._info_fetched is True
+
+
+@pytest.mark.asyncio
+async def test_info_fallback_on_timeout():
+    """When /info times out, max_tokens falls back to the default."""
+    svc = HttpEmbeddingService(url=_URL)
+
+    embed_response = httpx.Response(200, request=httpx.Request("POST", _URL), content=b"[[0.1, 0.2]]")
+    mock_get = AsyncMock(side_effect=httpx.TimeoutException("timed out"))
+    mock_post = AsyncMock(return_value=embed_response)
+
+    with patch.object(svc._client, "get", mock_get), patch.object(svc._client, "post", mock_post):
+        await svc.embed("hello")
+
+    assert svc.max_tokens == _DEFAULT_MAX_TOKENS
+
+
+@pytest.mark.asyncio
+async def test_info_fetched_only_once():
+    """/info is queried at most once, even across multiple embed calls."""
+    svc = HttpEmbeddingService(url=_URL)
+
+    info_body = json.dumps({"max_input_length": 512}).encode()
+    info_response = httpx.Response(200, request=httpx.Request("GET", "http://test-embedder/info"), content=info_body)
+    embed_response = httpx.Response(200, request=httpx.Request("POST", _URL), content=b"[[0.1, 0.2]]")
+
+    mock_get = AsyncMock(return_value=info_response)
+    mock_post = AsyncMock(return_value=embed_response)
+
+    with patch.object(svc._client, "get", mock_get), patch.object(svc._client, "post", mock_post):
+        await svc.embed("first")
+        await svc.embed("second")
+
+    assert mock_get.call_count == 1
+    assert svc.max_tokens == 512
+
+
+@pytest.mark.asyncio
+async def test_info_fallback_env_var(monkeypatch):
+    """MEMORYHUB_EMBEDDING_MAX_TOKENS env var overrides the hardcoded default
+    when /info is unreachable."""
+    monkeypatch.setenv("MEMORYHUB_EMBEDDING_MAX_TOKENS", "256")
+    svc = HttpEmbeddingService(url=_URL)
+
+    embed_response = httpx.Response(200, request=httpx.Request("POST", _URL), content=b"[[0.1, 0.2]]")
+    mock_get = AsyncMock(side_effect=httpx.ConnectError("refused"))
+    mock_post = AsyncMock(return_value=embed_response)
+
+    with patch.object(svc._client, "get", mock_get), patch.object(svc._client, "post", mock_post):
+        await svc.embed("hello")
+
+    assert svc.max_tokens == 256
+
+
+# -- MockEmbeddingService max_tokens --
+
+
+def test_mock_embedding_service_default_max_tokens():
+    """MockEmbeddingService defaults to _DEFAULT_MAX_TOKENS."""
+    svc = MockEmbeddingService()
+    assert svc.max_tokens == _DEFAULT_MAX_TOKENS
+
+
+def test_mock_embedding_service_custom_max_tokens():
+    """MockEmbeddingService accepts a custom max_tokens."""
+    svc = MockEmbeddingService(max_tokens=256)
+    assert svc.max_tokens == 256

--- a/tests/test_services/test_memory_service.py
+++ b/tests/test_services/test_memory_service.py
@@ -1651,8 +1651,6 @@ async def test_create_memory_s3_no_adapter_inline_fallback(async_session, embedd
 
 async def test_create_memory_oversized_no_s3_truncates_embed_text(async_session, embedding_service):
     """Oversized content without S3 still truncates embed text to prevent 413."""
-    from memoryhub_core.config import AppSettings
-
     big_content = _make_oversized_content()
     captured_texts = []
     original_embed = embedding_service.embed
@@ -1668,8 +1666,7 @@ async def test_create_memory_oversized_no_s3_truncates_embed_text(async_session,
     finally:
         embedding_service.embed = original_embed
 
-    settings = AppSettings()
-    embedding_max_chars = settings.embedding_max_tokens * 4
+    embedding_max_chars = embedding_service.max_tokens * 4
     # The first embed call is for the parent node
     assert len(captured_texts) >= 1
     assert len(captured_texts[0]) == embedding_max_chars, (
@@ -1712,6 +1709,65 @@ async def test_create_memory_oversized_no_s3_stores_full_content_inline(async_se
     assert result.content == big_content, "full content should be stored inline"
     assert result.storage_type == "inline"
     assert result.content_ref is None
+
+
+async def test_chunking_uses_embedding_service_max_tokens(async_session):
+    """Chunking threshold comes from embedding_service.max_tokens, not config (#511)."""
+    from sqlalchemy import select as sa_select
+
+    from memoryhub_core.models.memory import MemoryNode
+    from memoryhub_core.services.embeddings import MockEmbeddingService
+
+    low_limit_service = MockEmbeddingService(max_tokens=64)
+    max_chars = low_limit_service.max_tokens * 4  # 256 chars
+
+    paragraphs = [f"Paragraph {i}: " + "x" * 100 for i in range(10)]
+    content = "\n\n".join(paragraphs)
+    assert len(content) > max_chars
+    data = _make_create_data(content=content)
+    result, _ = await create_memory(data, async_session, low_limit_service, s3_adapter=None)
+
+    chunks_stmt = sa_select(MemoryNode).where(
+        MemoryNode.parent_id == result.id,
+        MemoryNode.branch_type == "chunk",
+        MemoryNode.deleted_at.is_(None),
+    )
+    chunks = (await async_session.execute(chunks_stmt)).scalars().all()
+    assert len(chunks) >= 1, (
+        f"content of {len(content)} chars should be chunked with max_tokens=64 "
+        f"(threshold={max_chars} chars), got 0 chunks"
+    )
+
+
+async def test_truncation_uses_embedding_service_max_tokens(async_session):
+    """Parent embed text is truncated to embedding_service.max_tokens * 4 (#511)."""
+    from memoryhub_core.services.embeddings import MockEmbeddingService
+
+    low_limit_service = MockEmbeddingService(max_tokens=64)
+    max_chars = low_limit_service.max_tokens * 4  # 256 chars
+
+    captured_texts = []
+    original_embed = low_limit_service.embed
+
+    async def capturing_embed(text):
+        captured_texts.append(text)
+        return await original_embed(text)
+
+    low_limit_service.embed = capturing_embed
+    paragraphs = [f"Paragraph {i}: " + "x" * 100 for i in range(10)]
+    content = "\n\n".join(paragraphs)
+    assert len(content) > max_chars
+    data = _make_create_data(content=content)
+    try:
+        await create_memory(data, async_session, low_limit_service, s3_adapter=None)
+    finally:
+        low_limit_service.embed = original_embed
+
+    assert len(captured_texts) >= 1
+    assert len(captured_texts[0]) == max_chars, (
+        f"embed text should be truncated to {max_chars} chars (max_tokens=64), "
+        f"got {len(captured_texts[0])}"
+    )
 
 
 # -- update_memory: two-tier storage --


### PR DESCRIPTION
## Summary

The project deploys two embedding models with different token limits — granite (8192 tokens, GPU) and all-MiniLM-L6-v2 (256 tokens, CPU) — but `embedding_max_tokens` was hardcoded to 8192. On CPU clusters, the memory service truncated content to 32,768 chars before embedding, but TEI tokenized it to far more than 256 tokens and returned HTTP 413. Any memory over ~1000 characters failed to write.

The fix makes the token limit **model-linked at runtime**:

- `EmbeddingService` now exposes a `max_tokens` property on the abstract interface
- `HttpEmbeddingService` queries TEI's `GET /info` endpoint on first use to read the deployed model's actual `max_input_length`, and caches it for the lifetime of the process
- All truncation and chunking decisions (`memory.py`, `write_memory.py`) use `embedding_service.max_tokens` instead of the static config value
- If `/info` is unreachable, falls back to `MEMORYHUB_EMBEDDING_MAX_TOKENS` env var, then the config default (8192), with warnings logged on every fallback path
- HTTP 422 is now caught alongside 413 (TEI returns 422 for token-limit violations with `auto_truncate=false`)

This means swapping the embedding model no longer requires a config change — the service adapts automatically.

## Linked issues

Closes #511

## Design reference

`docs/design/storage-layer.md`

## Type of change

- [ ] `type:feature` — new user-visible capability
- [x] `type:bug` — fix for incorrect behavior
- [ ] `type:infra` — build, CI, deploy, or tooling change
- [ ] `type:design` — design doc only, no code

## Subsystem

- [ ] `memory-tree`
- [x] `storage`
- [ ] `curator`
- [ ] `governance`
- [x] `mcp-server`
- [ ] `operator`
- [ ] `observability`
- [ ] `org-ingestion`
- [ ] `auth`
- [ ] `ui`
- [ ] `llamastack`

## Test plan

- [x] **Unit tests only** — no infrastructure boundaries touched
      (pure logic, no DB/Valkey/embedding service interaction)

- [x] `pytest` passes locally (674 passed, 1 skipped)
- [ ] Manual verification against a running cluster (if applicable)
- [x] New tests added for new behavior

**New tests (10):** /info discovery (happy path, connect error fallback, timeout fallback, fetched-only-once, env var override), HTTP 422 handling, MockEmbeddingService max_tokens (default and custom), and two tests proving chunking/truncation are driven by `embedding_service.max_tokens` not the config.

## Reviewer checklist

- [x] Design doc referenced or created
- [x] No committed credentials or cluster-specific URLs
- [x] CLAUDE.md / docs updated if behavior or conventions changed
- [x] Commit message follows `subsystem: Imperative summary` format