### PR TITLE
embeddings: Eager /info fetch at startup and cache env fallback

### DIFF
--- a/memory-hub-mcp/src/main.py
+++ b/memory-hub-mcp/src/main.py
@@ -23,6 +23,7 @@ Default: compact.
 
 import logging
 import os
+from contextlib import asynccontextmanager
 
 from fastmcp import FastMCP
 
@@ -116,7 +117,17 @@ _PROFILE_MAP = {
 
 tools, instructions = _PROFILE_MAP[TOOL_PROFILE]
 
-mcp = FastMCP("MemoryHub", instructions=instructions)
+
+@asynccontextmanager
+async def lifespan(server):
+    from src.tools._deps import get_embedding_service
+    svc = get_embedding_service()
+    if hasattr(svc, "initialize"):
+        await svc.initialize()
+    yield {}
+
+
+mcp = FastMCP("MemoryHub", instructions=instructions, lifespan=lifespan)
 
 for tool_fn in tools:
     mcp.add_tool(tool_fn)

--- a/src/memoryhub_core/services/embeddings.py
+++ b/src/memoryhub_core/services/embeddings.py
@@ -103,12 +103,20 @@ class HttpEmbeddingService(EmbeddingService):
         self._client = httpx.AsyncClient(timeout=timeout)
         self._max_tokens: int | None = None
         self._info_fetched = False
+        max_tokens_override = os.environ.get("MEMORYHUB_EMBEDDING_MAX_TOKENS")
+        self._fallback_max_tokens_value: int = (
+            int(max_tokens_override) if max_tokens_override is not None else _DEFAULT_MAX_TOKENS
+        )
 
     @property
     def max_tokens(self) -> int:
         if self._max_tokens is not None:
             return self._max_tokens
-        return self._fallback_max_tokens()
+        return self._fallback_max_tokens_value
+
+    async def initialize(self) -> None:
+        """Eagerly discover model limits. Call at startup."""
+        await self._fetch_info()
 
     async def _fetch_info(self) -> None:
         """Query TEI /info once to discover max_input_length."""
@@ -134,37 +142,30 @@ class HttpEmbeddingService(EmbeddingService):
                 logger.warning(
                     "TEI /info response missing max_input_length; "
                     "falling back to %d tokens",
-                    self._fallback_max_tokens(),
+                    self._fallback_max_tokens_value,
                 )
         except httpx.ConnectError:
             logger.warning(
                 "Could not connect to TEI /info at %s; "
                 "using fallback max_tokens=%d",
                 info_url,
-                self._fallback_max_tokens(),
+                self._fallback_max_tokens_value,
             )
         except httpx.TimeoutException:
             logger.warning(
                 "TEI /info request timed out (%s); "
                 "using fallback max_tokens=%d",
                 info_url,
-                self._fallback_max_tokens(),
+                self._fallback_max_tokens_value,
             )
         except Exception:
             logger.warning(
                 "Failed to query TEI /info at %s; "
                 "using fallback max_tokens=%d",
                 info_url,
-                self._fallback_max_tokens(),
+                self._fallback_max_tokens_value,
                 exc_info=True,
             )
-
-    @staticmethod
-    def _fallback_max_tokens() -> int:
-        env = os.environ.get("MEMORYHUB_EMBEDDING_MAX_TOKENS")
-        if env is not None:
-            return int(env)
-        return _DEFAULT_MAX_TOKENS
 
     async def embed(self, text: str) -> list[float]:
         await self._fetch_info()

--- a/tests/test_services/test_embedding_errors.py
+++ b/tests/test_services/test_embedding_errors.py
@@ -215,6 +215,44 @@ async def test_info_fallback_env_var(monkeypatch):
     assert svc.max_tokens == 256
 
 
+# -- Eager initialization (#523) --
+
+
+@pytest.mark.asyncio
+async def test_initialize_triggers_fetch_info():
+    """initialize() calls _fetch_info so max_tokens is populated before first embed."""
+    svc = HttpEmbeddingService(url=_URL)
+
+    info_body = json.dumps({"max_input_length": 256}).encode()
+    info_response = httpx.Response(200, request=httpx.Request("GET", "http://test-embedder/info"), content=info_body)
+    mock_get = AsyncMock(return_value=info_response)
+
+    with patch.object(svc._client, "get", mock_get):
+        await svc.initialize()
+
+    assert svc.max_tokens == 256
+    assert svc._info_fetched is True
+    mock_get.assert_called_once()
+
+
+# -- Cached env fallback (#524) --
+
+
+def test_fallback_env_var_cached_at_construction(monkeypatch):
+    """MEMORYHUB_EMBEDDING_MAX_TOKENS is read once at construction, not on every access."""
+    monkeypatch.setenv("MEMORYHUB_EMBEDDING_MAX_TOKENS", "512")
+    svc = HttpEmbeddingService(url=_URL)
+    monkeypatch.delenv("MEMORYHUB_EMBEDDING_MAX_TOKENS")
+
+    assert svc.max_tokens == 512
+
+
+def test_fallback_without_env_var():
+    """Without the env var, fallback returns the hardcoded default."""
+    svc = HttpEmbeddingService(url=_URL)
+    assert svc.max_tokens == _DEFAULT_MAX_TOKENS
+
+
 # -- MockEmbeddingService max_tokens --
 
 


### PR DESCRIPTION
## Summary

- Add a FastMCP lifespan that calls `initialize()` on `HttpEmbeddingService` at startup so `max_tokens` is discovered from TEI's `/info` endpoint before the first request arrives
- Cache `MEMORYHUB_EMBEDDING_MAX_TOKENS` env var once in `__init__` instead of re-reading `os.environ` on every fallback access, matching the pattern used for `MEMORYHUB_EMBEDDING_URL` and `MEMORYHUB_EMBEDDING_TIMEOUT`
- Remove the `_fallback_max_tokens()` staticmethod — the fallback is now resolved to a concrete value at construction time

## Linked issues

Closes #523
Closes #524

## Design reference

`docs/design/storage-layer.md`

## Type of change

- [ ] `type:feature` — new user-visible capability
- [x] `type:bug` — fix for incorrect behavior
- [ ] `type:infra` — build, CI, deploy, or tooling change
- [ ] `type:design` — design doc only, no code

## Subsystem

- [ ] `storage`
- [x] `mcp-server`

## Test plan

- [x] **Unit tests only** — no infrastructure boundaries touched
      (pure logic, no DB/Valkey/embedding service interaction)

- [x] `pytest` passes locally (16 passed in `test_embedding_errors.py`)
- [x] Manual verification against a running cluster (if applicable)
- [x] New tests added for new behavior

**New tests (3):** `initialize()` triggers `/info` fetch, env var cached at construction (set → construct → unset → confirm cached value persists), fallback without env var returns hardcoded default.

**Manual verification:** Deployed to cluster — confirmed `max_input_length: 256 tokens (from TEI /info)` log line appears at startup before "Starting MCP server" message.

## Reviewer checklist

- [x] Design doc referenced or created
- [x] No committed credentials or cluster-specific URLs
- [ ] CLAUDE.md / docs updated if behavior or conventions changed
- [x] Commit message follows `subsystem: Imperative summary` format