### PR TITLE
cli: display api_key in create-agent and rotate-secret table output

### DIFF
--- a/memoryhub-cli/src/memoryhub_cli/admin.py
+++ b/memoryhub-cli/src/memoryhub_cli/admin.py
@@ -100,7 +100,7 @@ def create_agent(
     write_config: bool = typer.Option(
         False,
         "--write-config",
-        help="Write the client_secret to ~/.config/memoryhub/credentials",
+        help="Write the api_key to ~/.config/memoryhub/credentials",
     ),
     context: str = typer.Option(
         "",
@@ -113,7 +113,7 @@ def create_agent(
 ):
     """Create a new agent (OAuth client).
 
-    The client_secret is shown only once. Save it immediately.
+    The client_secret and api_key are shown only once. Save them immediately.
     """
     admin_key = _get_admin_key(output)
     auth_url = _get_auth_url(output)
@@ -160,12 +160,15 @@ def create_agent(
         f"  [yellow bold]Client Secret:   {data['client_secret']}[/yellow bold]"
     )
     console.print(
-        "\n  [dim]Save this secret now. It will not be shown again.[/dim]"
+        f"  [yellow bold]API Key:         {data['api_key']}[/yellow bold]"
+    )
+    console.print(
+        "\n  [dim]Save both values now. They will not be shown again.[/dim]"
     )
 
     if write_config:
         section = context or os.environ.get("MEMORYHUB_CONTEXT", "").strip() or "default"
-        write_credentials_section(section, data["client_secret"])
+        write_credentials_section(section, data["api_key"])
         console.print(f"\n  [green]Secret written to {CREDENTIALS_FILE} [{section}][/green]")
 
 
@@ -234,9 +237,9 @@ def rotate_secret(
         OutputFormat.table, "--output", "-o", help="Output format: table, json, quiet",
     ),
 ):
-    """Rotate the client secret for an agent.
+    """Rotate the client secret for an agent. This also regenerates the API key.
 
-    The new secret is shown only once. Save it immediately.
+    Both values are shown only once. Save them immediately.
     """
     admin_key = _get_admin_key(output)
     auth_url = _get_auth_url(output)
@@ -265,10 +268,13 @@ def rotate_secret(
 
     console.print(f"[green]Secret rotated for {data['client_id']}.[/green]\n")
     console.print(
-        f"  [yellow bold]New Secret:   {data['client_secret']}[/yellow bold]"
+        f"  [yellow bold]New Secret:    {data['client_secret']}[/yellow bold]"
     )
     console.print(
-        "\n  [dim]Save this secret now. It will not be shown again.[/dim]"
+        f"  [yellow bold]New API Key:   {data['api_key']}[/yellow bold]"
+    )
+    console.print(
+        "\n  [dim]Save both values now. They will not be shown again.[/dim]"
     )
 
 

--- a/memoryhub-cli/tests/test_admin.py
+++ b/memoryhub-cli/tests/test_admin.py
@@ -27,11 +27,16 @@ SAMPLE_CLIENT = {
     "updated_at": "2026-04-14T12:00:00",
 }
 
-SAMPLE_CREATED = {**SAMPLE_CLIENT, "client_secret": "super-secret-value"}
+SAMPLE_CREATED = {
+    **SAMPLE_CLIENT,
+    "client_secret": "super-secret-value",
+    "api_key": "mh-dev-abc123",
+}
 
 SAMPLE_ROTATED = {
     "client_id": "test-agent",
     "client_secret": "new-secret-value",
+    "api_key": "mh-dev-rotated789",
 }
 
 
@@ -82,7 +87,8 @@ class TestCreateAgent:
         assert result.exit_code == 0
         assert "test-agent" in result.output
         assert "super-secret-value" in result.output
-        assert "Save this secret" in result.output
+        assert "mh-dev-abc123" in result.output
+        assert "Save both values" in result.output
 
     def test_json_output(self):
         mock_client = AsyncMock()
@@ -100,6 +106,7 @@ class TestCreateAgent:
         parsed = json.loads(result.output)
         assert parsed["data"]["client_id"] == "test-agent"
         assert parsed["data"]["client_secret"] == "super-secret-value"
+        assert parsed["data"]["api_key"] == "mh-dev-abc123"
 
     def _run_write_config(self, tmp_path, extra_args=None):
         mock_client = AsyncMock()
@@ -129,7 +136,7 @@ class TestCreateAgent:
         import configparser
         cp = configparser.ConfigParser(interpolation=None)
         cp.read(creds)
-        assert cp.get("default", "api_key") == "super-secret-value"
+        assert cp.get("default", "api_key") == "mh-dev-abc123"
 
     def test_write_config_with_context(self, tmp_path):
         result, creds = self._run_write_config(
@@ -139,7 +146,7 @@ class TestCreateAgent:
         import configparser
         cp = configparser.ConfigParser(interpolation=None)
         cp.read(creds)
-        assert cp.get("my-cluster", "api_key") == "super-secret-value"
+        assert cp.get("my-cluster", "api_key") == "mh-dev-abc123"
 
     def test_conflict_409(self):
         error_resp = _mock_error_response(
@@ -233,6 +240,8 @@ class TestRotateSecret:
 
         assert result.exit_code == 0
         assert "new-secret-value" in result.output
+        assert "mh-dev-rotated789" in result.output
+        assert "Save both values" in result.output
         assert "rotated" in result.output.lower()
 
     def test_json_output(self):
@@ -252,6 +261,7 @@ class TestRotateSecret:
         assert result.exit_code == 0
         parsed = json.loads(result.output)
         assert parsed["data"]["client_secret"] == "new-secret-value"
+        assert parsed["data"]["api_key"] == "mh-dev-rotated789"
 
     def test_not_found(self):
         error_resp = _mock_error_response(404, "Client 'ghost' not found")


### PR DESCRIPTION
## Summary
  - Show `api_key` alongside `client_secret` in `create-agent` table output
  - Fix `--write-config` to write `api_key` (was incorrectly writing `client_secret`)
  - Show `api_key` in `rotate-secret` table output (server regenerates both)
  - Update docstrings and help text

  ## Test plan
  - [x] `pytest tests/test_admin.py` — 15 tests pass
  - [ ] Manual: `memoryhub admin create-agent test-agent` shows both secrets
  - [ ] Manual: `memoryhub admin create-agent test-agent --write-config` writes `mh-dev-...` key
  - [ ] Manual: `memoryhub admin rotate-secret test-agent` shows both new values

  Fixes #458