### PR TITLE
demos: SOC demo multi-framework incident response with shared memory

### DIFF
--- a/demos/soc-demo/TALK_TRACK.md
+++ b/demos/soc-demo/TALK_TRACK.md
@@ -1,0 +1,356 @@
+# SOC Demo Talk Track (15-20 min video)
+
+Hybrid format: web UI (constellation display) + terminal at key moments.
+Stage directions in **[brackets]**. Approximate timings in the margin.
+
+---
+
+## 1. Cold Open (0:00 - 1:30)
+
+**[Screen: Title card or the standby screen with the four agent cards visible]**
+
+> Most SOC teams run a mix of tools. Your Tier 1 analyst uses one platform,
+> forensics uses another, threat intel has their own stack. That's fine for
+> humans because you have a war room, you have a shared wiki, you have
+> Slack. But what happens when those analysts are AI agents?
+>
+> Each agent framework has its own memory model. LangGraph keeps state in a
+> graph. Claude Code keeps context in a conversation. A FIPS-Agent keeps it
+> in a session object. If your forensics agent discovers something critical
+> at 3 AM, your incident commander running on a different framework has no
+> way to know about it unless you build custom plumbing between every pair
+> of frameworks. That doesn't scale.
+>
+> MemoryHub solves this. It's a shared memory layer that any agent on any
+> framework can write to and read from. Today I'm going to walk through a
+> full incident response scenario -- credential compromise at a fictional
+> financial services company -- using four agents on four different
+> frameworks, all sharing memory through MemoryHub.
+
+**[Click REPLAY or press SPACE to start the scenario]**
+
+---
+
+## 2. The Setup (1:30 - 3:00)
+
+**[Screen: Constellation display. Agents transition from OFFLINE to IDLE as
+the scenario initializes. Point out the layout.]**
+
+> Let me orient you to what you're looking at. In the center is the
+> MemoryHub node -- that's the shared memory store. Around it, four agents,
+> each on a different framework.
+>
+> At the top, our Tier 1 SOC Analyst, running on Claude Code with a cloud
+> Claude model. On the left, Threat Intel on Hermes. On the right,
+> Forensics on FIPS-Agent. And at the bottom, the Incident Commander on
+> OpenClaw. Three of these four are running a local Gemma 4 model deployed
+> on-cluster through OpenShift AI. Only the Tier 1 analyst uses a cloud
+> API.
+>
+> The framework badges are color-coded so you can always tell who's who.
+> And notice each agent card shows two IDs: an actor_id, which is the agent
+> role, and a driver_id, which is the human operator on shift. That
+> separation matters -- we'll see why during the shift change.
+
+**[Switch to terminal briefly to show the seed memories]**
+
+> Before the incident starts, MemoryHub already has institutional memory
+> from past incidents. Let me show you what's been seeded.
+
+**[Run: `python seed-memories.py --list` or show the 6 seed memories]**
+
+> Six memories from prior work. An old incident report from four months
+> ago. A team heuristic about service account patterns. A lesson learned
+> about breakglass credential rotation. These are the kinds of things a
+> human SOC team accumulates over years. We're giving that same
+> institutional knowledge to the agents.
+
+---
+
+## 3. Phase 1: Detection (3:00 - 4:00)
+
+**[Screen: Back to constellation. The Tier 1 agent activates.]**
+
+> 02:14 AM. CrowdStrike fires an alert: anomalous service account logon
+> from an IP that's never been associated with this account before. The
+> Tier 1 agent picks it up.
+>
+> Watch the status pill change from IDLE to SEARCHING. The agent's first
+> instinct -- just like a good human analyst -- is to check whether we've
+> seen anything like this before.
+
+**[The SVG line animates outward from Tier 1 to MemoryHub hub]**
+
+> That search hits MemoryHub. And this is where it gets interesting.
+
+---
+
+## 4. Phase 2: Triage & Cross-Incident Pattern Match (4:00 - 6:30)
+
+**[Screen: Constellation. Memory chip appears in the timeline strip.]**
+
+> The agent finds a match. Four months ago, IR-2024-117, a different
+> incident entirely, a different team investigated it. But the pattern is
+> the same: service account anomaly, off-hours access, same staging path
+> structure. That old investigation was handled by a forensics agent on a
+> completely different framework, but because the memory lives in
+> MemoryHub, the Tier 1 agent can read it.
+
+**[Click the memory chip in the timeline to open the detail panel]**
+
+> Look at the detail panel. You can see the full memory content, the
+> weight (how important the authoring agent considered it), the framework
+> it was written from, and the timestamp. The dashed border on this chip
+> means it's a prior-incident memory, not something from today.
+>
+> Without this cross-incident context, a Tier 1 agent would likely classify
+> this as a low-severity anomaly. Maybe it's a misconfigured service
+> account, a developer testing after hours. But with the pattern match,
+> the agent escalates to a full incident. That's the difference between
+> catching a breach in 20 minutes and catching it in 20 days.
+
+**[Switch to terminal: show the MemoryHub search call and result]**
+
+> Under the hood, this is a single SDK call. The agent sends a natural
+> language query -- "service account anomaly off-hours" -- and MemoryHub
+> returns semantically relevant memories across all projects the agent has
+> access to. The agent didn't need to know about IR-2024-117. It didn't
+> need to know which framework wrote that memory. It just searched, and
+> the institutional knowledge was there.
+
+---
+
+## 5. Phase 3: Investigation (6:30 - 8:30)
+
+**[Screen: Constellation. Forensics and Threat Intel activate in parallel.]**
+
+> Now we're in full incident response. Two agents spin up simultaneously.
+> Forensics is building a timeline -- lateral movement, credential
+> harvesting, what the attacker touched. Threat Intel is looking at TTPs,
+> trying to figure out who's behind this.
+
+**[Both agents show SEARCHING then WRITING status. Memory chips appear.]**
+
+> Watch the memory timeline at the bottom. Both agents are writing findings
+> to MemoryHub as they go. Forensics writes a timeline reconstruction.
+> Threat Intel writes an initial attribution assessment.
+>
+> And here's the key thing: Forensics finds a memory it wrote itself during
+> IR-2024-117. A false positive filter for ai.exe that it developed four
+> months ago. No human authored that operational knowledge -- the agent
+> learned it from its own prior investigation and it's applying it now.
+> That's agent self-learning through persistent memory.
+
+**[Click the self-authored memory chip, note the "self-authored" indicator]**
+
+> The detail panel marks this as self-authored. The same agent, same
+> actor_id, wrote it months ago and is now reading it back. That's the
+> kind of institutional knowledge that usually lives in a senior analyst's
+> head and walks out the door when they leave.
+
+---
+
+## 6. Phase 4: Contradiction (8:30 - 11:00)
+
+**[Screen: Constellation. This is the most visually dramatic phase.]**
+
+> Phase 4 is where things get interesting. At 06:00, we have a shift
+> change. The night shift operators hand off to the day shift.
+
+**[Agent cards update: driver_ids change, status briefly shows HANDOFF]**
+
+> Notice the driver_id fields just changed on every agent card. The agents
+> are the same -- same actor_ids, same accumulated context -- but the
+> humans overseeing them swapped out. MemoryHub tracks both. Every memory
+> operation from this point forward is attributed to the new human
+> operators, but the investigation context carries over seamlessly. No
+> re-briefing, no "let me read you in on where we are."
+>
+> Now, the network analysis comes back. And it contradicts Threat Intel's
+> initial attribution. The C2 infrastructure doesn't match the threat group
+> that was initially fingered. A different agent framework, the IC on
+> OpenClaw, surfaces this.
+
+**[Hub flashes. Contradiction chip appears in red in the timeline.]**
+
+> Watch what happens. MemoryHub doesn't overwrite the original assessment.
+> It preserves both. The IC calls `report_contradiction`, and now both the
+> original attribution and the contradicting network analysis exist side by
+> side, linked.
+
+**[Click the contradiction chip. Detail panel shows side-by-side comparison.]**
+
+> The detail panel shows both assessments with a red divider between them.
+> This is critical for incident response. You never want an AI agent
+> silently overwriting a prior conclusion. Especially in a security
+> context, you need the full chain of reasoning. What was believed, when
+> it changed, and why.
+
+**[Switch to terminal: show the report_contradiction SDK call]**
+
+> One SDK call. `report_contradiction` takes the memory ID of the original
+> assessment and a description of the observed contradiction. MemoryHub
+> links them, increments a contradiction counter, and preserves both for
+> the audit trail.
+
+---
+
+## 7. Phase 5: Containment & Quarantine (11:00 - 13:30)
+
+**[Screen: Constellation. IC activates, reads the breakglass lesson.]**
+
+> The IC is now coordinating containment. It needs to rotate compromised
+> credentials. But before it acts, it searches MemoryHub for operational
+> lessons. And it finds one from eight months ago: "Last time we rotated
+> breakglass credentials, backup systems were down for six hours."
+
+**[Memory chip lights up. IC status shows READING.]**
+
+> That's a painful lesson someone learned the hard way. Now every agent,
+> on any framework, benefits from it. The IC adjusts its containment plan
+> to sequence the rotation with backup system verification.
+
+**[Hub flashes red. A quarantine event fires.]**
+
+> Now watch this. The forensics agent tries to write a memory that contains
+> an actual service account credential -- the compromised password. MemoryHub
+> blocks it. The hub flashes red, and you see a quarantine chip appear
+> in the timeline.
+
+**[Click the quarantine chip.]**
+
+> The content was quarantined before it ever entered shared memory. PII and
+> credential detection runs at the write boundary. The agent gets a
+> notification, rewrites the memory with a vault pointer instead of the raw
+> credential, and the corrected version goes through.
+>
+> This is governance built into the memory layer. You don't rely on each
+> agent framework to implement its own credential filtering. MemoryHub
+> enforces it centrally, regardless of which framework is writing.
+
+---
+
+## 8. Phase 6: Audit Trail (13:30 - 15:00)
+
+**[Screen: Detail panel showing the audit table]**
+
+> Let's look at the audit trail. Every memory operation -- every search,
+> write, read, contradiction report -- is logged with the actor_id (the
+> agent role), the driver_id (the human on shift), the timestamp, and the
+> operation type.
+
+**[Scroll through the audit entries. Point out the shift change boundary.]**
+
+> You can see the shift change right here. Before 06:00, all operations
+> are attributed to the night shift operators. After 06:00, the day
+> shift. But the investigation is continuous. If this were a real incident
+> and legal needed to reconstruct who knew what and when, this audit trail
+> gives you that.
+>
+> The actor/driver separation also answers a question regulators care
+> about: was a human in the loop? Every agent action traces back to a
+> responsible human through the driver_id. The agent can't operate without
+> one.
+
+---
+
+## 9. Phase 7: Post-Incident Learning (15:00 - 16:30)
+
+**[Screen: Constellation. IC writes final lessons learned.]**
+
+> The incident is contained. Now the IC writes lessons learned back to
+> MemoryHub. The breakglass sequencing that worked. The contradiction
+> pattern that flagged a misattribution. The cross-incident search that
+> caught the breach early.
+
+**[Final memory chips appear in the timeline. Memory count increments.]**
+
+> These lessons are now available to any agent, on any framework, on the
+> next incident. The next time a Tier 1 agent on Claude Code sees a
+> service account anomaly, it won't just find IR-2024-117. It'll find
+> this incident too. The institutional knowledge compounds.
+
+---
+
+## 10. Architecture Recap (16:30 - 18:00)
+
+**[Switch to terminal or a slide showing the component diagram]**
+
+> Let me pull back and show you what's running under the hood.
+>
+> MemoryHub is deployed on OpenShift. PostgreSQL with pgvector for storage
+> and semantic search. An MCP server that any agent framework can connect
+> to using the standard Model Context Protocol. An SDK for Python clients
+> that wraps the MCP calls.
+>
+> The four agents connect to the same MemoryHub instance. They don't know
+> about each other. They don't need custom integrations between frameworks.
+> They just read and write memories through a common API. MemoryHub handles
+> the access control, the semantic indexing, the contradiction tracking,
+> and the audit trail.
+>
+> Three of the four agents are running Gemma 4 on-cluster through
+> OpenShift AI's vLLM serving. No data leaves the cluster for those three.
+> The Tier 1 agent uses a cloud Claude model to show that MemoryHub works
+> across deployment models too -- cloud and on-prem agents sharing the same
+> memory.
+
+---
+
+## 11. Close (18:00 - 19:00)
+
+**[Screen: Constellation in final state, all 7 phase indicators lit]**
+
+> Four agents. Four frameworks. One shared memory.
+>
+> The value proposition is straightforward. If you're building AI-assisted
+> security operations -- or any multi-agent system -- your agents need to
+> share context. Without shared memory, every agent starts from zero on
+> every incident. With MemoryHub, they inherit the institutional knowledge
+> of every agent that came before them, regardless of framework.
+>
+> Cross-incident pattern recognition. Self-learning from prior
+> investigations. Contradiction preservation instead of silent overwrites.
+> Credential quarantine at the memory boundary. Full audit trail with
+> human accountability.
+>
+> This is what agent memory infrastructure looks like.
+
+---
+
+## Production Notes
+
+### Key visual moments to frame tightly
+
+1. **Cross-incident search hit** (Phase 2) -- the SVG line animating from Tier 1 to
+   the hub, then the dashed-border memory chip appearing. This is the "hero moment."
+2. **Contradiction side-by-side** (Phase 4) -- the red-bordered detail panel with
+   both assessments visible. Dramatic and immediately legible.
+3. **Quarantine flash** (Phase 5) -- the hub pulsing red. Short but visceral.
+4. **Shift change** (Phase 4) -- driver_id fields updating simultaneously across
+   all four agent cards.
+
+### Terminal segments to prepare
+
+- Seed memories listing (Phase 2 setup)
+- MemoryHub search SDK call + result (Phase 2)
+- `report_contradiction` SDK call (Phase 4)
+- Optionally: `harness.py` invocation showing the agent calls in real time
+
+### Pacing guidance
+
+- Phases 1-2 (detection through pattern match): spend the most time here. This is
+  the "aha" moment. If the viewer understands one thing, it should be cross-incident
+  search.
+- Phase 4 (contradiction): second most important. Viewers from regulated industries
+  will immediately see the audit value.
+- Phases 3, 5, 6, 7: move briskly. The concepts land fast once the audience
+  understands the memory model.
+
+### Things to avoid
+
+- Don't over-explain MCP. Say "standard protocol" and move on. The audience
+  cares about the capability, not the transport layer.
+- Don't dwell on framework differences. The point is that they don't matter.
+- Don't show raw JSON unless it clarifies something. The UI is more compelling.
+- Don't say "AI agent" when "agent" alone is clear from context.

--- a/demos/soc-demo/agents/soc-forensics/Containerfile
+++ b/demos/soc-demo/agents/soc-forensics/Containerfile
@@ -35,7 +35,7 @@ FROM registry.redhat.io/ubi9/python-311:latest AS runtime
 LABEL io.opencontainers.image.title="soc-forensics" \
       io.opencontainers.image.version="0.4.0" \
       io.opencontainers.image.description="BaseAgent framework — production-ready AI agent for OpenShift" \
-      io.opencontainers.image.source="https://github.com/OWNER/soc-forensics" \
+      io.opencontainers.image.source="https://github.com/redhat-ai-americas/memory-hub" \
       io.opencontainers.image.vendor="Red Hat"
 
 # Unbuffered stdout/stderr so container logs appear immediately

--- a/demos/soc-demo/front-end/soc-frontend/Makefile
+++ b/demos/soc-demo/front-end/soc-frontend/Makefile
@@ -10,30 +10,60 @@
 
 NAMESPACE ?= soc-demo
 APP       := soc-frontend
+HARNESS   := soc-harness
 PACE      ?= 4
+CTX       ?= mcp-rhoai
 
-.PHONY: deploy build url replay logs clean
+.PHONY: deploy deploy-all build sidecar-build url replay logs logs-harness secret clean
 
 deploy:
-	-@oc new-project $(NAMESPACE) 2>/dev/null || oc project $(NAMESPACE)
-	oc apply -n $(NAMESPACE) -k manifests/
-	oc start-build $(APP) -n $(NAMESPACE) --from-dir=. --follow
-	oc rollout status deploy/$(APP) -n $(NAMESPACE) --timeout=180s
+	-@oc new-project $(NAMESPACE) --context $(CTX) 2>/dev/null || true
+	oc apply -n $(NAMESPACE) --context $(CTX) -k manifests/
+	oc start-build $(APP) -n $(NAMESPACE) --context $(CTX) --from-dir=. --follow
+	oc rollout status deploy/$(APP) -n $(NAMESPACE) --context $(CTX) --timeout=180s
 	@echo ""
-	@echo "  display: https://$$(oc get route $(APP) -n $(NAMESPACE) -o jsonpath='{.spec.host}')"
-	@echo "  feed it: make replay"
+	@echo "  display: https://$$(oc get route $(APP) -n $(NAMESPACE) --context $(CTX) -o jsonpath='{.spec.host}')"
+
+sidecar-build:
+	@rm -rf .sidecar-stage
+	@mkdir .sidecar-stage
+	cp sidecar/Containerfile sidecar/trigger.py sidecar/run-live.sh \
+	   sidecar/requirements.txt .sidecar-stage/
+	cp ../../harness.py ../../seed-memories.py .sidecar-stage/
+	cp replay.py scenario.json .sidecar-stage/
+	oc start-build $(HARNESS) -n $(NAMESPACE) --context $(CTX) \
+	   --from-dir=.sidecar-stage --follow
+	@rm -rf .sidecar-stage
+
+deploy-all: deploy sidecar-build
+	oc rollout restart deploy/$(APP) -n $(NAMESPACE) --context $(CTX)
+	oc rollout status deploy/$(APP) -n $(NAMESPACE) --context $(CTX) --timeout=180s
+	@echo ""
+	@echo "  display: https://$$(oc get route $(APP) -n $(NAMESPACE) --context $(CTX) -o jsonpath='{.spec.host}')"
+	@echo "  buttons: REPLAY and LIVE available on the standby screen"
 
 build:
-	oc start-build $(APP) -n $(NAMESPACE) --from-dir=. --follow
+	oc start-build $(APP) -n $(NAMESPACE) --context $(CTX) --from-dir=. --follow
 
 url:
-	@echo https://$$(oc get route $(APP) -n $(NAMESPACE) -o jsonpath='{.spec.host}')
+	@echo https://$$(oc get route $(APP) -n $(NAMESPACE) --context $(CTX) -o jsonpath='{.spec.host}')
 
 replay:
-	python replay.py --server https://$$(oc get route $(APP) -n $(NAMESPACE) -o jsonpath='{.spec.host}') --pace $(PACE)
+	python replay.py --server https://$$(oc get route $(APP) -n $(NAMESPACE) --context $(CTX) -o jsonpath='{.spec.host}') --pace $(PACE)
 
 logs:
-	oc logs -f deploy/$(APP) -n $(NAMESPACE)
+	oc logs -f deploy/$(APP) -c $(APP) -n $(NAMESPACE) --context $(CTX)
+
+logs-harness:
+	oc logs -f deploy/$(APP) -c $(HARNESS) -n $(NAMESPACE) --context $(CTX)
+
+secret:
+	@echo "Create the soc-harness-config secret:"
+	@echo ""
+	@echo "  oc create secret generic soc-harness-config -n $(NAMESPACE) --context $(CTX) \\"
+	@echo "    --from-literal=soc-forensics-url=https://YOUR_FIPS_AGENT_ROUTE \\"
+	@echo "    --from-literal=memoryhub-url=https://YOUR_MEMORYHUB_URL \\"
+	@echo "    --from-literal=memoryhub-api-key=YOUR_API_KEY"
 
 clean:
-	oc delete -n $(NAMESPACE) -k manifests/ --ignore-not-found
+	oc delete -n $(NAMESPACE) --context $(CTX) -k manifests/ --ignore-not-found

--- a/demos/soc-demo/front-end/soc-frontend/manifests/buildconfig-sidecar.yaml
+++ b/demos/soc-demo/front-end/soc-frontend/manifests/buildconfig-sidecar.yaml
@@ -1,0 +1,16 @@
+apiVersion: build.openshift.io/v1
+kind: BuildConfig
+metadata:
+  name: soc-harness
+spec:
+  source:
+    type: Binary
+    binary: {}
+  strategy:
+    type: Docker
+    dockerStrategy:
+      dockerfilePath: Containerfile
+  output:
+    to:
+      kind: ImageStreamTag
+      name: soc-harness:latest

--- a/demos/soc-demo/front-end/soc-frontend/manifests/deployment.yaml
+++ b/demos/soc-demo/front-end/soc-frontend/manifests/deployment.yaml
@@ -5,7 +5,9 @@ metadata:
   annotations:
     image.openshift.io/triggers: >-
       [{"from":{"kind":"ImageStreamTag","name":"soc-frontend:latest"},
-        "fieldPath":"spec.template.spec.containers[?(@.name==\"soc-frontend\")].image"}]
+        "fieldPath":"spec.template.spec.containers[?(@.name==\"soc-frontend\")].image"},
+       {"from":{"kind":"ImageStreamTag","name":"soc-harness:latest"},
+        "fieldPath":"spec.template.spec.containers[?(@.name==\"soc-harness\")].image"}]
 spec:
   replicas: 1
   selector:
@@ -47,3 +49,43 @@ spec:
               memory: 128Mi
             limits:
               memory: 256Mi
+        - name: soc-harness
+          image: image-registry.openshift-image-registry.svc:5000/soc-demo/soc-harness:latest
+          ports:
+            - containerPort: 8001
+          env:
+            - name: FRONTEND_URL
+              value: "http://localhost:8000"
+            - name: SOC_FORENSICS_URL
+              valueFrom:
+                secretKeyRef:
+                  name: soc-harness-config
+                  key: soc-forensics-url
+            - name: MEMORYHUB_URL
+              valueFrom:
+                secretKeyRef:
+                  name: soc-harness-config
+                  key: memoryhub-url
+            - name: MEMORYHUB_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: soc-harness-config
+                  key: memoryhub-api-key
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8001
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8001
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              memory: 512Mi

--- a/demos/soc-demo/front-end/soc-frontend/manifests/imagestream-sidecar.yaml
+++ b/demos/soc-demo/front-end/soc-frontend/manifests/imagestream-sidecar.yaml
@@ -1,0 +1,7 @@
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: soc-harness
+spec:
+  lookupPolicy:
+    local: true

--- a/demos/soc-demo/front-end/soc-frontend/manifests/kustomization.yaml
+++ b/demos/soc-demo/front-end/soc-frontend/manifests/kustomization.yaml
@@ -6,7 +6,9 @@ commonLabels:
   app.kubernetes.io/part-of: memoryhub-demo
 resources:
   - imagestream.yaml
+  - imagestream-sidecar.yaml
   - buildconfig.yaml
+  - buildconfig-sidecar.yaml
   - deployment.yaml
   - service.yaml
   - route.yaml

--- a/demos/soc-demo/front-end/soc-frontend/replay.py
+++ b/demos/soc-demo/front-end/soc-frontend/replay.py
@@ -26,7 +26,8 @@ def post(path, body):
 
 
 post("/reset", {})
-events = json.load(open(args.scenario, encoding="utf-8"))
+with open(args.scenario, encoding="utf-8") as f:
+    events = json.load(f)
 for e in events:
     post("/emit", e)
     print(f"[{e.get('timestamp','--:--')}] {e['type']:<15} {e.get('agent','')}")

--- a/demos/soc-demo/front-end/soc-frontend/server.py
+++ b/demos/soc-demo/front-end/soc-frontend/server.py
@@ -9,11 +9,14 @@ Set EMIT_TOKEN to require an X-Emit-Token header on POST /emit
 """
 import json
 import os
+
+import httpx
 from fastapi import FastAPI, Header, HTTPException, WebSocket, WebSocketDisconnect
 from fastapi.staticfiles import StaticFiles
 
 app = FastAPI()
 EMIT_TOKEN = os.environ.get("EMIT_TOKEN", "")
+SIDECAR_URL = os.environ.get("SIDECAR_URL", "http://localhost:8001")
 viewers: set[WebSocket] = set()
 history: list[dict] = []  # replayed to late-joining viewers
 
@@ -61,6 +64,49 @@ async def reset(x_emit_token: str | None = Header(default=None)):
     check_token(x_emit_token)
     history.clear()
     return {"ok": True}
+
+
+@app.get("/trigger/status")
+async def trigger_status():
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        try:
+            resp = await client.get(f"{SIDECAR_URL}/status")
+            return resp.json()
+        except httpx.ConnectError:
+            raise HTTPException(503, "trigger sidecar not available")
+
+
+@app.post("/trigger/stop")
+async def trigger_stop():
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        try:
+            resp = await client.post(f"{SIDECAR_URL}/stop")
+            return resp.json()
+        except httpx.ConnectError:
+            raise HTTPException(503, "trigger sidecar not available")
+
+
+@app.post("/trigger/reset")
+async def trigger_reset():
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        try:
+            resp = await client.post(f"{SIDECAR_URL}/reset")
+            return resp.json()
+        except httpx.ConnectError:
+            raise HTTPException(503, "trigger sidecar not available")
+
+
+@app.post("/trigger/{mode}")
+async def trigger(mode: str, pace: float = 4.0):
+    if mode not in ("replay", "live"):
+        raise HTTPException(404, "unknown mode")
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        try:
+            params = {"pace": pace} if mode == "replay" else {}
+            resp = await client.post(f"{SIDECAR_URL}/trigger/{mode}", params=params)
+            return resp.json()
+        except httpx.ConnectError:
+            raise HTTPException(503, "trigger sidecar not available")
 
 
 app.mount("/", StaticFiles(directory="static", html=True), name="static")

--- a/demos/soc-demo/front-end/soc-frontend/sidecar/Containerfile
+++ b/demos/soc-demo/front-end/soc-frontend/sidecar/Containerfile
@@ -1,0 +1,14 @@
+FROM registry.access.redhat.com/ubi9/python-311
+
+WORKDIR /opt/app-root/src
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+# trigger API + live-run wrapper
+COPY --chmod=755 trigger.py run-live.sh ./
+
+# harness and replay files (staged by Makefile sidecar-build target)
+COPY harness.py seed-memories.py replay.py scenario.json ./
+
+EXPOSE 8001
+CMD ["uvicorn", "trigger:app", "--host", "0.0.0.0", "--port", "8001"]

--- a/demos/soc-demo/front-end/soc-frontend/sidecar/requirements.txt
+++ b/demos/soc-demo/front-end/soc-frontend/sidecar/requirements.txt
@@ -1,3 +1,5 @@
 fastapi>=0.110
 uvicorn[standard]>=0.29
+memoryhub>=0.15.3
 httpx>=0.28
+rich>=13.0

--- a/demos/soc-demo/front-end/soc-frontend/sidecar/run-live.sh
+++ b/demos/soc-demo/front-end/soc-frontend/sidecar/run-live.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+python seed-memories.py
+exec python harness.py

--- a/demos/soc-demo/front-end/soc-frontend/sidecar/trigger.py
+++ b/demos/soc-demo/front-end/soc-frontend/sidecar/trigger.py
@@ -1,0 +1,138 @@
+"""Sidecar trigger API for SOC demo.
+
+Spawns harness.py (live mode) or replay.py (replay mode) as subprocesses
+when triggered by the frontend. Only one run at a time.
+"""
+
+import os
+import signal
+import subprocess
+
+import httpx
+from fastapi import FastAPI, HTTPException, Query
+
+app = FastAPI(title="SOC Demo Sidecar Trigger")
+
+_state: dict = {
+    "proc": None,
+    "mode": None,
+    "status": "idle",
+}
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+
+def _child_env() -> dict:
+    env = os.environ.copy()
+    env["FRONTEND_URL"] = "http://localhost:8000"
+    return env
+
+
+def _poll_state() -> None:
+    """Update status based on subprocess poll result."""
+    proc = _state["proc"]
+    if proc is None:
+        return
+    rc = proc.poll()
+    if rc is None:
+        _state["status"] = "running"
+    elif rc == 0:
+        _state["status"] = "done"
+    else:
+        _state["status"] = "error"
+
+
+@app.post("/trigger/replay")
+async def trigger_replay(pace: float = Query(default=4.0)):
+    _poll_state()
+    if _state["status"] == "running":
+        raise HTTPException(status_code=409, detail="A run is already in progress")
+
+    proc = subprocess.Popen(
+        [
+            "python", "replay.py",
+            "--server", "http://localhost:8000",
+            "--pace", str(pace),
+            "--scenario", "scenario.json",
+        ],
+        cwd=HERE,
+        env=_child_env(),
+    )
+    _state["proc"] = proc
+    _state["mode"] = "replay"
+    _state["status"] = "running"
+    return {"status": "running", "mode": "replay"}
+
+
+@app.post("/trigger/live")
+async def trigger_live():
+    _poll_state()
+    if _state["status"] == "running":
+        raise HTTPException(status_code=409, detail="A run is already in progress")
+
+    proc = subprocess.Popen(
+        ["bash", "run-live.sh"],
+        cwd=HERE,
+        env=_child_env(),
+    )
+    _state["proc"] = proc
+    _state["mode"] = "live"
+    _state["status"] = "running"
+    return {"status": "running", "mode": "live"}
+
+
+@app.get("/status")
+async def get_status():
+    _poll_state()
+    exit_code = None
+    proc = _state["proc"]
+    if proc is not None:
+        exit_code = proc.returncode
+    return {
+        "status": _state["status"],
+        "mode": _state["mode"],
+        "exit_code": exit_code,
+    }
+
+
+@app.post("/stop")
+async def stop_run():
+    _poll_state()
+    if _state["status"] != "running":
+        raise HTTPException(status_code=409, detail="No run is in progress")
+
+    _state["proc"].send_signal(signal.SIGTERM)
+    try:
+        _state["proc"].wait(timeout=10)
+    except subprocess.TimeoutExpired:
+        _state["proc"].kill()
+        _state["proc"].wait(timeout=5)
+    _state["status"] = "done"
+    return {"status": "stopped"}
+
+
+@app.post("/reset")
+async def reset_state():
+    _poll_state()
+    if _state["proc"] is not None and _state["status"] == "running":
+        _state["proc"].send_signal(signal.SIGTERM)
+        try:
+            _state["proc"].wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            _state["proc"].kill()
+    _state["proc"] = None
+    _state["mode"] = None
+    _state["status"] = "idle"
+
+    try:
+        async with httpx.AsyncClient() as client:
+            await client.post("http://localhost:8000/reset", timeout=5.0)
+    except httpx.HTTPError:
+        pass  # frontend may not be running yet
+
+    return {"status": "idle"}
+
+
+@app.get("/healthz")
+async def healthz():
+    return {"ok": True}

--- a/demos/soc-demo/front-end/soc-frontend/static/index.html
+++ b/demos/soc-demo/front-end/soc-frontend/static/index.html
@@ -118,6 +118,14 @@ footer{border-top:1px solid var(--line);background:var(--panel);padding:8px 14px
 @keyframes bannerin{from{transform:translate(-50%,-14px);opacity:0}to{transform:translate(-50%,0);opacity:1}}
 @keyframes bannerdrop{from{transform:translateY(-14px);opacity:0}to{transform:translateY(0);opacity:1}}
 @keyframes blink{50%{opacity:.4}}
+#trigger-btns{display:flex;gap:14px;margin-top:8px}
+.trigger-btn{font-family:'Red Hat Mono',monospace;font-size:13px;font-weight:700;letter-spacing:.12em;padding:13px 28px;border-radius:8px;border:2px solid;cursor:pointer;transition:all .2s;background:transparent}
+.trigger-btn.replay{color:#4DD0E1;border-color:#4DD0E155}
+.trigger-btn.replay:hover:not(:disabled){background:#4DD0E118;border-color:#4DD0E1}
+.trigger-btn.live-btn{color:#81C784;border-color:#81C78455}
+.trigger-btn.live-btn:hover:not(:disabled){background:#81C78418;border-color:#81C784}
+.trigger-btn:disabled{opacity:.35;cursor:not-allowed}
+#trigger-status{font-family:'Red Hat Mono',monospace;font-size:11px;color:#7f86a3;margin-top:6px;letter-spacing:.1em}
 [hidden]{display:none !important}
 </style>
 </head>
@@ -167,6 +175,11 @@ footer{border-top:1px solid var(--line);background:var(--panel);padding:8px 14px
     <div class="inc">INCIDENT IR-2024-184 · HOST FIN-WS-0219 · ALERT AT T+02:47</div>
     <div id="roster"></div>
     <div id="waiting">WAITING FOR EVENT STREAM…</div>
+    <div id="trigger-btns" hidden>
+      <button class="trigger-btn replay" id="btn-replay">▶ REPLAY</button>
+      <button class="trigger-btn live-btn" id="btn-live">◉ LIVE</button>
+    </div>
+    <div id="trigger-status" hidden></div>
     <div class="foot">memoryhub + vLLM on OpenShift · api.anthropic.com · fed by harness events over WebSocket</div>
   </div>
 </div>
@@ -274,7 +287,12 @@ function build(n){
 function render(){
   const s = build(idx), cur = idx>0 ? events[idx-1] : null;
   $('standby').hidden = idx !== 0;
-  $('waiting').textContent = events.length ? 'PRESS SPACE TO BEGIN' : 'WAITING FOR EVENT STREAM…';
+  if (!triggerAvailable) {
+    $('waiting').textContent = events.length ? 'PRESS SPACE TO BEGIN' : 'WAITING FOR EVENT STREAM…';
+  } else if (events.length) {
+    $('waiting').hidden = true;
+    $('trigger-btns').hidden = true;
+  }
 
   const phN = s.phase ? s.phase.phase : 0;
   $('phaselabel').textContent = 'PHASE '+phN+' · '+(s.phase ? (s.phase.label||'').toUpperCase() : 'STANDBY');
@@ -411,6 +429,89 @@ window.addEventListener('keydown', e => {
   else if (e.key==='Escape'){ $('pclose').onclick(); }
   else if (e.key==='l'||e.key==='L'){ toggleLive(); }
 });
+// ---- sidecar trigger ----
+let triggerAvailable = false, triggerPollId = null;
+
+async function checkSidecar() {
+  try {
+    const r = await fetch('/trigger/status');
+    if (!r.ok) return;
+    triggerAvailable = true;
+    updateTriggerUI(await r.json());
+  } catch (e) { /* sidecar not available */ }
+}
+
+function updateTriggerUI(data) {
+  if (!triggerAvailable) return;
+  const btns = $('trigger-btns'), waiting = $('waiting'), status = $('trigger-status');
+  if (data.status === 'running') {
+    btns.hidden = false; waiting.hidden = true;
+    $('btn-replay').disabled = true; $('btn-live').disabled = true;
+    status.hidden = false;
+    status.textContent = 'RUNNING ' + (data.mode || '').toUpperCase() + '…';
+    status.style.color = '#7f86a3';
+    if (!triggerPollId) triggerPollId = setInterval(pollStatus, 2000);
+  } else if (data.status === 'error') {
+    btns.hidden = false; waiting.hidden = true;
+    $('btn-replay').disabled = false; $('btn-live').disabled = false;
+    status.hidden = false;
+    status.textContent = 'ERROR · exit code ' + (data.exit_code ?? '?');
+    status.style.color = '#ff8a80';
+    clearTriggerPoll();
+  } else if (data.status === 'done') {
+    btns.hidden = false; waiting.hidden = true;
+    $('btn-replay').disabled = false; $('btn-live').disabled = false;
+    status.hidden = false;
+    status.textContent = 'COMPLETE · press SPACE to step through';
+    status.style.color = '#81C784';
+    clearTriggerPoll();
+  } else {
+    btns.hidden = false; waiting.hidden = true;
+    $('btn-replay').disabled = false; $('btn-live').disabled = false;
+    status.hidden = true;
+    clearTriggerPoll();
+  }
+}
+
+function clearTriggerPoll() {
+  if (triggerPollId) { clearInterval(triggerPollId); triggerPollId = null; }
+}
+
+async function triggerRun(mode) {
+  $('btn-replay').disabled = true; $('btn-live').disabled = true;
+  $('trigger-status').hidden = false;
+  $('trigger-status').textContent = 'STARTING ' + mode.toUpperCase() + '…';
+  $('trigger-status').style.color = '#7f86a3';
+  try {
+    // reset frontend event history first
+    await fetch('/trigger/reset', {method: 'POST'});
+    events = []; idx = 0; manual = null; render();
+    const r = await fetch('/trigger/' + mode, {method: 'POST'});
+    const data = await r.json();
+    if (r.status === 409) {
+      $('trigger-status').textContent = 'ALREADY RUNNING';
+      $('btn-replay').disabled = true; $('btn-live').disabled = true;
+      triggerPollId = setInterval(pollStatus, 2000);
+    } else {
+      triggerPollId = setInterval(pollStatus, 2000);
+    }
+  } catch (e) {
+    $('trigger-status').textContent = 'FAILED: ' + e.message;
+    $('trigger-status').style.color = '#ff8a80';
+    $('btn-replay').disabled = false; $('btn-live').disabled = false;
+  }
+}
+
+async function pollStatus() {
+  try {
+    const r = await fetch('/trigger/status');
+    if (r.ok) updateTriggerUI(await r.json());
+  } catch (e) { /* ignore transient errors */ }
+}
+
+$('btn-replay').onclick = () => triggerRun('replay');
+$('btn-live').onclick = () => triggerRun('live');
+checkSidecar();
 render();
 </script>
 </body>

--- a/demos/soc-demo/harness.py
+++ b/demos/soc-demo/harness.py
@@ -495,7 +495,8 @@ async def call_agent(
     url = SOC_FORENSICS_URL.rstrip("/")
     if not url.endswith("/v1/chat/completions"):
         url = f"{url}/v1/chat/completions"
-    async with httpx.AsyncClient(timeout=timeout, verify=False) as http:
+    verify = os.environ.get("SOC_TLS_VERIFY", "true").lower() != "false"
+    async with httpx.AsyncClient(timeout=timeout, verify=verify) as http:
         resp = await http.post(
             url,
             json={
@@ -580,9 +581,9 @@ async def run_scenario():
         return 1
 
     register_block = (
-        f'\n## Session Registration (REQUIRED FIRST STEP)\n\n'
-        f'Before using any memory tools, call register_session '
-        f'with api_key="{api_key}". Do this FIRST.\n'
+        '\n## Session Registration (REQUIRED FIRST STEP)\n\n'
+        'Before using any memory tools, call register_session. '
+        'The api_key is pre-configured in your environment. Do this FIRST.\n'
     )
 
     emit_reset()
@@ -726,8 +727,8 @@ async def run_scenario():
             try:
                 await client.report_contradiction(
                     memory_id=attr_id, observed_behavior=response[:1000])
-            except Exception:
-                pass
+            except Exception as exc:
+                console.print(f"  [dim red]Contradiction report failed: {exc}[/]")
 
         print_contradiction(
             "threatintel",

--- a/demos/soc-demo/smoke-test.py
+++ b/demos/soc-demo/smoke-test.py
@@ -18,10 +18,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../sdk/src"))
 
 from memoryhub import MemoryHubClient
 
-URL = os.environ.get(
-    "MEMORYHUB_URL",
-    "https://memory-hub-mcp-memory-hub-mcp.apps.cluster-n7pd5.n7pd5.sandbox5167.opentlc.com/mcp/",
-)
+URL = os.environ.get("MEMORYHUB_URL", "")
 API_KEY = os.environ.get("MEMORYHUB_API_KEY", "")
 PROJECT_ID = "midwest-financial-soc"
 


### PR DESCRIPTION
## Summary

- Sidecar trigger API enabling replay and live demo modes from the
  frontend, with subprocess lifecycle management
- Video talk track (15-20 min) covering all 7 phases with stage
  directions for hybrid UI + terminal recording
- Review fixes: removed API key from LLM prompt, removed hardcoded
  cluster URL, made TLS verification configurable, added error logging
  for contradiction reports, fixed subprocess orphan risk in trigger
  sidecar, updated placeholder OCI label, fixed unclosed file handle

Builds on the existing SOC demo infrastructure already on main
(harness, frontend, agent scaffolds, seed data, smoke test).

## Key capabilities demonstrated

- Cross-framework memory sharing (4 frameworks, 2 model deployment models)
- Cross-incident pattern recognition (agent finds 4-month-old prior incident)
- Agent self-learning (reads its own prior investigation output)
- Contradiction preservation (competing assessments linked, not overwritten)
- PII/credential quarantine at the memory write boundary
- Shift change with driver_id/actor_id separation and full audit trail

## Test plan

- [ ] `make deploy` in soc-demo namespace on mcp-rhoai
- [ ] `make replay` sends scripted scenario through the frontend
- [ ] Smoke test validates cross-framework memory sharing without LLM calls
- [ ] Walk through talk track against replay to verify timing and transitions