### PR TITLE
fix: integration tests marker hook

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -25,8 +25,11 @@ from memoryhub_core.config import DatabaseSettings
 from memoryhub_core.services.embeddings import MockEmbeddingService
 from memoryhub_core.services.valkey_client import ValkeyClient, ValkeySettings, set_valkey_client
 
-# Mark every test in this package as an integration test automatically.
-pytestmark = pytest.mark.integration
+def pytest_collection_modifyitems(config, items):
+    """Auto-mark every test collected under tests/integration/ as 'integration'."""
+    for item in items:
+        if "tests/integration/" in str(item.fspath):
+            item.add_marker(pytest.mark.integration)
 
 
 def _build_db_url() -> str:

--- a/tests/integration/test_backfill.py
+++ b/tests/integration/test_backfill.py
@@ -15,6 +15,8 @@ from sqlalchemy import select
 
 from memoryhub_core.models.memory import MemoryNode
 
+pytestmark = pytest.mark.integration
+
 
 def _load_backfill():
     """Load the backfill script as a module despite hyphen in filename."""


### PR DESCRIPTION
## Summary

While investigating #375, noticed the following:

```
memory-hub % pytest tests/ -m "not integration" --collect-only -q
tests/integration/test_backfill.py::test_count_candidates_finds_unextracted
tests/integration/test_backfill.py::test_count_candidates_excludes_entities_and_deleted
tests/integration/test_backfill.py::test_scan_returns_oldest_first
tests/integration/test_backfill.py::test_scan_respects_limit
tests/integration/test_backfill.py::test_update_extraction_status_sets_metadata
tests/integration/test_backfill.py::test_update_extraction_status_preserves_existing_metadata
tests/perf/test_cross_encoder.py::test_ndcg_perfect_ranking
tests/perf/test_cross_encoder.py::test_ndcg_inverse_ranking
```

Seems like 6 integration tests from test_backfill.py leak into the testing suite while integration tests are deselected. test_backfill.py is the only integration test file that is missing the integration tests mark. While the mark from conftest.py is supposed to make up for it, official docs describe module-level pytestmark for test modules, not package-wide via conftest. 

Adding a hook to the conftest to make up for this issue. 

Not entirely sure whether it was the reason for the initial report of 375. 

## Linked issues

"Refs #375".

## Type of change

<!-- Check one. Matches the `type:*` issue labels. -->

- [ ] `type:feature` — new user-visible capability
- [X] `type:bug` — fix for incorrect behavior
- [ ] `type:infra` — build, CI, deploy, or tooling change
- [ ] `type:design` — design doc only, no code

## Subsystem

<!-- Check the primary subsystem this touches. Matches the
     `subsystem:*` issue labels. -->

- [ ] `memory-tree`
- [ ] `storage`
- [ ] `curator`
- [ ] `governance`
- [ ] `mcp-server`
- [ ] `operator`
- [ ] `observability`
- [ ] `org-ingestion`
- [ ] `auth`
- [ ] `ui`
- [ ] `llamastack`

## Test plan

<!-- Which infrastructure boundaries does this PR exercise?
     Check the option that best describes your test coverage. -->

- [ ] **Unit tests only** — no infrastructure boundaries touched
      (pure logic, no DB/Valkey/embedding service interaction)
- [ ] **Integration tests included for:** <!-- list subsystems -->
      `[ pgvector / Valkey / embedding service / auth / S3 ]`
- [ ] **Integration tests deferred because:**
      <!-- This should be rare. Justify why, and link the follow-up issue. -->

<!-- General verification: -->

- [X] `pytest` passes locally (or the affected subset)
- [ ] Manual verification against a running cluster (if applicable)
- [ ] New tests added for new behavior

## Reviewer checklist

- [ ] Design doc referenced or created
- [ ] No committed credentials or cluster-specific URLs
- [ ] CLAUDE.md / docs updated if behavior or conventions changed
- [ ] Commit message follows `subsystem: Imperative summary` format

## Release readiness (if this PR touches `sdk/` or `memoryhub-cli/`)

<!-- Skip this section if the PR does not modify files under sdk/ or memoryhub-cli/. -->

- [ ] `pyproject.toml` version matches `__init__.py` `__version__`
- [ ] `CHANGELOG.md` has an entry for the new version
- [ ] If breaking: CHANGELOG entry is flagged with `BREAKING` and links the tracking issue
