### PR TITLE
retrieval: Rank on prefix, hydrate top-k for S3-backed search results (#389)

### DIFF
--- a/memory-hub-mcp/src/tools/search_memory.py
+++ b/memory-hub-mcp/src/tools/search_memory.py
@@ -1064,32 +1064,6 @@ async def search_memory(
                 response["pivot_reason"] = focus_meta["pivot_reason"]
             return response
 
-        # --- S3 hydration for content_mode="full" ---
-        if content_mode == "full":
-            s3 = get_s3_adapter()
-            if s3 is not None:
-                for idx, (item, score) in enumerate(results):
-                    if (
-                        isinstance(item, MemoryNodeRead)
-                        and item.storage_type == "s3"
-                        and item.content_ref
-                    ):
-                        try:
-                            full_content = await s3.get_content(item.content_ref)
-                            results[idx] = (
-                                item.model_copy(update={
-                                    "content": full_content,
-                                    "content_truncated": False,
-                                    "full_available": False,
-                                }),
-                                score,
-                            )
-                        except Exception as exc:
-                            logger.warning(
-                                "S3 hydration failed for %s: %s",
-                                item.id, exc,
-                            )
-
         # mode='index' degrades every full result to stub form. Done before
         # branch handling so nested branches are also stubs in this mode.
         if mode == "index":
@@ -1179,6 +1153,64 @@ async def search_memory(
                     pid: bs for pid, bs in nested_by_parent.items() if pid in kept_ids
                 }
 
+        # --- S3 hydration for content_mode="full" ---
+        # Hydration happens lazily inside the token-budget packing loop
+        # below, right before an entry is finalized as full-form. That is
+        # the only point where the true final top-k -- post mode
+        # conversion, backfill, compilation cap, branch nesting, AND
+        # budget packing -- is known. Fetching eagerly here would still
+        # pay S3 I/O for entries the budget cap goes on to degrade to
+        # stubs.
+        #
+        # The cost check that gates the fetch is computed from the
+        # un-hydrated (truncated) content, so it's an estimate -- but
+        # max_response_tokens is already documented as a *soft* cap, so
+        # an entry occasionally landing a bit over budget once hydrated
+        # is consistent with the existing contract, not a new risk.
+        s3 = get_s3_adapter() if content_mode == "full" else None
+
+        async def _hydrate_item(item: MemoryNodeRead) -> MemoryNodeRead:
+            if item.storage_type == "s3" and item.content_ref:
+                try:
+                    full = await s3.get_content(item.content_ref)
+                    return item.model_copy(update={
+                        "content": full,
+                        "content_truncated": False,
+                        "full_available": False,
+                    })
+                except Exception as exc:
+                    logger.warning(
+                        "S3 hydration failed for %s: %s",
+                        item.id, exc,
+                    )
+            return item
+
+        async def _hydrate_full_entry(
+            item: MemoryNodeRead | MemoryNodeStub,
+            child_branches: list[tuple[MemoryNodeRead | MemoryNodeStub, float]],
+        ) -> tuple[
+            MemoryNodeRead | MemoryNodeStub,
+            list[tuple[MemoryNodeRead | MemoryNodeStub, float]],
+            bool,
+        ]:
+            """Hydrate an item and its branches once they're known to survive
+            as full-form. Returns (item, child_branches, changed); changed is
+            True when a fetch updated content, so the caller knows to re-run
+            _format_entry/_format_entry_cached for an accurate cost."""
+            if s3 is None or not isinstance(item, MemoryNodeRead):
+                return item, child_branches, False
+            new_item = await _hydrate_item(item)
+            changed = new_item is not item
+            new_branches = []
+            for b, bscore in child_branches:
+                if isinstance(b, MemoryNodeRead):
+                    new_b = await _hydrate_item(b)
+                    changed = changed or (new_b is not b)
+                else:
+                    new_b = b
+                new_branches.append((new_b, bscore))
+            return new_item, new_branches, changed
+
         # Token-budget packing. Walk results in order; full-form entries
         # that exceed the remaining budget (and everything after them)
         # are degraded to stub form. Stubs are always included so the
@@ -1217,8 +1249,35 @@ async def search_memory(
                     item, child_branches, is_appendix, verbose=verbose,
                 )
                 if skip_budget or isinstance(item, MemoryNodeStub) or cost <= budget:
-                    formatted.append(entry)
-                    budget = max(0, budget - cost)
+                    item, child_branches, changed = await _hydrate_full_entry(
+                        item, child_branches,
+                    )
+                    if changed:
+                        entry, cost = _format_entry_cached(
+                            item, child_branches, is_appendix, verbose=verbose,
+                        )
+                    # Re-check against the real (post-hydration) cost -- the
+                    # pre-hydration estimate came from truncated content and
+                    # can be far off for S3-backed items, which were spilled
+                    # to S3 precisely because they're large. Bound the waste
+                    # to this one boundary item rather than trusting the
+                    # cheap estimate.
+                    if skip_budget or cost <= budget:
+                        formatted.append(entry)
+                        budget = max(0, budget - cost)
+                    else:
+                        budget_exhausted = True
+                        stub_item = _to_stub(item)
+                        stub_branches = [
+                            ((_to_stub(b) if isinstance(b, MemoryNodeRead) else b), s)
+                            for b, s in child_branches
+                        ]
+                        stub_entry, stub_cost = _format_entry_cached(
+                            stub_item, stub_branches, is_appendix,
+                            verbose=verbose,
+                        )
+                        formatted.append(stub_entry)
+                        budget = max(0, budget - stub_cost)
                 else:
                     budget_exhausted = True
                     stub_item = _to_stub(item)
@@ -1260,8 +1319,34 @@ async def search_memory(
                     item, relevance_score, child_branches, verbose=verbose,
                 )
                 if skip_budget or isinstance(item, MemoryNodeStub) or cost <= budget:
-                    formatted.append(entry)
-                    budget = max(0, budget - cost)
+                    item, child_branches, changed = await _hydrate_full_entry(
+                        item, child_branches,
+                    )
+                    if changed:
+                        entry, cost = _format_entry(
+                            item, relevance_score, child_branches, verbose=verbose,
+                        )
+                    # Re-check against the real (post-hydration) cost -- see
+                    # the matching comment in the cache-optimized branch above.
+                    if skip_budget or cost <= budget:
+                        formatted.append(entry)
+                        budget = max(0, budget - cost)
+                    else:
+                        budget_exhausted = True
+                        stub_item = _to_stub(item)
+                        stub_branches = [
+                            (
+                                (_to_stub(b) if isinstance(b, MemoryNodeRead) else b),
+                                s,
+                            )
+                            for b, s in child_branches
+                        ]
+                        stub_entry, stub_cost = _format_entry(
+                            stub_item, relevance_score, stub_branches,
+                            verbose=verbose,
+                        )
+                        formatted.append(stub_entry)
+                        budget = max(0, budget - stub_cost)
                 else:
                     budget_exhausted = True
                     stub_item = _to_stub(item)

--- a/memory-hub-mcp/src/tools/search_memory.py
+++ b/memory-hub-mcp/src/tools/search_memory.py
@@ -1224,145 +1224,83 @@ async def search_memory(
         budget_exhausted = False
         formatted: list[dict[str, Any]] = []
 
+        def _stubbed_entry(
+            item: MemoryNodeRead | MemoryNodeStub,
+            child_branches: list[tuple[MemoryNodeRead | MemoryNodeStub, float]],
+            format_fn,
+        ) -> tuple[dict[str, Any], int]:
+            stub_item = _to_stub(item) if isinstance(item, MemoryNodeRead) else item
+            stub_branches = [
+                ((_to_stub(b) if isinstance(b, MemoryNodeRead) else b), s)
+                for b, s in child_branches
+            ]
+            return format_fn(stub_item, stub_branches)
+
+        async def _pack_entry(
+            item: MemoryNodeRead | MemoryNodeStub,
+            child_branches: list[tuple[MemoryNodeRead | MemoryNodeStub, float]],
+            budget: int,
+            budget_exhausted: bool,
+            format_fn,
+        ) -> tuple[dict[str, Any], int, bool]:
+            """Decide full vs. stub for one packing-loop entry, hydrating
+            lazily. format_fn(item, child_branches) -> (entry, cost)
+            abstracts over the raw vs. cache-optimized entry shapes -- their
+            extra relevance_score/is_appendix arguments are already bound by
+            the caller. Returns (entry, new_budget, new_budget_exhausted).
+            """
+            if not skip_budget and budget_exhausted:
+                entry, cost = _stubbed_entry(item, child_branches, format_fn)
+                return entry, max(0, budget - cost), budget_exhausted
+
+            entry, cost = format_fn(item, child_branches)
+            if not (skip_budget or isinstance(item, MemoryNodeStub) or cost <= budget):
+                entry, cost = _stubbed_entry(item, child_branches, format_fn)
+                return entry, max(0, budget - cost), True
+
+            item, child_branches, changed = await _hydrate_full_entry(
+                item, child_branches,
+            )
+            if changed:
+                entry, cost = format_fn(item, child_branches)
+            # Re-check against the real (post-hydration) cost -- the
+            # pre-hydration estimate came from truncated content and can be
+            # far off for S3-backed items, which were spilled to S3
+            # precisely because they're large. Bound the waste to this one
+            # boundary item rather than trusting the cheap estimate.
+            if skip_budget or cost <= budget:
+                return entry, max(0, budget - cost), budget_exhausted
+            entry, cost = _stubbed_entry(item, child_branches, format_fn)
+            return entry, max(0, budget - cost), True
+
         if compilation_meta is not None:
             # Cache-optimized: iterate compilation-ordered results
             for item, _score, is_appendix in compilation_meta["ordered_results"]:
                 child_branches = nested_by_parent.get(str(item.id), [])
 
-                if not skip_budget and budget_exhausted:
-                    output_item = (
-                        _to_stub(item) if isinstance(item, MemoryNodeRead) else item
+                def _format(it, branches, is_appendix=is_appendix):
+                    return _format_entry_cached(
+                        it, branches, is_appendix, verbose=verbose,
                     )
-                    output_branches = [
-                        ((_to_stub(b) if isinstance(b, MemoryNodeRead) else b), s)
-                        for b, s in child_branches
-                    ]
-                    entry, cost = _format_entry_cached(
-                        output_item, output_branches, is_appendix,
-                        verbose=verbose,
-                    )
-                    formatted.append(entry)
-                    budget = max(0, budget - cost)
-                    continue
 
-                entry, cost = _format_entry_cached(
-                    item, child_branches, is_appendix, verbose=verbose,
+                entry, budget, budget_exhausted = await _pack_entry(
+                    item, child_branches, budget, budget_exhausted, _format,
                 )
-                if skip_budget or isinstance(item, MemoryNodeStub) or cost <= budget:
-                    item, child_branches, changed = await _hydrate_full_entry(
-                        item, child_branches,
-                    )
-                    if changed:
-                        entry, cost = _format_entry_cached(
-                            item, child_branches, is_appendix, verbose=verbose,
-                        )
-                    # Re-check against the real (post-hydration) cost -- the
-                    # pre-hydration estimate came from truncated content and
-                    # can be far off for S3-backed items, which were spilled
-                    # to S3 precisely because they're large. Bound the waste
-                    # to this one boundary item rather than trusting the
-                    # cheap estimate.
-                    if skip_budget or cost <= budget:
-                        formatted.append(entry)
-                        budget = max(0, budget - cost)
-                    else:
-                        budget_exhausted = True
-                        stub_item = _to_stub(item)
-                        stub_branches = [
-                            ((_to_stub(b) if isinstance(b, MemoryNodeRead) else b), s)
-                            for b, s in child_branches
-                        ]
-                        stub_entry, stub_cost = _format_entry_cached(
-                            stub_item, stub_branches, is_appendix,
-                            verbose=verbose,
-                        )
-                        formatted.append(stub_entry)
-                        budget = max(0, budget - stub_cost)
-                else:
-                    budget_exhausted = True
-                    stub_item = _to_stub(item)
-                    stub_branches = [
-                        ((_to_stub(b) if isinstance(b, MemoryNodeRead) else b), s)
-                        for b, s in child_branches
-                    ]
-                    stub_entry, stub_cost = _format_entry_cached(
-                        stub_item, stub_branches, is_appendix,
-                        verbose=verbose,
-                    )
-                    formatted.append(stub_entry)
-                    budget = max(0, budget - stub_cost)
+                formatted.append(entry)
         else:
             # Raw results: existing similarity-ranked behavior
             for item, relevance_score in top_level:
                 child_branches = nested_by_parent.get(str(item.id), [])
 
-                if not skip_budget and budget_exhausted:
-                    output_item = (
-                        _to_stub(item) if isinstance(item, MemoryNodeRead) else item
+                def _format(it, branches, relevance_score=relevance_score):
+                    return _format_entry(
+                        it, relevance_score, branches, verbose=verbose,
                     )
-                    output_branches = [
-                        (
-                            (_to_stub(b) if isinstance(b, MemoryNodeRead) else b),
-                            s,
-                        )
-                        for b, s in child_branches
-                    ]
-                    entry, cost = _format_entry(
-                        output_item, relevance_score, output_branches,
-                        verbose=verbose,
-                    )
-                    formatted.append(entry)
-                    budget = max(0, budget - cost)
-                    continue
 
-                entry, cost = _format_entry(
-                    item, relevance_score, child_branches, verbose=verbose,
+                entry, budget, budget_exhausted = await _pack_entry(
+                    item, child_branches, budget, budget_exhausted, _format,
                 )
-                if skip_budget or isinstance(item, MemoryNodeStub) or cost <= budget:
-                    item, child_branches, changed = await _hydrate_full_entry(
-                        item, child_branches,
-                    )
-                    if changed:
-                        entry, cost = _format_entry(
-                            item, relevance_score, child_branches, verbose=verbose,
-                        )
-                    # Re-check against the real (post-hydration) cost -- see
-                    # the matching comment in the cache-optimized branch above.
-                    if skip_budget or cost <= budget:
-                        formatted.append(entry)
-                        budget = max(0, budget - cost)
-                    else:
-                        budget_exhausted = True
-                        stub_item = _to_stub(item)
-                        stub_branches = [
-                            (
-                                (_to_stub(b) if isinstance(b, MemoryNodeRead) else b),
-                                s,
-                            )
-                            for b, s in child_branches
-                        ]
-                        stub_entry, stub_cost = _format_entry(
-                            stub_item, relevance_score, stub_branches,
-                            verbose=verbose,
-                        )
-                        formatted.append(stub_entry)
-                        budget = max(0, budget - stub_cost)
-                else:
-                    budget_exhausted = True
-                    stub_item = _to_stub(item)
-                    stub_branches = [
-                        (
-                            (_to_stub(b) if isinstance(b, MemoryNodeRead) else b),
-                            s,
-                        )
-                        for b, s in child_branches
-                    ]
-                    stub_entry, stub_cost = _format_entry(
-                        stub_item, relevance_score, stub_branches,
-                        verbose=verbose,
-                    )
-                    formatted.append(stub_entry)
-                    budget = max(0, budget - stub_cost)
+                formatted.append(entry)
 
         response = {
             "results": formatted,

--- a/memory-hub-mcp/tests/tools/test_search_memory.py
+++ b/memory-hub-mcp/tests/tools/test_search_memory.py
@@ -1974,3 +1974,373 @@ class TestCompactEntryHonestyFlags:
         assert "content_truncated" in entry
         assert "full_available" in entry
         assert entry["relevance_score"] == 0.85
+
+
+# ---------------------------------------------------------------------------
+# #389 -- S3 hydration must target only the final top-k
+# ---------------------------------------------------------------------------
+
+
+def _fake_s3_result(content_prefix, ref, weight=0.9, score=0.9, *, node_id=None):
+    """Build a (MemoryNodeRead, score) tuple with S3-backed storage."""
+    import uuid as _uuid
+    from datetime import datetime
+
+    from memoryhub_core.models.schemas import MemoryNodeRead, MemoryScope, StorageType
+
+    return (
+        MemoryNodeRead(
+            id=node_id or _uuid.uuid4(),
+            parent_id=None,
+            content=content_prefix,
+            stub=content_prefix[:80],
+            storage_type=StorageType.S3,
+            content_ref=ref,
+            weight=weight,
+            scope=MemoryScope.USER,
+            branch_type=None,
+            owner_id="wjackson",
+            tenant_id="default",
+            is_current=True,
+            version=1,
+            previous_version_id=None,
+            metadata=None,
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
+            content_truncated=True,
+            full_available=True,
+            has_children=False,
+            has_rationale=False,
+            branch_count=0,
+        ),
+        score,
+    )
+
+
+@pytest.mark.asyncio
+async def test_s3_hydration_skips_entries_trimmed_by_compilation_cap():
+    """#389: S3 hydration must only fetch content for the final top-k.
+
+    When backfill inflates the result set beyond max_results, the compilation
+    cap trims it. S3 hydration should NOT be called for entries that were
+    trimmed, only for the surviving top-k.
+    """
+    # 2 entries survive the cap, 3 get trimmed
+    kept = [_fake_s3_result(f"kept-{i}", f"s3://bucket/kept-{i}") for i in range(2)]
+    trimmed = [_fake_s3_result(f"trimmed-{i}", f"s3://bucket/trimmed-{i}") for i in range(3)]
+    all_results = kept + trimmed
+
+    ordered = [(item, score, False) for item, score in all_results]
+
+    mock_session = AsyncMock()
+    mock_gen = AsyncMock()
+    fake_embedding_service = AsyncMock()
+    mock_s3 = AsyncMock()
+    hydrated_refs = []
+
+    async def _track_get_content(ref):
+        hydrated_refs.append(ref)
+        return f"FULL CONTENT FOR {ref}"
+
+    mock_s3.get_content = _track_get_content
+
+    auth_mod._current_session = {
+        "user_id": "wjackson",
+        "scopes": ["user"],
+        "identity_type": "user",
+    }
+    try:
+        with (
+            patch(
+                "src.tools.search_memory.get_db_session",
+                return_value=(mock_session, mock_gen),
+            ),
+            patch("src.tools.search_memory.release_db_session", new_callable=AsyncMock),
+            patch(
+                "src.tools.search_memory.get_embedding_service",
+                return_value=fake_embedding_service,
+            ),
+            patch(
+                "src.tools.search_memory.search_memories",
+                new_callable=AsyncMock,
+                return_value=all_results,
+            ),
+            patch(
+                "src.tools.search_memory.count_search_matches",
+                new_callable=AsyncMock,
+                return_value=5,
+            ),
+            patch(
+                "src.tools.search_memory._backfill_compiled_entries",
+                new_callable=AsyncMock,
+                return_value=all_results,
+            ),
+            patch(
+                "src.tools.search_memory._apply_cache_optimized_ordering",
+                new_callable=AsyncMock,
+                return_value={
+                    "ordered_results": ordered,
+                    "compilation_hash": "deadbeef",
+                    "compilation_epoch": 1,
+                    "appendix_count": 0,
+                },
+            ),
+            patch(
+                "src.tools.search_memory.get_s3_adapter",
+                return_value=mock_s3,
+            ),
+            patch("src.tools.search_memory.ROLE_ISOLATION_ENABLED", False),
+            patch("src.tools.search_memory.PROJECT_ISOLATION_ENABLED", False),
+        ):
+            result = await search_memory(
+                query="memory", max_results=2, content_mode="full",
+                max_response_tokens=0,
+            )
+    finally:
+        auth_mod._current_session = None
+
+    assert len(result["results"]) == 2
+    assert set(hydrated_refs) == {"s3://bucket/kept-0", "s3://bucket/kept-1"}
+    for entry in result["results"]:
+        assert entry["content_truncated"] is False
+
+
+@pytest.mark.asyncio
+async def test_s3_hydration_skipped_for_mode_index():
+    """#389: mode='index' converts all results to stubs before hydration runs.
+
+    Since stubs have no storage_type/content_ref, hydration is a no-op.
+    No S3 calls should be made even with content_mode='full'.
+    """
+    s3_results = [_fake_s3_result(f"item-{i}", f"s3://bucket/item-{i}") for i in range(3)]
+
+    mock_session = AsyncMock()
+    mock_gen = AsyncMock()
+    fake_embedding_service = AsyncMock()
+    mock_s3 = AsyncMock()
+    mock_s3.get_content = AsyncMock(return_value="should not be called")
+
+    auth_mod._current_session = {
+        "user_id": "wjackson",
+        "scopes": ["user"],
+        "identity_type": "user",
+    }
+    try:
+        with (
+            patch(
+                "src.tools.search_memory.get_db_session",
+                return_value=(mock_session, mock_gen),
+            ),
+            patch("src.tools.search_memory.release_db_session", new_callable=AsyncMock),
+            patch(
+                "src.tools.search_memory.get_embedding_service",
+                return_value=fake_embedding_service,
+            ),
+            patch(
+                "src.tools.search_memory.search_memories",
+                new_callable=AsyncMock,
+                return_value=s3_results,
+            ),
+            patch(
+                "src.tools.search_memory.count_search_matches",
+                new_callable=AsyncMock,
+                return_value=3,
+            ),
+            patch(
+                "src.tools.search_memory.get_s3_adapter",
+                return_value=mock_s3,
+            ),
+            patch("src.tools.search_memory.ROLE_ISOLATION_ENABLED", False),
+            patch("src.tools.search_memory.PROJECT_ISOLATION_ENABLED", False),
+            patch(
+                "src.tools.search_memory.detect_patterns",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+        ):
+            result = await search_memory(
+                query="memory", mode="index", content_mode="full",
+                raw_results=True,
+            )
+    finally:
+        auth_mod._current_session = None
+
+    mock_s3.get_content.assert_not_called()
+    assert len(result["results"]) == 3
+    assert all(entry["result_type"] == "stub" for entry in result["results"])
+
+
+@pytest.mark.asyncio
+async def test_s3_hydration_covers_nested_branches():
+    """#389: S3 hydration must also hydrate branch entries nested under parents.
+
+    With include_branches=True and content_mode='full', both the parent and
+    its child branch should have their S3 content fetched.
+    """
+    import uuid as _uuid
+
+    parent_id = _uuid.uuid4()
+    child_id = _uuid.uuid4()
+
+    parent = _fake_s3_result(
+        "parent prefix", "s3://bucket/parent",
+        node_id=parent_id,
+    )
+    child_item, child_score = _fake_s3_result(
+        "child prefix", "s3://bucket/child",
+        node_id=child_id,
+    )
+    child_with_parent = (
+        child_item.model_copy(update={
+            "parent_id": parent_id,
+            "branch_type": "rationale",
+        }),
+        child_score,
+    )
+
+    all_results = [parent, child_with_parent]
+
+    mock_session = AsyncMock()
+    mock_gen = AsyncMock()
+    fake_embedding_service = AsyncMock()
+    mock_s3 = AsyncMock()
+    hydrated_refs = []
+
+    async def _track_get_content(ref):
+        hydrated_refs.append(ref)
+        return f"FULL CONTENT FOR {ref}"
+
+    mock_s3.get_content = _track_get_content
+
+    auth_mod._current_session = {
+        "user_id": "wjackson",
+        "scopes": ["user"],
+        "identity_type": "user",
+    }
+    try:
+        with (
+            patch(
+                "src.tools.search_memory.get_db_session",
+                return_value=(mock_session, mock_gen),
+            ),
+            patch("src.tools.search_memory.release_db_session", new_callable=AsyncMock),
+            patch(
+                "src.tools.search_memory.get_embedding_service",
+                return_value=fake_embedding_service,
+            ),
+            patch(
+                "src.tools.search_memory.search_memories",
+                new_callable=AsyncMock,
+                return_value=all_results,
+            ),
+            patch(
+                "src.tools.search_memory.count_search_matches",
+                new_callable=AsyncMock,
+                return_value=2,
+            ),
+            patch(
+                "src.tools.search_memory.get_s3_adapter",
+                return_value=mock_s3,
+            ),
+            patch("src.tools.search_memory.ROLE_ISOLATION_ENABLED", False),
+            patch("src.tools.search_memory.PROJECT_ISOLATION_ENABLED", False),
+            patch(
+                "src.tools.search_memory.detect_patterns",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+        ):
+            result = await search_memory(
+                query="memory", content_mode="full", raw_results=True,
+                include_branches=True, max_response_tokens=0,
+            )
+    finally:
+        auth_mod._current_session = None
+
+    assert set(hydrated_refs) == {"s3://bucket/parent", "s3://bucket/child"}
+    assert len(result["results"]) == 1
+    parent_entry = result["results"][0]
+    assert parent_entry["content_truncated"] is False
+    assert "branches" in parent_entry
+    assert parent_entry["branches"][0]["content_truncated"] is False
+
+
+@pytest.mark.asyncio
+async def test_s3_hydration_then_budget_degrades_to_stub():
+    """#389: an item whose truncated-content cost estimate fits the budget,
+    but whose real hydrated content does not, must be re-checked against
+    the real cost and degraded to a stub -- not kept as full just because
+    the pre-hydration estimate looked cheap. The S3 fetch itself is
+    unavoidable (verbose=False keeps the estimate low enough that the
+    item clears the pre-hydration gate, exactly as a real S3-backed item
+    would since it was spilled to S3 for being large), but the discarded
+    content must never leak into the stub response.
+    """
+    s3_results = [
+        _fake_s3_result("big item", "s3://bucket/big", score=0.9),
+    ]
+
+    mock_session = AsyncMock()
+    mock_gen = AsyncMock()
+    fake_embedding_service = AsyncMock()
+    mock_s3 = AsyncMock()
+    calls = []
+
+    async def _return_huge(ref):
+        calls.append(ref)
+        return "x" * 100_000
+
+    mock_s3.get_content = _return_huge
+
+    auth_mod._current_session = {
+        "user_id": "wjackson",
+        "scopes": ["user"],
+        "identity_type": "user",
+    }
+    try:
+        with (
+            patch(
+                "src.tools.search_memory.get_db_session",
+                return_value=(mock_session, mock_gen),
+            ),
+            patch("src.tools.search_memory.release_db_session", new_callable=AsyncMock),
+            patch(
+                "src.tools.search_memory.get_embedding_service",
+                return_value=fake_embedding_service,
+            ),
+            patch(
+                "src.tools.search_memory.search_memories",
+                new_callable=AsyncMock,
+                return_value=s3_results,
+            ),
+            patch(
+                "src.tools.search_memory.count_search_matches",
+                new_callable=AsyncMock,
+                return_value=1,
+            ),
+            patch(
+                "src.tools.search_memory.get_s3_adapter",
+                return_value=mock_s3,
+            ),
+            patch("src.tools.search_memory.ROLE_ISOLATION_ENABLED", False),
+            patch("src.tools.search_memory.PROJECT_ISOLATION_ENABLED", False),
+            patch(
+                "src.tools.search_memory.detect_patterns",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+        ):
+            result = await search_memory(
+                query="memory", content_mode="full", raw_results=True,
+                max_response_tokens=100, verbose=False,
+            )
+    finally:
+        auth_mod._current_session = None
+
+    assert calls == ["s3://bucket/big"]
+    assert len(result["results"]) == 1
+    entry = result["results"][0]
+    assert entry["result_type"] == "stub"
+    # The stub must not leak the hydrated (huge) content -- _to_stub()
+    # discards it, falling back to the original truncated prefix.
+    assert entry["content"] == "big item"

--- a/memory-hub-mcp/tests/tools/test_search_memory.py
+++ b/memory-hub-mcp/tests/tools/test_search_memory.py
@@ -1999,7 +1999,7 @@ def _fake_s3_result(content_prefix, ref, weight=0.9, score=0.9, *, node_id=None)
             weight=weight,
             scope=MemoryScope.USER,
             branch_type=None,
-            owner_id="wjackson",
+            owner_id="test-user",
             tenant_id="default",
             is_current=True,
             version=1,


### PR DESCRIPTION
## Summary

S3 hydration for `content_mode="full"` used to run on the full candidate set right after ranking, before mode="index" conversion, compilation backfill, the #212 cache-optimized cap, branch nesting, and token-budget packing decided which candidates would actually survive into the response -- wasting S3 GETs on content that was dropped or stubbed before it reached the caller. Hydration now happens lazily, inside the token-budget packing loop, gated on the same cost-vs-budget decision that already decides full vs. stub, so only the real final top-k pays the S3 round-trip.

## Linked issues

Closes #389

## Design reference

- `benchmarks/results/h6-content-delivery-audit.md` (per issue #389; documents the original truncated-content defect and recommends Option A, on-demand S3 hydration at search time, which `content_mode="full"` already implements -- this PR fixes *when* that hydration runs, not whether it runs)

## Type of change

- [x] `type:feature` — new user-visible capability
- [ ] `type:bug` — fix for incorrect behavior
- [ ] `type:infra` — build, CI, deploy, or tooling change
- [ ] `type:design` — design doc only, no code

<!-- Matches issue #389's own `type:feature` label. The change itself
     reads like a bug fix (wasted I/O), but #389 frames it as completing
     the read-half of the S3-spill feature, not a correctness defect --
     content_mode="full" already returned the right data, just paid for
     more S3 GETs than necessary to do it. -->

## Subsystem

- [x] `memory-tree`
- [ ] `storage`
- [ ] `curator`
- [ ] `governance`
- [ ] `mcp-server`
- [ ] `operator`
- [ ] `observability`
- [ ] `org-ingestion`
- [ ] `auth`
- [ ] `ui`
- [ ] `llamastack`

## Test plan

- [x] **Unit tests only** — no infrastructure boundaries touched (DB session, S3 adapter, and Valkey client are all mocked)
- [ ] **Integration tests included for:**
- [ ] **Integration tests deferred because:**
- [x] `pytest` passes locally (or the affected subset)
- [ ] Manual verification against a running cluster (if applicable)
- [x] New tests added for new behavior

`memory-hub-mcp/tests/tools/test_search_memory.py` — 57 passed, 4 new:

- `test_s3_hydration_skips_entries_trimmed_by_compilation_cap` — entries trimmed by the `#212` cap are never hydrated
- `test_s3_hydration_skipped_for_mode_index` — `mode="index"` results in  zero S3 calls
- `test_s3_hydration_covers_nested_branches` — branch entries under `include_branches=True` are hydrated alongside their parent
- `test_s3_hydration_then_budget_degrades_to_stub` — an item whose truncated-content estimate clears the budget gate but whose real hydrated content doesn't is re-degraded to a stub, and the discarded hydrated content never leaks into the stub response

Also ran the full `pytest tests/` suite outside this file: 20 pre-existing failures, all confirmed identical on `main` via `git stash` (a broken `embedding_max_chars` mock in `write_memory.py` tests, untouched by this change) — not a regression.

## Reviewer checklist

- [x] Design doc referenced or created
- [x] No committed credentials or cluster-specific URLs
- [ ] CLAUDE.md / docs updated if behavior or conventions changed (no behavior contract changed -- `content_mode="full"`'s documented semantics are unchanged, only when the S3 fetch happens)
- [x] Commit message follows `subsystem: Imperative summary` format

## Note for reviewers

**Scope boundary:** #389 also lists parallel S3 GETs in scope. This PR keeps hydration sequential across top-level items by design -- the budget decision for item N depends on item N-1 already being resolved, so parallelizing across items would reintroduce the original waste (speculative fetches for candidates the budget cap later drops). Parallelizing one item's fetch with its own branches' fetches (`asyncio.gather`) is a safe, scoped follow-up not included here, since it only pays off for entries with multiple branches.

**Merge conflict heads-up:** `#404` (effective_k observability) is an independent, unmerged branch touching the same file. Simulated the merge locally: `search_memory.py` merges cleanly; `test_search_memory.py` has one trivial append-append conflict (both PRs add tests at end-of-file) -- not a logic conflict, resolved by keeping both blocks.

## Release readiness (if this PR touches `sdk/` or `memoryhub-cli/`)

N/A — this PR does not modify files under `sdk/` or `memoryhub-cli/`.
