### PR TITLE
cli: Add rotate-api-key admin command

### DIFF
--- a/memoryhub-cli/src/memoryhub_cli/admin.py
+++ b/memoryhub-cli/src/memoryhub_cli/admin.py
@@ -100,7 +100,7 @@ def create_agent(
     write_config: bool = typer.Option(
         False,
         "--write-config",
-        help="Write the client_secret to ~/.config/memoryhub/credentials",
+        help="Write the api_key to ~/.config/memoryhub/credentials",
     ),
     context: str = typer.Option(
         "",
@@ -113,7 +113,7 @@ def create_agent(
 ):
     """Create a new agent (OAuth client).
 
-    The client_secret is shown only once. Save it immediately.
+    The client_secret and api_key are shown only once. Save them immediately.
     """
     admin_key = _get_admin_key(output)
     auth_url = _get_auth_url(output)
@@ -160,12 +160,15 @@ def create_agent(
         f"  [yellow bold]Client Secret:   {data['client_secret']}[/yellow bold]"
     )
     console.print(
-        "\n  [dim]Save this secret now. It will not be shown again.[/dim]"
+        f"  [yellow bold]API Key:         {data['api_key']}[/yellow bold]"
+    )
+    console.print(
+        "\n  [dim]Save both values now. They will not be shown again.[/dim]"
     )
 
     if write_config:
         section = context or os.environ.get("MEMORYHUB_CONTEXT", "").strip() or "default"
-        write_credentials_section(section, data["client_secret"])
+        write_credentials_section(section, data["api_key"])
         console.print(f"\n  [green]Secret written to {CREDENTIALS_FILE} [{section}][/green]")
 
 
@@ -234,9 +237,9 @@ def rotate_secret(
         OutputFormat.table, "--output", "-o", help="Output format: table, json, quiet",
     ),
 ):
-    """Rotate the client secret for an agent.
+    """Rotate the client secret for an agent. This also regenerates the API key.
 
-    The new secret is shown only once. Save it immediately.
+    Both values are shown only once. Save them immediately.
     """
     admin_key = _get_admin_key(output)
     auth_url = _get_auth_url(output)
@@ -265,10 +268,13 @@ def rotate_secret(
 
     console.print(f"[green]Secret rotated for {data['client_id']}.[/green]\n")
     console.print(
-        f"  [yellow bold]New Secret:   {data['client_secret']}[/yellow bold]"
+        f"  [yellow bold]New Secret:    {data['client_secret']}[/yellow bold]"
     )
     console.print(
-        "\n  [dim]Save this secret now. It will not be shown again.[/dim]"
+        f"  [yellow bold]New API Key:   {data['api_key']}[/yellow bold]"
+    )
+    console.print(
+        "\n  [dim]Save both values now. They will not be shown again.[/dim]"
     )
 
 

--- a/memoryhub-cli/src/memoryhub_cli/admin.py
+++ b/memoryhub-cli/src/memoryhub_cli/admin.py
@@ -278,6 +278,51 @@ def rotate_secret(
     )
 
 
+@admin_app.command("rotate-api-key")
+def rotate_api_key(
+    client_id: str = typer.Argument(..., help="Client ID of the agent"),
+    output: OutputFormat = typer.Option(
+        OutputFormat.table, "--output", "-o", help="Output format: table, json, quiet",
+    ),
+):
+    """Rotate only the API key for an agent, leaving the client secret unchanged.
+
+    The new API key is shown only once. Save it immediately.
+    """
+    admin_key = _get_admin_key(output)
+    auth_url = _get_auth_url(output)
+
+    async def _do():
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(
+                f"{auth_url}/admin/clients/{client_id}/rotate-api-key",
+                headers=_admin_headers(admin_key),
+                timeout=30,
+            )
+            resp.raise_for_status()
+            return resp.json()
+
+    try:
+        data = _run(_do())
+    except httpx.HTTPStatusError as exc:
+        _handle_http_error(exc, output)
+        return
+
+    if output == OutputFormat.json:
+        json_success(data)
+        return
+    if output == OutputFormat.quiet:
+        return
+
+    console.print(f"[green]API key rotated for {data['client_id']}.[/green]\n")
+    console.print(
+        f"  [yellow bold]New API Key:   {data['api_key']}[/yellow bold]"
+    )
+    console.print(
+        "\n  [dim]Save this key now. It will not be shown again.[/dim]"
+    )
+
+
 @admin_app.command("disable-agent")
 def disable_agent(
     client_id: str = typer.Argument(..., help="Client ID of the agent to disable"),

--- a/memoryhub-cli/tests/test_admin.py
+++ b/memoryhub-cli/tests/test_admin.py
@@ -27,11 +27,16 @@ SAMPLE_CLIENT = {
     "updated_at": "2026-04-14T12:00:00",
 }
 
-SAMPLE_CREATED = {**SAMPLE_CLIENT, "client_secret": "super-secret-value"}
+SAMPLE_CREATED = {
+    **SAMPLE_CLIENT,
+    "client_secret": "super-secret-value",
+    "api_key": "mh-dev-abc123",
+}
 
 SAMPLE_ROTATED = {
     "client_id": "test-agent",
     "client_secret": "new-secret-value",
+    "api_key": "mh-dev-rotated789",
 }
 
 
@@ -82,7 +87,8 @@ class TestCreateAgent:
         assert result.exit_code == 0
         assert "test-agent" in result.output
         assert "super-secret-value" in result.output
-        assert "Save this secret" in result.output
+        assert "mh-dev-abc123" in result.output
+        assert "Save both values" in result.output
 
     def test_json_output(self):
         mock_client = AsyncMock()
@@ -100,6 +106,7 @@ class TestCreateAgent:
         parsed = json.loads(result.output)
         assert parsed["data"]["client_id"] == "test-agent"
         assert parsed["data"]["client_secret"] == "super-secret-value"
+        assert parsed["data"]["api_key"] == "mh-dev-abc123"
 
     def _run_write_config(self, tmp_path, extra_args=None):
         mock_client = AsyncMock()
@@ -129,7 +136,7 @@ class TestCreateAgent:
         import configparser
         cp = configparser.ConfigParser(interpolation=None)
         cp.read(creds)
-        assert cp.get("default", "api_key") == "super-secret-value"
+        assert cp.get("default", "api_key") == "mh-dev-abc123"
 
     def test_write_config_with_context(self, tmp_path):
         result, creds = self._run_write_config(
@@ -139,7 +146,7 @@ class TestCreateAgent:
         import configparser
         cp = configparser.ConfigParser(interpolation=None)
         cp.read(creds)
-        assert cp.get("my-cluster", "api_key") == "super-secret-value"
+        assert cp.get("my-cluster", "api_key") == "mh-dev-abc123"
 
     def test_conflict_409(self):
         error_resp = _mock_error_response(
@@ -233,6 +240,8 @@ class TestRotateSecret:
 
         assert result.exit_code == 0
         assert "new-secret-value" in result.output
+        assert "mh-dev-rotated789" in result.output
+        assert "Save both values" in result.output
         assert "rotated" in result.output.lower()
 
     def test_json_output(self):
@@ -252,6 +261,7 @@ class TestRotateSecret:
         assert result.exit_code == 0
         parsed = json.loads(result.output)
         assert parsed["data"]["client_secret"] == "new-secret-value"
+        assert parsed["data"]["api_key"] == "mh-dev-rotated789"
 
     def test_not_found(self):
         error_resp = _mock_error_response(404, "Client 'ghost' not found")

--- a/memoryhub-cli/tests/test_admin.py
+++ b/memoryhub-cli/tests/test_admin.py
@@ -39,6 +39,11 @@ SAMPLE_ROTATED = {
     "api_key": "mh-dev-rotated789",
 }
 
+SAMPLE_API_KEY_ROTATED = {
+    "client_id": "test-agent",
+    "api_key": "mh-dev-newkey456",
+}
+
 
 def _mock_response(data, status_code=200):
     """Build a mock httpx.Response."""
@@ -277,6 +282,67 @@ class TestRotateSecret:
         with patch.dict("os.environ", _env_with_admin_key(), clear=False):
             with patch("memoryhub_cli.admin.httpx.AsyncClient", return_value=mock_client):
                 result = runner.invoke(app, ["admin", "rotate-secret", "ghost"])
+
+        assert result.exit_code == 1
+        assert "not_found" in result.output
+
+
+# ── rotate-api-key ──────────────────────────────────────────────────────────
+
+
+class TestRotateApiKey:
+    def test_happy_path(self):
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.post = AsyncMock(
+            return_value=_mock_response(SAMPLE_API_KEY_ROTATED)
+        )
+
+        with patch.dict("os.environ", _env_with_admin_key(), clear=False):
+            with patch("memoryhub_cli.admin.httpx.AsyncClient", return_value=mock_client):
+                result = runner.invoke(
+                    app, ["admin", "rotate-api-key", "test-agent"]
+                )
+
+        assert result.exit_code == 0
+        assert "mh-dev-newkey456" in result.output
+        assert "Save this key" in result.output
+        assert "rotated" in result.output.lower()
+
+    def test_json_output(self):
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.post = AsyncMock(
+            return_value=_mock_response(SAMPLE_API_KEY_ROTATED)
+        )
+
+        with patch.dict("os.environ", _env_with_admin_key(), clear=False):
+            with patch("memoryhub_cli.admin.httpx.AsyncClient", return_value=mock_client):
+                result = runner.invoke(
+                    app, ["admin", "rotate-api-key", "test-agent", "--output", "json"]
+                )
+
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert parsed["data"]["client_id"] == "test-agent"
+        assert parsed["data"]["api_key"] == "mh-dev-newkey456"
+
+    def test_not_found(self):
+        error_resp = _mock_error_response(404, "Client 'ghost' not found")
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.post = AsyncMock(
+            side_effect=httpx.HTTPStatusError(
+                "not found", request=error_resp.request, response=error_resp
+            )
+        )
+
+        with patch.dict("os.environ", _env_with_admin_key(), clear=False):
+            with patch("memoryhub_cli.admin.httpx.AsyncClient", return_value=mock_client):
+                result = runner.invoke(app, ["admin", "rotate-api-key", "ghost"])
 
         assert result.exit_code == 1
         assert "not_found" in result.output


### PR DESCRIPTION
## Summary

Adds `memoryhub admin rotate-api-key <client_id>` to rotate just the `api_key` for an agent without touching `client_secret` — mirrors the existing `rotate-secret` command, following the same pattern.

## Linked issues

Closes #459

## Design reference

- `docs/identity-model/cli-requirements.md`

## Type of change

- [x] `type:feature` — new user-visible capability

## Subsystem

Closest existing label: `subsystem:client`

## Test plan

- [x] **Unit tests only** — no infrastructure boundaries touched (pure logic, no DB/Valkey/embedding service interaction)
- [x] `pytest` passes locally (or the affected subset)
- [x] New tests added for new behavior

`pytest memoryhub-cli/tests/test_admin.py` — all tests pass, including new `TestRotateApiKey` (happy path, JSON output, 404 not-found).

## Reviewer checklist

- [x] Design doc referenced or created
- [x] No committed credentials or cluster-specific URLs
- [x] CLAUDE.md / docs updated if behavior or conventions changed
- [x] Commit message follows `subsystem: Imperative summary` format

## Release readiness (if this PR touches `sdk/` or `memoryhub-cli/`)

- [ ] `pyproject.toml` version matches `__init__.py` `__version__`
- [ ] `CHANGELOG.md` has an entry for the new version
- [ ] If breaking: CHANGELOG entry is flagged with `BREAKING` and links the tracking issue