### PR TITLE
retrieval: Surface effective_k so silent k-capping is visible (#404)

### DIFF
--- a/benchmarks/evalhub-adapter/src/memoryhub_evalhub/preflight.py
+++ b/benchmarks/evalhub-adapter/src/memoryhub_evalhub/preflight.py
@@ -176,10 +176,62 @@ def get_version_shas() -> dict:
 # ---------------------------------------------------------------------------
 
 
+def check_retrieval_caps(
+    requested_k: int | None = None,
+    *,
+    harness_k: int | None = None,
+    sdk_max_results: int | None = None,
+    tool_max_results: int = 200,
+) -> dict:
+    """Compute the effective_k after all caps in the retrieval chain.
+
+    Each layer in the chain (harness env, SDK config, MCP tool param)
+    may clamp the requested k.  Returns a dict with ``requested_k``,
+    ``effective_k``, and ``caps`` (list of caps that reduced k).
+
+    Logs one warning per request when any cap is triggered.
+    """
+    # `or 10` would silently rewrite an explicit 0 (falsy) back to 10 —
+    # the same silent-capping class #404 is meant to kill.
+    resolved_requested = requested_k if requested_k is not None else 10
+    k = resolved_requested
+    caps: list[dict[str, object]] = []
+
+    if harness_k is not None and k > harness_k:
+        caps.append({"source": "harness", "limit": harness_k})
+        k = harness_k
+
+    if sdk_max_results is not None and k > sdk_max_results:
+        caps.append({"source": "sdk_config", "limit": sdk_max_results})
+        k = sdk_max_results
+
+    if k > tool_max_results:
+        caps.append({"source": "mcp_tool_param", "limit": tool_max_results})
+        k = tool_max_results
+
+    if caps:
+        sources = ", ".join(c["source"] for c in caps)
+        logger.warning(
+            "effective_k capped: requested_k=%d effective_k=%d cap_sources=[%s]",
+            resolved_requested, k, sources,
+        )
+
+    return {
+        "requested_k": resolved_requested,
+        "effective_k": k,
+        "caps": caps,
+    }
+
+
 async def run_preflight(
     db_url: str,
     tenant_id: str = "amb-benchmark",
     reranker_url: str | None = None,
+    *,
+    requested_k: int | None = None,
+    harness_k: int | None = None,
+    sdk_max_results: int | None = None,
+    tool_max_results: int = 200,
 ) -> dict:
     """Execute all preflight checks and return the manifest dict."""
     conn = await asyncpg.connect(db_url)
@@ -193,6 +245,12 @@ async def run_preflight(
                 "domain": await check_signal_domain(conn, tenant_id),
                 "graph": await check_signal_graph(conn, tenant_id),
             },
+            "retrieval": check_retrieval_caps(
+                requested_k,
+                harness_k=harness_k,
+                sdk_max_results=sdk_max_results,
+                tool_max_results=tool_max_results,
+            ),
             "corpus": await check_corpus(conn, tenant_id),
             "versions": get_version_shas(),
             "timestamp": datetime.now(UTC).isoformat(),
@@ -287,8 +345,28 @@ def main() -> None:
     reranker_url = os.environ.get("MEMORYHUB_RERANKER_URL")
     tenant_id = os.environ.get("MEMORYHUB_TENANT_ID", "amb-benchmark")
 
+    # MEMORYHUB_K is the desired k (what the operator wants), not a cap.
+    # The harness _resolve_k overrides UP (None/10 → MEMORYHUB_K), so
+    # there is no harness cap to pass here.
+    raw_requested_k = os.environ.get("MEMORYHUB_K", "").strip()
+    requested_k = int(raw_requested_k) if raw_requested_k else None
+
+    sdk_max_results: int | None = None
+    try:
+        from memoryhub.config import load_project_config
+
+        sdk_max_results = load_project_config().retrieval_defaults.max_results
+    except ImportError:
+        logger.debug("memoryhub SDK not installed; skipping SDK config for preflight")
+
     manifest = asyncio.run(
-        run_preflight(db_url, tenant_id=tenant_id, reranker_url=reranker_url)
+        run_preflight(
+            db_url,
+            tenant_id=tenant_id,
+            reranker_url=reranker_url,
+            requested_k=requested_k,
+            sdk_max_results=sdk_max_results,
+        )
     )
     print(json.dumps(manifest, indent=2))
 

--- a/benchmarks/evalhub-adapter/tests/test_preflight.py
+++ b/benchmarks/evalhub-adapter/tests/test_preflight.py
@@ -20,6 +20,7 @@ _mod = importlib.util.module_from_spec(_spec)
 sys.modules[_mod.__name__] = _mod
 _spec.loader.exec_module(_mod)
 
+check_retrieval_caps = _mod.check_retrieval_caps
 check_signal_focus = _mod.check_signal_focus
 check_signal_reranker = _mod.check_signal_reranker
 enforce_manifest = _mod.enforce_manifest
@@ -43,6 +44,11 @@ SAMPLE_MANIFEST = {
         "focus": {"active": False, "reason": "benchmark does not call set_focus"},
         "domain": {"active": True, "tagged_count": 500},
         "graph": {"active": False, "edge_count": 0},
+    },
+    "retrieval": {
+        "requested_k": 10,
+        "effective_k": 10,
+        "caps": [],
     },
     "corpus": {
         "tenant_id": "amb-benchmark",
@@ -178,3 +184,155 @@ class TestCheckSignalReranker:
         assert result["active"] is False
         assert result["url"] == "http://192.0.2.1:1"
         assert "reason" in result
+
+
+# ---------------------------------------------------------------------------
+# check_retrieval_caps
+# ---------------------------------------------------------------------------
+
+
+class TestCheckRetrievalCaps:
+    def test_no_caps_applied(self):
+        result = check_retrieval_caps(10)
+        assert result["requested_k"] == 10
+        assert result["effective_k"] == 10
+        assert result["caps"] == []
+
+    def test_harness_cap(self):
+        result = check_retrieval_caps(70, harness_k=50)
+        assert result["requested_k"] == 70
+        assert result["effective_k"] == 50
+        assert len(result["caps"]) == 1
+        assert result["caps"][0]["source"] == "harness"
+
+    def test_sdk_cap(self):
+        result = check_retrieval_caps(70, sdk_max_results=50)
+        assert result["requested_k"] == 70
+        assert result["effective_k"] == 50
+        assert len(result["caps"]) == 1
+        assert result["caps"][0]["source"] == "sdk_config"
+
+    def test_tool_cap(self):
+        result = check_retrieval_caps(300, tool_max_results=200)
+        assert result["requested_k"] == 300
+        assert result["effective_k"] == 200
+        assert len(result["caps"]) == 1
+        assert result["caps"][0]["source"] == "mcp_tool_param"
+
+    def test_multiple_caps_lowest_wins(self):
+        result = check_retrieval_caps(
+            70, harness_k=50, sdk_max_results=30, tool_max_results=200
+        )
+        assert result["requested_k"] == 70
+        assert result["effective_k"] == 30
+        assert len(result["caps"]) == 2
+
+    def test_default_requested_k(self):
+        result = check_retrieval_caps(None)
+        assert result["requested_k"] == 10
+        assert result["effective_k"] == 10
+
+    def test_explicit_zero_not_replaced_with_default(self):
+        """Regression: requested_k=0 must not be swallowed by `or 10`."""
+        result = check_retrieval_caps(0)
+        assert result["requested_k"] == 0
+        assert result["effective_k"] == 0
+        assert result["caps"] == []
+
+    def test_deliberate_cap_k70_cap10(self):
+        """Issue #404: k=70 with cap=10 should clearly show the discrepancy."""
+        result = check_retrieval_caps(70, harness_k=10)
+        assert result["requested_k"] == 70
+        assert result["effective_k"] == 10
+        assert result["caps"][0]["source"] == "harness"
+        assert result["caps"][0]["limit"] == 10
+
+        # Verify this shows up as a mismatch in manifest enforcement
+        # when the expected manifest assumes no cap was applied.
+        manifest_with_cap = {**SAMPLE_MANIFEST, "retrieval": result}
+        expected_no_cap = {
+            "retrieval": {"effective_k": 70}
+        }
+        ok, diff = enforce_manifest(manifest_with_cap, expected_no_cap)
+        assert ok is False
+        assert "retrieval.effective_k" in diff
+        assert "70" in diff
+        assert "10" in diff
+
+
+# ---------------------------------------------------------------------------
+# main() wiring
+# ---------------------------------------------------------------------------
+
+main = _mod.main
+run_preflight = _mod.run_preflight
+
+
+class TestMainWiring:
+    """Verify main() passes the right values to run_preflight."""
+
+    def _run_main(self, monkeypatch, env_overrides=None):
+        """Helper: run main() with mocked run_preflight, return captured kwargs."""
+        env = {
+            "MEMORYHUB_DB_HOST": "localhost",
+            "MEMORYHUB_DB_PORT": "5432",
+            "MEMORYHUB_DB_USER": "test",
+            "MEMORYHUB_DB_PASS": "test",
+            "MEMORYHUB_DB_NAME": "test",
+        }
+        if env_overrides:
+            env.update(env_overrides)
+        for k, v in env.items():
+            monkeypatch.setenv(k, v)
+        monkeypatch.delenv("MEMORYHUB_RERANKER_URL", raising=False)
+        monkeypatch.delenv("MEMORYHUB_TENANT_ID", raising=False)
+        monkeypatch.setattr("sys.argv", ["preflight"])
+
+        captured = {}
+
+        async def fake_run_preflight(db_url, **kwargs):
+            captured.update(kwargs)
+            return {
+                "signals": {},
+                "retrieval": check_retrieval_caps(
+                    kwargs.get("requested_k"),
+                    sdk_max_results=kwargs.get("sdk_max_results"),
+                ),
+                "corpus": {},
+                "versions": {},
+                "timestamp": "",
+            }
+
+        monkeypatch.setattr(_mod, "run_preflight", fake_run_preflight)
+        main()
+        return captured
+
+    def test_memoryhub_k_becomes_requested_k(self, monkeypatch):
+        """MEMORYHUB_K should flow to requested_k, not harness_k."""
+        captured = self._run_main(monkeypatch, {"MEMORYHUB_K": "70"})
+        assert captured["requested_k"] == 70
+        assert captured.get("harness_k") is None
+
+    def test_no_memoryhub_k_yields_none(self, monkeypatch):
+        monkeypatch.delenv("MEMORYHUB_K", raising=False)
+        captured = self._run_main(monkeypatch)
+        assert captured["requested_k"] is None
+
+    def test_sdk_max_results_not_passed_without_sdk(self, monkeypatch):
+        """When memoryhub SDK is not importable, sdk_max_results should be None."""
+        monkeypatch.delenv("MEMORYHUB_K", raising=False)
+        captured = self._run_main(monkeypatch)
+        assert captured.get("sdk_max_results") is None
+
+    def test_harness_k_not_duplicated_from_memoryhub_k(self, monkeypatch):
+        """Regression: main() must not pass the same MEMORYHUB_K as both
+        requested_k and harness_k — the harness overrides UP, not caps DOWN."""
+        captured = self._run_main(monkeypatch, {"MEMORYHUB_K": "70"})
+        assert captured["requested_k"] == 70
+        assert captured.get("harness_k") is None
+
+    def test_memoryhub_k_zero_is_preserved(self, monkeypatch):
+        """Explicit MEMORYHUB_K=0 must reach requested_k as 0, not become None/10."""
+        captured = self._run_main(monkeypatch, {"MEMORYHUB_K": "0"})
+        assert captured["requested_k"] == 0
+        assert captured.get("harness_k") is None

--- a/memory-hub-mcp/src/tools/search_memory.py
+++ b/memory-hub-mcp/src/tools/search_memory.py
@@ -912,6 +912,13 @@ async def search_memory(
             f"Valid scopes: {', '.join(sorted(VALID_SCOPES))}."
         )
 
+    # effective_k: the actual result count limit the server will apply.
+    # Pydantic already validated max_results to [1, 200], so this is
+    # the value the server uses. Upstream caps (harness env, SDK config)
+    # happen before the request reaches us — this field lets consumers
+    # compare what the server received against what they originally wanted.
+    effective_k = max_results
+
     record_event(
         event_type="memory.search",
         actor_id=claims["sub"],
@@ -1054,6 +1061,7 @@ async def search_memory(
                 "results": [],
                 "total_matching": total_matching,
                 "has_more": False,
+                "effective_k": effective_k,
                 "message": (
                     "No memories found matching your query. "
                     "Try broader search terms or remove scope/owner filters."
@@ -1284,6 +1292,7 @@ async def search_memory(
             "total_matching": total_matching,
             "has_more": total_matching > len(formatted),
             "content_mode": content_mode,
+            "effective_k": effective_k,
         }
         if compilation_meta is not None:
             response["compilation_hash"] = compilation_meta["compilation_hash"]

--- a/memory-hub-mcp/tests/tools/test_search_memory.py
+++ b/memory-hub-mcp/tests/tools/test_search_memory.py
@@ -1974,3 +1974,58 @@ class TestCompactEntryHonestyFlags:
         assert "content_truncated" in entry
         assert "full_available" in entry
         assert entry["relevance_score"] == 0.85
+
+
+# ---------------------------------------------------------------------------
+# effective_k observability (#404)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_search_memory_effective_k_in_response():
+    """effective_k appears in the search response metadata."""
+    result = await _patched_search_call(
+        [_fake_search_result("mem1", 0.9)],
+        total_matching=1,
+        max_results=15,
+    ).run()
+    assert "effective_k" in result
+    assert result["effective_k"] == 15
+
+
+@pytest.mark.asyncio
+async def test_search_memory_effective_k_default():
+    """effective_k equals max_results default (10) when not specified."""
+    result = await _patched_search_call(
+        [_fake_search_result("mem1", 0.9)],
+        total_matching=1,
+    ).run()
+    assert result["effective_k"] == 10
+
+
+@pytest.mark.asyncio
+async def test_search_memory_effective_k_in_empty_response():
+    """effective_k appears even when no results are returned."""
+    result = await _patched_search_call(
+        [],
+        total_matching=0,
+        max_results=20,
+    ).run()
+    assert "effective_k" in result
+    assert result["effective_k"] == 20
+
+
+@pytest.mark.asyncio
+async def test_search_memory_effective_k_at_tool_boundary():
+    """effective_k equals max_results at the upper boundary (200).
+
+    Pydantic rejects max_results > 200 before the function body runs,
+    so effective_k always equals the received max_results. This test
+    verifies behavior at the boundary.
+    """
+    result = await _patched_search_call(
+        [_fake_search_result("mem1", 0.9)],
+        total_matching=1,
+        max_results=200,
+    ).run()
+    assert result["effective_k"] == 200

--- a/sdk/src/memoryhub/client.py
+++ b/sdk/src/memoryhub/client.py
@@ -550,6 +550,10 @@ class MemoryHubClient:
         loading = self._project_config.memory_loading
         if max_results is None:
             max_results = defaults.max_results
+            logger.debug(
+                "max_results not specified, using SDK default: %d",
+                max_results,
+            )
         if mode is None:
             mode = defaults.default_mode
         if max_response_tokens is None:

--- a/sdk/src/memoryhub/models.py
+++ b/sdk/src/memoryhub/models.py
@@ -101,6 +101,7 @@ class SearchResult(BaseModel):
     results: list[Memory]
     total_matching: int = 0
     has_more: bool = False
+    effective_k: int | None = None
     pivot_suggested: bool | None = None
     pivot_reason: str | None = None
     focus_fallback_reason: str | None = None


### PR DESCRIPTION
## Summary
Operators had no signal when `MEMORYHUB_K` was reduced by a later cap in
the harness / SDK / MCP tool chain. This adds `effective_k` to search
responses and a `retrieval` block on the preflight manifest
(`requested_k`, `effective_k`, `caps[]`), and logs one warning when any
stage clamps k.
The MCP server cannot see upstream harness/SDK caps — it reports the
`max_results` it actually received (Pydantic `[1, 200]`). Per-stage cap
decisions live in the preflight manifest.
## Linked issues
Closes #404
## Design reference
- `session-summaries/2026-07-15-dreaming-chunk-sweep-facts.md` (max_results chain)
- `NEXT_SESSION-retrieval-polish.md` (Phase 1 / #404)
- Commit `79537e1` (immediate cap fix; this PR is the observability follow-up)
## Type of change
- [ ] `type:feature` — new user-visible capability
- [x] `type:bug` — fix for incorrect behavior
- [ ] `type:infra` — build, CI, deploy, or tooling change
- [ ] `type:design` — design doc only, no code
## Subsystem
- [x] `memory-tree`
- [ ] `storage`
- [ ] `curator`
- [ ] `governance`
- [ ] `mcp-server`
- [ ] `operator`
- [ ] `observability`
- [ ] `org-ingestion`
- [ ] `auth`
- [ ] `ui`
- [ ] `llamastack`
## Test plan
- [x] **Unit tests only** — no infrastructure boundaries touched
      (pure logic, no DB/Valkey/embedding service interaction)
- [ ] **Integration tests included for:**
      `[ pgvector / Valkey / embedding service / auth / S3 ]`
- [ ] **Integration tests deferred because:**
- [x] `pytest` passes locally (or the affected subset)
- [ ] Manual verification against a running cluster (if applicable)
- [x] New tests added for new behavior
Locally verified:
- `pytest benchmarks/evalhub-adapter/tests/test_preflight.py` — 27 passed
  (includes `test_deliberate_cap_k70_cap10`: k=70 + cap=10 → manifest mismatch)
- `pytest memory-hub-mcp/tests/tools/test_search_memory.py -k effective_k` — 4 passed
- `pytest sdk/tests/test_models.py -k search_result` — 3 passed
- Preflight warning fires once on cap, silent when no cap
## Reviewer checklist
- [x] Design doc referenced or created
- [x] No committed credentials or cluster-specific URLs
- [ ] CLAUDE.md / docs updated if behavior or conventions changed
- [x] Commit message follows `subsystem: Imperative summary` format
Same-commit consumer audit: `search_memory` gained `effective_k`;
`sdk/src/memoryhub/models.py` (`SearchResult`) was updated in the same
commit. `memoryhub-ui/backend/` and `memoryhub-cli/` do not consume this
field.
## Release readiness (if this PR touches `sdk/` or `memoryhub-cli/`)
Additive, backward-compatible field (`effective_k: int | None = None`).
No SDK version bump in this PR — follow the usual separate SDK release
if this should ship to PyPI.
- [x] `pyproject.toml` version matches `__init__.py` `__version__` (unchanged, 0.15.3)
- [ ] `CHANGELOG.md` has an entry for the new version
- [ ] If breaking: CHANGELOG entry is flagged with `BREAKING` and links the tracking issue