### PR TITLE
installer: Guard RHOAI references in confirmation and summary output (#526, #527)

### DIFF
--- a/memoryhub-ui/deploy/deploy.sh
+++ b/memoryhub-ui/deploy/deploy.sh
@@ -22,8 +22,18 @@ NAMESPACE="${MEMORYHUB_UI_NAMESPACE:-memoryhub-ui}"
 DEPLOYMENT="memoryhub-ui"
 IMAGESTREAM="memoryhub-ui"
 CONTEXT="${MEMORYHUB_CONTEXT:-mcp-rhoai}"
+RHOAI_NS="redhat-ods-applications"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+SKIP_TILE=false
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --skip-tile) SKIP_TILE=true ;;
+        *) echo "Unknown argument: $1"; exit 1 ;;
+    esac
+    shift
+done
 
 echo "=== MemoryHub UI Deployment ==="
 echo "Namespace: $NAMESPACE"
@@ -152,29 +162,34 @@ if [ "$RUNNING_DIGEST" != "$LATEST_DIGEST" ]; then
 fi
 echo "  OK: running digest matches imagestream :latest"
 
-# Step 9: Sync the RHOAI dashboard proxy route.
-#
-# The RHOAI dashboard resolves the "Open application" link by looking up
-# a Route named `memoryhub-ui` in its own namespace (redhat-ods-applications).
-# The `routeNamespace` field in OdhApplication is defined in the CRD but
-# the dashboard backend does not read it (logs "namespace undefined").
-#
-# Workaround: create a selectorless Service + Endpoints + Route in the
-# dashboard namespace. The Endpoints point at the ClusterIP of the real
-# memoryhub-ui Service (not the pod IP), so the proxy is stable across
-# pod restarts, rollouts, and node migrations. The ClusterIP only changes
-# if the Service in memoryhub-ui is deleted and recreated (full uninstall).
-RHOAI_NS="redhat-ods-applications"
-echo ""
-echo "Syncing RHOAI dashboard proxy route in $RHOAI_NS..."
-UI_CLUSTER_IP=$(oc get svc memoryhub-ui --context "$CONTEXT" -n "$NAMESPACE" \
-    -o jsonpath='{.spec.clusterIP}' 2>/dev/null || echo "")
-if [ -z "$UI_CLUSTER_IP" ]; then
-    echo "  WARNING: could not resolve memoryhub-ui Service ClusterIP."
-    echo "  Re-run this script after the UI Service exists in $NAMESPACE."
-else
-    echo "  UI Service ClusterIP: $UI_CLUSTER_IP"
-    cat <<PROXY_EOF | oc apply --context "$CONTEXT" -f - 2>/dev/null
+# Steps 9-10: RHOAI dashboard integration (proxy route + tile).
+# Skipped when RHOAI is not installed or --skip-tile is passed.
+if [ "$SKIP_TILE" = true ]; then
+    echo ""
+    echo "Skipping RHOAI proxy route and tile (--skip-tile)"
+elif oc get namespace "$RHOAI_NS" --context "$CONTEXT" &>/dev/null; then
+    # Step 9: Sync the RHOAI dashboard proxy route.
+    #
+    # The RHOAI dashboard resolves the "Open application" link by looking up
+    # a Route named `memoryhub-ui` in its own namespace (redhat-ods-applications).
+    # The `routeNamespace` field in OdhApplication is defined in the CRD but
+    # the dashboard backend does not read it (logs "namespace undefined").
+    #
+    # Workaround: create a selectorless Service + Endpoints + Route in the
+    # dashboard namespace. The Endpoints point at the ClusterIP of the real
+    # memoryhub-ui Service (not the pod IP), so the proxy is stable across
+    # pod restarts, rollouts, and node migrations. The ClusterIP only changes
+    # if the Service in memoryhub-ui is deleted and recreated (full uninstall).
+    echo ""
+    echo "Syncing RHOAI dashboard proxy route in $RHOAI_NS..."
+    UI_CLUSTER_IP=$(oc get svc memoryhub-ui --context "$CONTEXT" -n "$NAMESPACE" \
+        -o jsonpath='{.spec.clusterIP}' 2>/dev/null || echo "")
+    if [ -z "$UI_CLUSTER_IP" ]; then
+        echo "  WARNING: could not resolve memoryhub-ui Service ClusterIP."
+        echo "  Re-run this script after the UI Service exists in $NAMESPACE."
+    else
+        echo "  UI Service ClusterIP: $UI_CLUSTER_IP"
+        cat <<PROXY_EOF | oc apply --context "$CONTEXT" -f - 2>/dev/null
 apiVersion: v1
 kind: Service
 metadata:
@@ -198,9 +213,9 @@ subsets:
   - port: 8080
     protocol: TCP
 PROXY_EOF
-    # Create the Route only if it doesn't exist (idempotent).
-    if ! oc get route memoryhub-ui --context "$CONTEXT" -n "$RHOAI_NS" &>/dev/null; then
-        cat <<ROUTE_EOF | oc apply --context "$CONTEXT" -f - 2>/dev/null
+        # Create the Route only if it doesn't exist (idempotent).
+        if ! oc get route memoryhub-ui --context "$CONTEXT" -n "$RHOAI_NS" &>/dev/null; then
+            cat <<ROUTE_EOF | oc apply --context "$CONTEXT" -f - 2>/dev/null
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
@@ -216,14 +231,23 @@ spec:
     termination: edge
     insecureEdgeTerminationPolicy: Redirect
 ROUTE_EOF
+        fi
+        echo "  Proxy route synced."
     fi
-    echo "  Proxy route synced."
-fi
 
-# Step 10: Apply the OdhApplication tile (idempotent).
-echo ""
-echo "Applying RHOAI tile..."
-oc apply --context "$CONTEXT" -f "$PROJECT_ROOT/openshift/odh-application.yaml"
+    # Step 10: Apply the OdhApplication tile (idempotent).
+    if oc get crd odhapplications.dashboard.opendatahub.io --context "$CONTEXT" &>/dev/null; then
+        echo ""
+        echo "Applying RHOAI tile..."
+        oc apply --context "$CONTEXT" -f "$PROJECT_ROOT/openshift/odh-application.yaml"
+    else
+        echo ""
+        echo "  OdhApplication CRD not found — skipping tile (proxy route still synced)"
+    fi
+else
+    echo ""
+    echo "RHOAI not installed ($RHOAI_NS namespace not found) — skipping proxy route and tile."
+fi
 
 # Step 11: Print route URL
 ROUTE=$(oc get route "$DEPLOYMENT" --context "$CONTEXT" -n "$NAMESPACE" -o jsonpath='{.spec.host}' 2>/dev/null || echo "")

--- a/scripts/check-prereqs.sh
+++ b/scripts/check-prereqs.sh
@@ -128,8 +128,7 @@ info "Checking for Red Hat OpenShift AI (namespace redhat-ods-applications)..."
 if oc get namespace --context "$CONTEXT" redhat-ods-applications &>/dev/null; then
     pass "redhat-ods-applications namespace found — RHOAI is installed"
 else
-    fail "Namespace 'redhat-ods-applications' not found. MemoryHub expects Red Hat OpenShift AI to be installed. See https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed for installation."
-    (( FAILURES++ ))
+    warn "Namespace 'redhat-ods-applications' not found. RHOAI dashboard tile will be skipped. MemoryHub works without RHOAI."
 fi
 
 # 7. Default storage class exists

--- a/scripts/deploy-full.sh
+++ b/scripts/deploy-full.sh
@@ -862,14 +862,12 @@ print_summary() {
     cluster_url=$(oc whoami --context "$CONTEXT" --show-server 2>/dev/null || echo "(unavailable)")
     current_user=$(oc whoami --context "$CONTEXT" 2>/dev/null || echo "(unavailable)")
 
-    local ui_route mcp_route auth_route rhoai_route
+    local ui_route mcp_route auth_route
     ui_route=$(oc get route --context "$CONTEXT" memoryhub-ui -n "$UI_NAMESPACE" \
         -o jsonpath='{.spec.host}' 2>/dev/null || echo "")
     mcp_route=$(oc get route --context "$CONTEXT" memory-hub-mcp -n "$MCP_PROJECT" \
         -o jsonpath='{.spec.host}' 2>/dev/null || echo "")
     auth_route=$(oc get route --context "$CONTEXT" auth-server -n "$AUTH_PROJECT" \
-        -o jsonpath='{.spec.host}' 2>/dev/null || echo "")
-    rhoai_route=$(oc get route --context "$CONTEXT" rhods-dashboard -n "$RHOAI_NAMESPACE" \
         -o jsonpath='{.spec.host}' 2>/dev/null || echo "")
 
     echo ""
@@ -895,10 +893,17 @@ print_summary() {
         printf "    %-24s %s\n" "Auth server:" "(route not found — check: oc get route --context "$CONTEXT" auth-server -n $AUTH_PROJECT)"
     fi
 
-    if [ -n "$rhoai_route" ]; then
-        printf "    %-24s %s\n" "RHOAI dashboard:" "https://${rhoai_route}"
+    if oc get namespace --context "$CONTEXT" "$RHOAI_NAMESPACE" &>/dev/null; then
+        local rhoai_route
+        rhoai_route=$(oc get route --context "$CONTEXT" rhods-dashboard -n "$RHOAI_NAMESPACE" \
+            -o jsonpath='{.spec.host}' 2>/dev/null || echo "")
+        if [ -n "$rhoai_route" ]; then
+            printf "    %-24s %s\n" "RHOAI dashboard:" "https://${rhoai_route}"
+        else
+            printf "    %-24s %s\n" "RHOAI dashboard:" "(route not found — check: oc get route --context "$CONTEXT" rhods-dashboard -n $RHOAI_NAMESPACE)"
+        fi
     else
-        printf "    %-24s %s\n" "RHOAI dashboard:" "(route not found — check: oc get route --context "$CONTEXT" rhods-dashboard -n $RHOAI_NAMESPACE)"
+        printf "    %-24s %s\n" "RHOAI dashboard:" "(not installed)"
     fi
 
     echo ""

--- a/scripts/deploy-full.sh
+++ b/scripts/deploy-full.sh
@@ -209,7 +209,7 @@ preflight() {
     echo "    Models:      $([ "$SKIP_MODELS" = true ] && echo "skip" || ([ "$GPU_MODELS" = true ] && echo "deploy (GPU)" || echo "deploy (CPU)"))"
     echo "    Auth server: $([ "$SKIP_AUTH" = true ] && echo "skip" || echo "deploy")"
     echo "    UI:          $([ "$SKIP_UI" = true ] && echo "skip" || echo "deploy")"
-    echo "    RHOAI tile:  $([ "$SKIP_TILE" = true ] && echo "skip" || echo "apply")"
+    echo "    RHOAI tile:  $([ "$SKIP_TILE" = true ] && echo "skip" || echo "apply (if RHOAI installed)")"
 }
 
 # ---------------------------------------------------------------------------
@@ -693,8 +693,11 @@ deploy_ui() {
         die "UI deploy script not found: $ui_deploy"
     fi
 
+    local ui_args=()
+    if [ "$SKIP_TILE" = true ]; then ui_args+=(--skip-tile); fi
+
     info "Deploying UI (namespace: $UI_NAMESPACE)..."
-    if ! bash "$ui_deploy"; then
+    if ! bash "$ui_deploy" "${ui_args[@]}"; then
         die "UI deployment failed. Check output above."
     fi
 
@@ -703,37 +706,7 @@ deploy_ui() {
 }
 
 # ---------------------------------------------------------------------------
-# Section 7: RHOAI OdhApplication tile
-# ---------------------------------------------------------------------------
-deploy_tile() {
-    banner "7. RHOAI OdhApplication Tile"
-
-    if [ "$SKIP_TILE" = true ]; then
-        skipped "OdhApplication tile (--skip-tile)"
-        return 0
-    fi
-
-    local odh_manifest="$REPO_ROOT/memoryhub-ui/openshift/odh-application.yaml"
-    if [ ! -f "$odh_manifest" ]; then
-        die "OdhApplication manifest not found: $odh_manifest"
-    fi
-
-    if oc get crd odhapplications.dashboard.opendatahub.io --context "$CONTEXT" &>/dev/null; then
-        info "Applying OdhApplication CR to $RHOAI_NAMESPACE..."
-        if ! oc apply --context "$CONTEXT" -f "$odh_manifest" -n "$RHOAI_NAMESPACE"; then
-            die "Failed to apply OdhApplication manifest."
-        fi
-        echo ""
-        echo -e "  ${GREEN}RHOAI tile applied${RESET}"
-    else
-        warn "OdhApplication CRD not found — skipping dashboard tile (non-blocking)"
-        echo ""
-        echo -e "  ${YELLOW}RHOAI tile skipped (CRD not available)${RESET}"
-    fi
-}
-
-# ---------------------------------------------------------------------------
-# Section 7b: Configure local client (API key for CLI/SDK)
+# Section 7: Configure local client (API key for CLI/SDK)
 # ---------------------------------------------------------------------------
 configure_local_client() {
     local users_cm="$REPO_ROOT/memory-hub-mcp/deploy/users-configmap.yaml"
@@ -964,7 +937,6 @@ main() {
     configure_local_client    # Write API key for CLI/SDK
     prepare_ui_infra          # SA + Secrets before UI
     deploy_ui
-    deploy_tile
     print_summary
     smoke_test
 

--- a/scripts/deploy-full.sh
+++ b/scripts/deploy-full.sh
@@ -693,11 +693,12 @@ deploy_ui() {
         die "UI deploy script not found: $ui_deploy"
     fi
 
-    local ui_args=()
-    if [ "$SKIP_TILE" = true ]; then ui_args+=(--skip-tile); fi
-
     info "Deploying UI (namespace: $UI_NAMESPACE)..."
-    if ! bash "$ui_deploy" "${ui_args[@]}"; then
+    if [ "$SKIP_TILE" = true ]; then
+        if ! bash "$ui_deploy" --skip-tile; then
+            die "UI deployment failed. Check output above."
+        fi
+    elif ! bash "$ui_deploy"; then
         die "UI deployment failed. Check output above."
     fi
 

--- a/scripts/uninstall-full.sh
+++ b/scripts/uninstall-full.sh
@@ -33,6 +33,7 @@ SKIP_DATA=false
 SKIP_TILE=false
 SKIP_MODELS=false
 NO_BACKUP=false
+RHOAI_PRESENT=false
 
 START_TIME=$(date +%s)
 
@@ -124,7 +125,8 @@ confirm() {
     echo ""
     echo "  The following resources will be removed:"
     echo ""
-    if [ "$SKIP_TILE" = false ]; then
+    if [ "$SKIP_TILE" = false ] && oc get namespace --context "$CONTEXT" "$RHOAI_NAMESPACE" &>/dev/null; then
+        RHOAI_PRESENT=true
         echo "    RHOAI tile artifacts in $RHOAI_NAMESPACE"
         echo "      - OdhApplication/memoryhub"
         echo "      - Route/memoryhub-ui"
@@ -432,10 +434,12 @@ summary() {
     banner "Uninstall Complete"
     echo ""
     echo "  Resources removed:"
-    if [ "$SKIP_TILE" = false ]; then
+    if [ "$SKIP_TILE" = true ]; then
+        echo "    ${YELLOW}-${RESET} RHOAI tile artifacts (skipped)"
+    elif [ "$RHOAI_PRESENT" = true ]; then
         echo "    ${GREEN}✓${RESET} RHOAI tile artifacts ($RHOAI_NAMESPACE)"
     else
-        echo "    ${YELLOW}-${RESET} RHOAI tile artifacts (skipped)"
+        echo "    ${YELLOW}-${RESET} RHOAI tile artifacts (not installed)"
     fi
     echo "    ${GREEN}✓${RESET} Namespace $UI_NAMESPACE"
     echo "    ${GREEN}✓${RESET} Legacy UI artifacts in $MCP_PROJECT"

--- a/scripts/uninstall-full.sh
+++ b/scripts/uninstall-full.sh
@@ -435,31 +435,31 @@ summary() {
     echo ""
     echo "  Resources removed:"
     if [ "$SKIP_TILE" = true ]; then
-        echo "    ${YELLOW}-${RESET} RHOAI tile artifacts (skipped)"
+        echo -e "    ${YELLOW}-${RESET} RHOAI tile artifacts (skipped)"
     elif [ "$RHOAI_PRESENT" = true ]; then
-        echo "    ${GREEN}✓${RESET} RHOAI tile artifacts ($RHOAI_NAMESPACE)"
+        echo -e "    ${GREEN}✓${RESET} RHOAI tile artifacts ($RHOAI_NAMESPACE)"
     else
-        echo "    ${YELLOW}-${RESET} RHOAI tile artifacts (not installed)"
+        echo -e "    ${YELLOW}-${RESET} RHOAI tile artifacts (not installed)"
     fi
-    echo "    ${GREEN}✓${RESET} Namespace $UI_NAMESPACE"
-    echo "    ${GREEN}✓${RESET} Legacy UI artifacts in $MCP_PROJECT"
-    echo "    ${GREEN}✓${RESET} Namespace $MCP_PROJECT"
+    echo -e "    ${GREEN}✓${RESET} Namespace $UI_NAMESPACE"
+    echo -e "    ${GREEN}✓${RESET} Legacy UI artifacts in $MCP_PROJECT"
+    echo -e "    ${GREEN}✓${RESET} Namespace $MCP_PROJECT"
     if [ "$SKIP_DATA" = false ]; then
-        echo "    ${GREEN}✓${RESET} Namespace $STORAGE_NAMESPACE (S3 data deleted)"
+        echo -e "    ${GREEN}✓${RESET} Namespace $STORAGE_NAMESPACE (S3 data deleted)"
     else
-        echo "    ${YELLOW}-${RESET} Namespace $STORAGE_NAMESPACE (preserved)"
+        echo -e "    ${YELLOW}-${RESET} Namespace $STORAGE_NAMESPACE (preserved)"
     fi
     if [ "$SKIP_MODELS" = false ]; then
-        echo "    ${GREEN}✓${RESET} Namespace $EMBEDDING_MODEL_NAMESPACE"
-        echo "    ${GREEN}✓${RESET} Namespace $RERANKER_MODEL_NAMESPACE"
+        echo -e "    ${GREEN}✓${RESET} Namespace $EMBEDDING_MODEL_NAMESPACE"
+        echo -e "    ${GREEN}✓${RESET} Namespace $RERANKER_MODEL_NAMESPACE"
     else
-        echo "    ${YELLOW}-${RESET} Model namespaces (skipped)"
+        echo -e "    ${YELLOW}-${RESET} Model namespaces (skipped)"
     fi
-    echo "    ${GREEN}✓${RESET} Namespace $AUTH_PROJECT"
+    echo -e "    ${GREEN}✓${RESET} Namespace $AUTH_PROJECT"
     if [ "$SKIP_DATA" = false ]; then
-        echo "    ${GREEN}✓${RESET} Namespace $DB_NAMESPACE (data deleted)"
+        echo -e "    ${GREEN}✓${RESET} Namespace $DB_NAMESPACE (data deleted)"
     else
-        echo "    ${YELLOW}-${RESET} Namespace $DB_NAMESPACE (preserved)"
+        echo -e "    ${YELLOW}-${RESET} Namespace $DB_NAMESPACE (preserved)"
     fi
     echo ""
     warn "Namespace deletions are async. Verify with:"

--- a/scripts/uninstall-full.sh
+++ b/scripts/uninstall-full.sh
@@ -226,10 +226,19 @@ remove_tile() {
         return 0
     fi
 
-    info "Removing OdhApplication/memoryhub..."
-    oc delete odhapplication --context "$CONTEXT" memoryhub \
-        -n "$RHOAI_NAMESPACE" \
-        --ignore-not-found
+    if ! oc get namespace "$RHOAI_NAMESPACE" --context "$CONTEXT" &>/dev/null; then
+        info "RHOAI not installed ($RHOAI_NAMESPACE namespace not found) — skipping tile cleanup."
+        return 0
+    fi
+
+    if oc get crd odhapplications.dashboard.opendatahub.io --context "$CONTEXT" &>/dev/null; then
+        info "Removing OdhApplication/memoryhub..."
+        oc delete odhapplication --context "$CONTEXT" memoryhub \
+            -n "$RHOAI_NAMESPACE" \
+            --ignore-not-found
+    else
+        info "OdhApplication CRD not found — skipping tile removal."
+    fi
 
     info "Removing Route/memoryhub-ui..."
     oc delete route --context "$CONTEXT" memoryhub-ui \


### PR DESCRIPTION
> **Stacked on #525** — this branch is based on `fix/ui-deploy-rhoai-optional`. Merge #525 first; once it lands, this PR's diff will reduce to the single commit below.

## Summary

On non-RHOAI clusters, `uninstall-full.sh` confirmation prompt listed RHOAI tile artifacts that wouldn't be removed, and `deploy-full.sh` summary printed a misleading "route not found" for the RHOAI dashboard. Guard both behind namespace-existence checks.

Follows up on #525 which already guarded `remove_tile()` and made RHOAI optional — these are the remaining UI output paths that still assumed RHOAI was present.

## Linked issues

Closes #526
Closes #527

## Design reference

- `docs/guides/cluster-install.md`

## Type of change

- [ ] `type:feature` — new user-visible capability
- [x] `type:bug` — fix for incorrect behavior
- [ ] `type:infra` — build, CI, deploy, or tooling change
- [ ] `type:design` — design doc only, no code

## Subsystem

- [ ] `memory-tree`
- [ ] `storage`
- [ ] `curator`
- [ ] `governance`
- [ ] `mcp-server`
- [ ] `operator`
- [ ] `observability`
- [ ] `org-ingestion`
- [ ] `auth`
- [x] `ui`
- [ ] `llamastack`

## Changes

**`scripts/uninstall-full.sh`**
- `confirm()`: RHOAI tile listing gated behind `oc get namespace` — on non-RHOAI clusters the artifact list is omitted entirely
- `summary()`: three-way display — "skipped" (`--skip-tile`), checkmark (RHOAI present), or "(not installed)" (namespace absent)
- New `RHOAI_PRESENT` flag tracks namespace existence from `confirm()` for use in `summary()`

**`scripts/deploy-full.sh`**
- `print_summary()`: RHOAI dashboard route query moved inside namespace-existence guard; shows "(not installed)" when namespace absent, preserves "route not found" diagnostic only when RHOAI is installed but route is missing

## Test plan

- [x] Run `deploy-full.sh` on a non-RHOAI cluster — summary shows `RHOAI dashboard: (not installed)`
- [x] Run `deploy-full.sh` on a RHOAI cluster — summary shows the dashboard URL as before
- [x] Run `uninstall-full.sh` on a non-RHOAI cluster — confirmation prompt omits RHOAI tile artifacts; summary shows `RHOAI tile artifacts (not installed)`
- [x] Run `uninstall-full.sh --skip-tile` — summary shows `RHOAI tile artifacts (skipped)`
- [ ] Golden test (preserve-data): `scripts/uninstall-full.sh --skip-data --yes && scripts/deploy-full.sh`

- [ ] `pytest` passes locally (or the affected subset)
- [x] Manual verification against a running cluster (if applicable)
- [ ] New tests added for new behavior

## Reviewer checklist

- [x] Design doc referenced or created
- [x] No committed credentials or cluster-specific URLs
- [ ] CLAUDE.md / docs updated if behavior or conventions changed
- [x] Commit message follows `subsystem: Imperative summary` format

🤖 Generated with [Claude Code](https://claude.com/claude-code)