### PR TITLE
storage: Set logical_id on chunk, fact, and copied branch nodes.

### DIFF
--- a/src/memoryhub_core/models/memory.py
+++ b/src/memoryhub_core/models/memory.py
@@ -38,7 +38,7 @@ class MemoryNode(TimestampMixin, Base):
     # Stable identity across versions. All versions of the same logical
     # memory share one logical_id; v1 sets logical_id = id, updates inherit.
     logical_id: Mapped[uuid.UUID | None] = mapped_column(
-        UUID(as_uuid=True), nullable=True, index=True,
+        UUID(as_uuid=True), nullable=False, index=True,
     )
 
     # Tree structure (adjacency list)

--- a/src/memoryhub_core/services/memory.py
+++ b/src/memoryhub_core/services/memory.py
@@ -298,8 +298,10 @@ async def _create_chunk_children(
             branch_count=0,
             has_rationale=False,
         )
+        chunk_id = uuid.uuid4()
         chunk_node = MemoryNode(
-            id=uuid.uuid4(),
+            id=chunk_id,
+            logical_id=chunk_id,
             content=chunk_text,
             stub=chunk_stub,
             scope=scope,
@@ -366,8 +368,10 @@ async def create_fact_children(
             branch_count=0,
             has_rationale=False,
         )
+        fact_id = uuid.uuid4()
         fact_node = MemoryNode(
-            id=uuid.uuid4(),
+            id=fact_id,
+            logical_id=fact_id,
             content=fact["content"],
             stub=fact_stub,
             scope=scope,
@@ -641,6 +645,7 @@ async def update_memory(
         # Deep copy non-chunk branch to new parent
         copied_child = MemoryNode(
             id=uuid.uuid4(),
+            logical_id=child.logical_id,
             content=child.content,
             stub=child.stub,
             scope=child.scope,

--- a/tests/test_services/test_memory_service.py
+++ b/tests/test_services/test_memory_service.py
@@ -477,6 +477,100 @@ async def test_update_chain_shares_logical_id(async_session, embedding_service):
     assert v1.logical_id == v2.logical_id == v3.logical_id
     assert len({v1.id, v2.id, v3.id}) == 3
 
+async def test_chunk_children_have_logical_id(async_session, embedding_service):
+    """Chunk children set logical_id = id (new entities)."""
+    from sqlalchemy import select as sa_select
+    
+    from memoryhub_core.models.memory import MemoryNode
+    
+    s3 = MockS3Adapter()
+    data = _make_create_data(content=_make_oversized_content())
+    result, _ = await create_memory(data, async_session, embedding_service, s3_adapter=s3)
+
+    chunks_stmt = sa_select(MemoryNode).where(
+        MemoryNode.parent_id == result.id,
+        MemoryNode.branch_type == "chunk",
+    )
+    chunks = (await async_session.execute(chunks_stmt)).scalars().all()
+
+    assert len(chunks) >= 2
+    for chunk in chunks:
+        assert chunk.logical_id is not None
+        assert chunk.logical_id == chunk.id
+
+async def test_fact_children_have_logical_id(async_session, embedding_service):
+    """Fact children set logical_id = id (new entities)."""
+    from memoryhub_core.services.memory import create_fact_children
+
+    from sqlalchemy import select as sa_select
+
+    from memoryhub_core.models.memory import MemoryNode
+
+    parent, _ = await create_memory(
+        _make_create_data(content="User preferences"), async_session, embedding_service,
+    )
+
+    await create_fact_children(
+        facts=[
+            {"content": "Prefers Python"},
+            {"content": "Uses Red Hat UBI"},
+        ],
+        parent_id=parent.id,
+        scope="user",
+        scope_id=None,
+        owner_id="test-owner",
+        tenant_id="default",
+        domains=None,
+        extraction_run_id="test-run-1",
+        embedding_service=embedding_service,
+        session=async_session,
+    )
+
+    facts_stmt = sa_select(MemoryNode).where(
+        MemoryNode.parent_id == parent.id,
+        MemoryNode.branch_type == "fact",
+    )
+    facts = (await async_session.execute(facts_stmt)).scalars().all()
+
+    assert len(facts) == 2
+    for fact in facts:
+        assert fact.logical_id is not None
+        assert fact.logical_id == fact.id
+
+
+async def test_deep_copied_branches_inherit_logical_id(async_session, embedding_service):
+    """Deep-copied branches keep their logical_id across parent versions."""
+    from sqlalchemy import select as sa_select
+
+    from memoryhub_core.models.memory import MemoryNode
+
+    parent, _ = await create_memory(
+        _make_create_data(content="Original"), async_session, embedding_service,
+    )
+
+    rationale_data = _make_create_data(
+        content="Because this is important",
+        parent_id=parent.id,
+        branch_type="rationale",
+    )
+    rationale, _ = await create_memory(rationale_data, async_session, embedding_service)
+    original_logical_id = rationale.logical_id
+
+    updated = await update_memory(
+        parent.id, MemoryNodeUpdate(content="Updated"), async_session, embedding_service,
+    )
+
+    children_stmt = sa_select(MemoryNode).where(
+        MemoryNode.parent_id == updated.id,
+        MemoryNode.branch_type == "rationale"
+    )
+    children = (await async_session.execute(children_stmt)).scalars().all()
+
+    assert len(children) == 1
+    copied = children[0]
+    assert copied.id != rationale.id
+    assert copied.logical_id == original_logical_id
+
 
 # -- get_memory_history --
 


### PR DESCRIPTION
## Summary

Three `MemoryNode` construction sites omitted `logical_id`, violating the
NOT NULL constraint from migration 027. Chunk and fact node creation hit
`IntegrityError`; branch copies during `update_memory` fail the same way.
Fixed all three sites and updated the model declaration to `nullable=False`
to match the database.

## Linked issues

Closes #512

## Design reference

- `docs/design/storage-layer.md`
- `alembic/versions/027_add_logical_id.py`

## Type of change

- [ ] `type:feature` — new user-visible capability
- [x] `type:bug` — fix for incorrect behavior
- [ ] `type:infra` — build, CI, deploy, or tooling change
- [ ] `type:design` — design doc only, no code

## Subsystem

- [ ] `memory-tree`
- [x] `storage`
- [ ] `curator`
- [ ] `governance`
- [ ] `mcp-server`
- [ ] `operator`
- [ ] `observability`
- [ ] `org-ingestion`
- [ ] `auth`
- [ ] `ui`
- [ ] `llamastack`

## Test plan

- [x] **Unit tests only** — no infrastructure boundaries touched
      (pure logic, no DB/Valkey/embedding service interaction)
- [ ] **Integration tests included for:**
      `[ pgvector / Valkey / embedding service / auth / S3 ]`
- [ ] **Integration tests deferred because:**

- [x] `pytest` passes locally (or the affected subset)
- [ ] Manual verification against a running cluster (if applicable)
- [x] New tests added for new behavior

Three tests added:
- `test_chunk_children_have_logical_id` — verifies chunks set `logical_id = id`
- `test_fact_children_have_logical_id` — verifies facts set `logical_id = id`
- `test_deep_copied_branches_inherit_logical_id` — verifies copies inherit `logical_id`

## Reviewer checklist

- [x] Design doc referenced or created
- [x] No committed credentials or cluster-specific URLs
- [ ] CLAUDE.md / docs updated if behavior or conventions changed
- [x] Commit message follows `subsystem: Imperative summary` format
