### PR TITLE
fix: Set logical_id on chunk and fact child nodes

### DIFF
--- a/src/memoryhub_core/models/memory.py
+++ b/src/memoryhub_core/models/memory.py
@@ -37,8 +37,8 @@ class MemoryNode(TimestampMixin, Base):
 
     # Stable identity across versions. All versions of the same logical
     # memory share one logical_id; v1 sets logical_id = id, updates inherit.
-    logical_id: Mapped[uuid.UUID | None] = mapped_column(
-        UUID(as_uuid=True), nullable=True, index=True,
+    logical_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), nullable=False, index=True,
     )
 
     # Tree structure (adjacency list)

--- a/src/memoryhub_core/services/memory.py
+++ b/src/memoryhub_core/services/memory.py
@@ -298,8 +298,10 @@ async def _create_chunk_children(
             branch_count=0,
             has_rationale=False,
         )
+        chunk_id = uuid.uuid4()
         chunk_node = MemoryNode(
-            id=uuid.uuid4(),
+            id=chunk_id,
+            logical_id=chunk_id,
             content=chunk_text,
             stub=chunk_stub,
             scope=scope,
@@ -366,8 +368,10 @@ async def create_fact_children(
             branch_count=0,
             has_rationale=False,
         )
+        fact_id = uuid.uuid4()
         fact_node = MemoryNode(
-            id=uuid.uuid4(),
+            id=fact_id,
+            logical_id=fact_id,
             content=fact["content"],
             stub=fact_stub,
             scope=scope,
@@ -639,8 +643,10 @@ async def update_memory(
             continue
 
         # Deep copy non-chunk branch to new parent
+        copied_id = uuid.uuid4()
         copied_child = MemoryNode(
-            id=uuid.uuid4(),
+            id=copied_id,
+            logical_id=child.logical_id or copied_id,
             content=child.content,
             stub=child.stub,
             scope=child.scope,

--- a/tests/test_services/test_memory_service.py
+++ b/tests/test_services/test_memory_service.py
@@ -478,6 +478,110 @@ async def test_update_chain_shares_logical_id(async_session, embedding_service):
     assert len({v1.id, v2.id, v3.id}) == 3
 
 
+async def test_chunk_children_have_logical_id(async_session, embedding_service):
+    """Chunk children created by two-tier storage have logical_id == id."""
+    from sqlalchemy import select as sa_select
+
+    from memoryhub_core.models.memory import MemoryNode
+
+    data = _make_create_data(content=_make_oversized_content())
+    result, _ = await create_memory(data, async_session, embedding_service, s3_adapter=MockS3Adapter())
+
+    chunks = (
+        await async_session.execute(
+            sa_select(MemoryNode).where(
+                MemoryNode.parent_id == result.id,
+                MemoryNode.branch_type == "chunk",
+            )
+        )
+    ).scalars().all()
+
+    assert len(chunks) >= 2, f"expected multiple chunks, got {len(chunks)}"
+    for chunk in chunks:
+        assert chunk.logical_id is not None, "chunk logical_id must not be None"
+        assert chunk.logical_id == chunk.id, "chunk logical_id should equal its own id"
+
+
+async def test_fact_children_have_logical_id(async_session, embedding_service):
+    """Fact children created by create_fact_children have logical_id == id."""
+    from sqlalchemy import select as sa_select
+
+    from memoryhub_core.models.memory import MemoryNode
+    from memoryhub_core.services.memory import create_fact_children
+
+    parent, _ = await create_memory(_make_create_data(), async_session, embedding_service)
+    facts = [
+        {"content": "User prefers dark mode"},
+        {"content": "User works in data science"},
+    ]
+    count = await create_fact_children(
+        facts=facts,
+        parent_id=parent.id,
+        scope=parent.scope,
+        scope_id=None,
+        owner_id=parent.owner_id,
+        tenant_id=_TEST_TENANT_ID,
+        domains=None,
+        extraction_run_id="test-run-001",
+        session=async_session,
+        embedding_service=embedding_service,
+    )
+    assert count == 2
+
+    fact_nodes = (
+        await async_session.execute(
+            sa_select(MemoryNode).where(
+                MemoryNode.parent_id == parent.id,
+                MemoryNode.branch_type == "fact",
+            )
+        )
+    ).scalars().all()
+
+    assert len(fact_nodes) == 2
+    for fact_node in fact_nodes:
+        assert fact_node.logical_id is not None, "fact logical_id must not be None"
+        assert fact_node.logical_id == fact_node.id, "fact logical_id should equal its own id"
+
+
+async def test_deep_copied_branches_preserve_logical_id(async_session, embedding_service):
+    """Deep-copied branches on update preserve the original's logical_id."""
+    from sqlalchemy import select as sa_select
+
+    from memoryhub_core.models.memory import MemoryNode
+
+    parent, _ = await create_memory(
+        _make_create_data(content="I use Red Hat UBI"), async_session, embedding_service
+    )
+    rationale_data = _make_create_data(
+        content="Because UBI images are FIPS-compliant",
+        parent_id=parent.id,
+        branch_type="rationale",
+    )
+    rationale, _ = await create_memory(rationale_data, async_session, embedding_service)
+    original_logical_id = rationale.logical_id
+
+    updated = await update_memory(
+        parent.id, MemoryNodeUpdate(content="I use Red Hat UBI 9"), async_session, embedding_service
+    )
+
+    copied_children = (
+        await async_session.execute(
+            sa_select(MemoryNode).where(
+                MemoryNode.parent_id == updated.id,
+                MemoryNode.branch_type == "rationale",
+                MemoryNode.deleted_at.is_(None),
+            )
+        )
+    ).scalars().all()
+
+    assert len(copied_children) == 1
+    copied = copied_children[0]
+    assert copied.id != rationale.id, "deep copy should have a new id"
+    assert copied.logical_id == original_logical_id, (
+        "deep-copied branch should preserve the original's logical_id"
+    )
+
+
 # -- get_memory_history --
 
 


### PR DESCRIPTION
## Summary

- Chunk and fact child nodes created during memory tree operations now
  correctly inherit the parent's `logical_id`, ensuring version tracking
  works across the full tree

## Test plan

- [ ] Verify chunk/fact child nodes have correct `logical_id` after creation
- [ ] Verify `update` on a parent propagates `logical_id` to new version's children