### PR TITLE
docs: Public benchmarks documentation and epic plan

### DIFF
--- a/NEXT_SESSION-public-benchmarks.md
+++ b/NEXT_SESSION-public-benchmarks.md
@@ -1,0 +1,197 @@
+# Next Session — public-benchmarks
+
+## Next: Handle AMB PR feedback, then build AML adapter
+
+Wait at least one week from PR submission (2026-08-21) for Vectorize review
+feedback on PR #34. If there's feedback, address it first. Then start Phase 3:
+build and deploy the AML HTTP adapter so we're ready for the November submission
+window.
+
+1. **Check AMB PR status and handle feedback**
+   Check vectorize-io/agent-memory-benchmark#34 for review comments. If there's
+   feedback, address it on the `memoryhub-provider` branch in the fork at
+   `~/Developer/agent-memory-benchmark`. If merged, verify MemoryHub appears on
+   agentmemorybenchmark.ai. If no review yet and it's been <2 weeks, move on to
+   the AML work.
+
+2. **Read AML API guide and document schemas**
+   Read https://agentmemories.ai/api-guide to understand the exact contract:
+   `POST /add`, `POST /search`, `GET /health`. Document the request/response
+   schemas before writing code. Pay attention to auth requirements (Bearer token
+   or X-Api-Key) and any field-level constraints.
+
+3. **Build FastAPI AML adapter**
+   Thin FastAPI app (~200 lines) translating AML's API contract into MemoryHub
+   SDK calls. Add endpoint writes memories, Search endpoint queries memories,
+   Health returns 2xx. Write integration tests simulating AML's smoke test
+   format. This lives in the memory-hub repo (not the AMB fork).
+
+4. **Deploy to OpenShift with public route**
+   Deploy the adapter to `mcp-rhoai` cluster with a public route. The adapter
+   needs to stay up 30+ days (AML stability requirement). Use the standard
+   deploy pattern (BuildConfig + Deployment, not local build).
+
+5. **If AML submission window is open, begin submission process**
+   Apply for eval key at agentmemories.ai/evaluation. If the window isn't open
+   yet (~November 2026), park the issue and note the date to revisit. If it is
+   open, run the smoke test (1 attempt per hour).
+
+**Sequencing.** Step 1 first (quick check). Steps 2-4 are the core work and
+should flow in order within a single session. Step 5 depends on AML's calendar.
+
+**Constraints for the session:**
+- Do not start this session before 2026-08-28 (one week from PR submission)
+- AML controls the answer LLM (gpt-4o-mini); our score will differ from the AMB result
+- The adapter needs its own OpenShift namespace and BuildConfig
+- Decide category before submission: Academic (must be open-source) vs Commercial
+
+**Session start protocol:**
+- Premise checks (~5 min, report before acting):
+  - AMB PR status: `gh pr view 34 -R vectorize-io/agent-memory-benchmark --json state,reviews,comments`
+  - If >2 weeks since submission with no review, ping maintainers on issue #33
+  - MemoryHub cluster health: `oc get pods --context mcp-rhoai -n memory-hub-mcp`
+  - Check AML site is accessible: `curl -s https://agentmemories.ai/api-guide | head -20`
+  - Check if anyone else submitted a MemoryHub entry to AML since last session
+- Rules with history:
+  - External repo writes require `/issue-gate` + explicit user approval (PR feedback iterations on the existing PR #34 are fine without re-gating)
+  - Use GEMINI_API_KEY exclusively, never GOOGLE_API_KEY (see CLAUDE.md)
+  - Deploy scripts run in main context, not delegated to sub-agents
+- Stop-and-ask before:
+  - Creating a new OpenShift namespace for the AML adapter
+  - Applying for an AML eval key (irreversible registration)
+  - Any public-facing write on a repo not owned by rdwj
+- Close ritual: session summary; update this epic file with what landed
+
+## What landed last session (2026-08-21)
+
+Reproduction run and upstream PR submission. Full pipeline completed in one session.
+
+- Full PersonaMem 32k reproduction: 83.7% (493/589) with gemini-3.1-pro-preview
+- Upstream issue vectorize-io/agent-memory-benchmark#33
+- Upstream PR vectorize-io/agent-memory-benchmark#34 (adapter + results + manifest)
+- GOOGLE_API_KEY cleanup in fork, CLAUDE.md updated
+- Memory: `feedback_publish_what_we_get`
+
+See `session-summaries/2026-08-21-public-benchmarks-reproduction-and-pr.md`.
+
+**Prior sessions:**
+- 2026-08-21 (earlier): Adapter, checkpointing, and infrastructure. See `session-summaries/2026-08-21-public-benchmarks-adapter-and-checkpointing.md`.
+- 2026-08-18: Research/planning and prep/clone. See `session-summaries/2026-08-18-public-benchmarks-*.md`.
+
+## Remaining epic phases
+
+Get MemoryHub onto both public agent-memory benchmark leaderboards (AMB and AML) with verified, reproducible results. Marketing-driven: ship at a decent level now, resubmit as scores improve. We already have 84.9% on PersonaMem 32k (2nd behind Hindsight at 86.6%) — the work is packaging and submitting, not running new benchmarks.
+
+### Phase 1: AMB Upstream Provider Adapter — COMPLETE
+
+Adapter shipped. 83.7% (493/589) on PersonaMem 32k with Gemini 3.1 Pro Preview. PR #34 submitted to vectorize-io/agent-memory-benchmark.
+
+### Phase 2: AMB Leaderboard PR — SUBMITTED, AWAITING REVIEW
+
+PR #34 open. Issue #33 filed. Waiting on Vectorize maintainer review.
+
+**External wait:** Vectorize PR review — no SLA, could be days or weeks. Ping after 2 weeks if no response.
+
+### Phase 3: AML HTTP Adapter
+
+Build a thin FastAPI app that exposes MemoryHub through AML's required API contract: `POST /add` (ingest messages), `POST /search` (return ranked memories), `GET /health`. Translates their request format into MemoryHub SDK calls. Deploy on our cluster with a public OpenShift route.
+
+AML uses gpt-4o-mini as the answer model (platform-controlled), so our score will differ from the 84.9% we got with Gemini Pro — but the retrieval quality is what we're showcasing.
+
+**Work:**
+1. Read [AML API guide](https://agentmemories.ai/api-guide) and document the exact request/response schemas
+2. Build FastAPI adapter (~200 lines): Add endpoint writes memories via SDK, Search endpoint queries via SDK
+3. Handle auth (Bearer token or X-Api-Key)
+4. Write integration tests simulating AML request format
+5. Deploy to OpenShift with public route, verify health endpoint accessible
+6. Ensure deployment can stay up 30+ days (AML stability requirement)
+
+**Definition of done:** FastAPI app deployed on `mcp-rhoai` cluster with public route. Passes a local integration test simulating AML's smoke test (Add messages, Search returns ranked results, Health returns 2xx).
+
+**Dependencies:** None — can start immediately
+
+### Phase 4: AML Submission
+
+Submit to AML when the next evaluation window opens (~November 2026). Mostly process, not code.
+
+**Work:**
+1. Apply for AML Eval Key at [agentmemories.ai/evaluation](https://agentmemories.ai/evaluation)
+2. Pass smoke test (1 attempt per hour, compatibility check)
+3. Run formal evaluation (1 attempt per 3 months)
+4. Request publication to leaderboard
+5. Decide category: Academic (must be open-source) vs Commercial
+
+**Definition of done:** MemoryHub appears on the AML leaderboard at [agentmemories.ai](https://agentmemories.ai) with a published score.
+
+**Dependencies:** Gated on Phase 3 (adapter deployed and stable). Gated on AML submission window (~November 2026).
+
+**External wait:** AML submission window opening, eval key issuance, formal evaluation run
+
+**Reminder:** Revisit this phase in late October 2026 to confirm AML window timing and prepare submission.
+
+### Phase 5 (optional): Score Improvement Sprint
+
+Cherry-pick the highest-ROI retrieval improvements to close the gap to Hindsight (86.6%). Resubmit to whichever leaderboard(s) are live.
+
+Candidates from open issues:
+- #370 Ablation Matrix B — focus, domain, and graph signals not yet tested; could reveal untapped retrieval signals
+- #389 S3 hydration for large-content tail — rank on prefix, hydrate top-k; could improve context quality
+- #453 disabled_signals reimplementation — needed to properly A/B test individual signals
+
+**Definition of done:** At least one retrieval improvement measurably increases PersonaMem 32k accuracy above 83.7%, verified by full 589-query re-run. Updated result submitted to live leaderboard(s).
+
+**Dependencies:** None for improvement work. Resubmission depends on Phase 2 or 4 being complete.
+
+---
+
+## Execution order (updated)
+
+```
+Phase 1 (AMB Adapter)  ── COMPLETE
+Phase 2 (AMB PR)       ── SUBMITTED, awaiting review
+                                ↓ parallel
+Phase 3 (AML Adapter)  ── NEXT SESSION ──→  Phase 4 (AML Submit, ~Nov 2026)
+                                ↓ parallel
+Phase 5 (Score Sprint)  ── optional, any time ──→  resubmit to whichever board is live
+```
+
+## What this covers (and what it doesn't)
+
+**In scope:**
+- AMB leaderboard submission with MemoryHub provider adapter (upstream PR) — DONE
+- AML leaderboard submission with HTTP adapter (November 2026 window)
+- Score improvements that directly increase leaderboard position
+- Issues #370, #389, #453 if they yield measurable accuracy gains
+
+**Out of scope (other epics or backlog own):**
+- Internal benchmark infrastructure (EvalHub, KubeFlow jobs) — existing tooling
+- Science-project benchmarks (adversarial resistance #334, entity extraction throughput #272) — backlog
+- LongMemEval full-haystack #330, LongMemEval LLM judge #331 — relevant to AML (which includes LongMemEval) but secondary to PersonaMem submission
+- Graph-traversal vs flat vector comparison #273 — research, not leaderboard-facing
+- arXiv survey paper — separate effort, see `project_arxiv_survey_paper` memory
+
+## What landed already
+
+- PersonaMem 32k benchmark: 84.9% (500/589) with Granite embeddings + reranker, Gemini 3.1 Pro Preview (2026-07-16, internal run)
+- PersonaMem 32k reproduction: 83.7% (493/589) with same model, upstream adapter (2026-08-21, submitted as PR #34)
+- LongMemEval oracle: R@5=0.999, R@10=1.000, MRR=1.000 (2026-07-10)
+- Full ablation data: 15+ chunk configs, source ablation, signal ablation, routing experiments
+- Competitive landscape cataloged in `benchmarks/amb-harness/external_results.json` (~40 systems)
+- Provider adapter in upstream fork: `~/Developer/agent-memory-benchmark/src/memory_bench/memory/memoryhub.py` (~130 lines)
+- Internal adapter: `benchmarks/amb-harness/src/memory_bench/memory/memoryhub.py` (503 lines)
+- Results documented in `benchmarks/RESULTS.md` and cited in project README
+
+## Watch out for
+
+- **AMB PR review**: No SLA. If no review by 2026-09-04 (2 weeks), ping maintainers on issue #33. Other PRs (#24, #25, #29) have been waiting weeks to months.
+- **AML controls the answer LLM**: gpt-4o-mini. Our score will differ from the 83.7% AMB result. The retrieval quality is what we're showcasing, not the final accuracy number.
+- **AML stability requirement**: The adapter needs 30+ days uptime. Use a proper Deployment with health checks, not a one-off pod.
+- **Context token gap**: Upstream run averaged 160k context tokens vs 26k in the original. Root cause: K=70 retrieval depth with large verbatim memories. Not a bug, but may draw reviewer questions on the AMB PR.
+- **Use GEMINI_API_KEY exclusively** for all Gemini calls. GOOGLE_API_KEY is a different account without credit visibility.
+
+## If blocked
+
+- **AMB PR stalls past 2 weeks**: Ping maintainers on issue #33. Fallback: submit via `external_results.json` (simpler, no adapter code needed).
+- **AML site down or API guide not accessible**: Check agentmemories.ai status. If the API guide is unavailable, check their GitHub for docs or contact via their submission form.
+- **Cluster down**: MemoryHub must be running. Check `oc get pods --context mcp-rhoai -n memory-hub-mcp`.
+- **AML submission window not open**: Park the submission, note the revisit date (late October 2026), and optionally start Phase 5 (score improvement) in the gap.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Persistent, governed memory for AI agents. MemoryHub gives agents a shared memor
 
 **Try it now** -- `pip install "memoryhub[local]"` for a personal edition backed by SQLite (no infrastructure needed), or deploy the [cluster edition](docs/guides/cluster-install.md) on OpenShift AI for multi-agent governance, OAuth 2.1, and team-wide shared memory.
 
-Retrieval quality: 84.9% on [AMB PersonaMem](benchmarks/RESULTS.md) (2nd on the leaderboard), R@5=0.999 on LongMemEval. Requires Python 3.10+.
+Retrieval quality: 83.7% on [AMB PersonaMem 32k](benchmarks/RESULTS.md) (submitted to leaderboard, pending review), R@5=0.999 on LongMemEval oracle. Requires Python 3.10+.
 
 ## How to think about agent memory
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,67 @@
+# Benchmarks
+
+Retrieval quality and performance benchmarks for MemoryHub.
+
+## Results Summary
+
+**AMB PersonaMem 32k** (589 MCQ queries across 195 conversation transcripts, 37 personas):
+
+- **83.7%** accuracy with Gemini 3.1 Pro Preview, Granite embeddings + reranker
+- Submitted to the [AMB leaderboard](https://agentmemorybenchmark.ai) as [PR #34](https://github.com/vectorize-io/agent-memory-benchmark/pull/34), pending review
+- Best internal result: 84.9% (same pipeline, internal harness)
+
+**LongMemEval oracle** (500 session-retrieval questions):
+
+- R@5=0.999, R@10=1.000, MRR=1.000
+- Oracle variant only (evidence sessions as haystack, not full 115K-token corpus)
+
+Full results with methodology, per-run configurations, ablation data, and competitive
+context are in [RESULTS.md](RESULTS.md).
+
+## Directory Layout
+
+```
+benchmarks/
+├── RESULTS.md                 # Living results document (all runs, methodology, analysis)
+├── amb-harness/               # Vendored AMB harness with MemoryHub provider adapter
+├── amb-outputs/               # Archived AMB output files by provider/config
+├── evalhub-adapter/           # EvalHub integration (BYOF adapter for TrustyAI)
+├── results/                   # Human-readable result summaries and analysis
+├── preflight.py               # Pre-run deployment validation
+├── analyze-failures.py        # Post-run failure analysis
+└── *.json                     # Raw result files (committed for reproducibility)
+```
+
+## Benchmarks
+
+| Benchmark | What it measures | Status |
+|-----------|-----------------|--------|
+| AMB PersonaMem 32k | End-to-end preference tracking across long conversations | Submitted to leaderboard, pending review |
+| LongMemEval oracle | Session-level retrieval (small haystack) | Run internally, not submitted |
+| Cluster retrieval | Hybrid vs vector-only on production memories | Internal |
+| Retrieval at scale | pgvector latency scaling (100 to 10K items) | Internal |
+| Cross-encoder pool sweep | Reranker candidate pool size optimization | Internal |
+
+## Running Benchmarks
+
+Benchmarks run against a deployed MemoryHub cluster. The primary benchmark (AMB PersonaMem)
+requires:
+
+1. A running MemoryHub instance with Granite embedding + reranker models
+2. A Gemini API key for the answer LLM
+3. The AMB harness environment set up in `amb-harness/`
+
+```bash
+cd benchmarks/amb-harness
+cp .env.example .env    # configure credentials
+uv run omb run --provider memoryhub --dataset personamem --split 32k
+```
+
+See `amb-harness/README.md` for full setup instructions.
+
+## Leaderboard Submissions
+
+| Leaderboard | Status | Score | Date |
+|-------------|--------|-------|------|
+| [AMB](https://agentmemorybenchmark.ai) | PR submitted, pending review | 83.7% PersonaMem 32k | 2026-08-21 |
+| [AML](https://agentmemories.ai) | Not yet submitted (target ~Nov 2026) | TBD | -- |

--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -25,14 +25,24 @@ Raw result JSON files are committed alongside this document in `benchmarks/`.
 | MemPalace (semantic only) | LongMemEval | 0.966 | -- | -- | text-embedding-3-large (3072d) | Wu et al., ICLR 2025 |
 | GPT-4o (no memory layer) | LongMemEval | ~0.30-0.70 | -- | -- | (none) | Wu et al., ICLR 2025 |
 
+**Published leaderboard results (AMB):**
+
 | System | PersonaMem 32k | Answer LLM | Embedding / Retrieval | Source |
 |--------|---------------|------------|----------------------|--------|
 | Hindsight | 86.6% | Gemini 3.1 Pro Preview | LLM fact extraction into semantic graph | AMB leaderboard |
-| **MemoryHub v0.3 (Granite)** | **84.9%** | Gemini 3.1 Pro Preview | granite-embedding-english + granite-reranker-english-r2 (GPU) | This document, 2026-07-16 |
 | hybrid-search | 84.4% | Gemini 3.1 Pro Preview | 512-token chunking, dense+sparse embeddings | AMB leaderboard |
 | Cognee | 81.8% | Gemini 3.1 Pro Preview | chunking + graph entity extraction | AMB leaderboard |
-| MemoryHub v0.2 (MiniLM) | 81.2% | Gemini 3.1 Pro Preview | all-MiniLM-L6-v2 (384d), no reranker | This document, 2026-07-12 |
-| BM25 baseline | 67.7% | Gemini 3.1 Flash Lite | keyword only | This document, 2026-07-12 |
+
+**MemoryHub results (submitted to AMB leaderboard, pending review):**
+
+| Run | PersonaMem 32k | Answer LLM | Embedding / Retrieval | Date |
+|-----|---------------|------------|----------------------|------|
+| Upstream adapter (submitted) | **83.7%** | Gemini 3.1 Pro Preview | granite-embedding-english + granite-reranker-english-r2 (GPU) | 2026-08-21 |
+| Internal v0.3 (Granite) | 84.9% | Gemini 3.1 Pro Preview | granite-embedding-english + granite-reranker-english-r2 (GPU) | 2026-07-16 |
+| Internal v0.2 (MiniLM) | 81.2% | Gemini 3.1 Pro Preview | all-MiniLM-L6-v2 (384d), no reranker | 2026-07-12 |
+| BM25 baseline | 67.7% | Gemini 3.1 Flash Lite | keyword only | 2026-07-12 |
+
+MemoryHub's upstream adapter and results were submitted as [PR #34](https://github.com/vectorize-io/agent-memory-benchmark/pull/34) to the AMB repository on 2026-08-21. Leaderboard placement is pending maintainer review.
 
 **Source ablation (Flash Lite answer LLM, not leaderboard-comparable -- same model across all three for relative comparison):**
 
@@ -44,9 +54,9 @@ Raw result JSON files are committed alongside this document in `benchmarks/`.
 
 Notes:
 - MemPalace numbers are from the LongMemEval paper's reported "session decomposition + fact-augmented key expansion + time-aware query expansion" pipeline.
-- Our run uses the oracle variant (evidence sessions only, not the full 115K-token haystack). The oracle variant isolates retrieval quality from the haystack-filtering step. Running LongMemEval_S (full haystack) is the next comparison point.
-- MemoryHub v0.3 uses granite-embedding-english + granite-reranker-english-r2 (GPU). MemoryHub v0.2 used all-MiniLM-L6-v2 (384-dim). MemPalace uses text-embedding-3-large (3072-dim).
-- All PersonaMem leaderboard runs use Gemini 3.1 Pro Preview as the answer LLM. The ablation table uses Gemini 3.1 Flash Lite (not comparable to leaderboard numbers, but valid for relative comparison across source configurations).
+- Our LongMemEval run uses the oracle variant (evidence sessions only, not the full 115K-token haystack). The oracle variant isolates retrieval quality from the haystack-filtering step. Running LongMemEval_S (full haystack) is the next comparison point.
+- The 83.7% submitted result and the 84.9% internal result both use Granite embeddings and reranker. The difference is attributable to adapter implementation details (upstream vs internal harness) and run-to-run variance.
+- All PersonaMem runs targeting leaderboard comparison use Gemini 3.1 Pro Preview as the answer LLM. The ablation table uses Gemini 3.1 Flash Lite (not comparable to Pro numbers, but valid for relative comparison across source configurations).
 - The v0.3 Combined row (84.9%, 2026-07-19) was removed from the main table -- it was invalidated by a tenant mismatch bug (dreaming memories were never searched). See the detailed run section below.
 - Retrieval-unit routing (#447) is the planned architecture change to make dreaming facts contribute to combined search results.
 
@@ -72,7 +82,7 @@ Notes:
 | MemoryHub | Gemini 3.1 Flash Lite | 589 | 417 | 70.8% |
 | BM25 baseline | Gemini 3.1 Flash Lite | 589 | 399 | 67.7% |
 
-**AMB Leaderboard comparison (all using Gemini 3.1 Pro Preview):**
+**Comparison with published AMB leaderboard entries (all using Gemini 3.1 Pro Preview):**
 
 | System | Approach | Accuracy |
 |--------|----------|----------|
@@ -93,7 +103,7 @@ Result files: `amb-outputs/personamem/_archive/memoryhub-pro-unchunked-20260712/
 |----------|-------|---------|---------|----------|
 | **MemoryHub (Granite)** | **Gemini 3.1 Pro Preview** | **589** | **500** | **84.9%** |
 
-**AMB Leaderboard comparison (all using Gemini 3.1 Pro Preview):**
+**Comparison with published AMB leaderboard entries (all using Gemini 3.1 Pro Preview):**
 
 | System | Approach | Accuracy |
 |--------|----------|----------|
@@ -151,6 +161,22 @@ Result file: `outputs/personamem/combined-pro/rag/32k.json`
 3. **Architecture changes needed to realize value:** retrieval-unit routing (search facts and transcripts separately, merge results), fact-aware scoring (boost extracted facts in RRF), or a two-stage pipeline (retrieve transcripts, then enrich with related facts).
 
 Result files: `outputs/personamem/combined-flash-lite/rag/32k.json`, `outputs/personamem/ablation-library-only/rag/32k.json`, `outputs/personamem/ablation-dreaming-only/rag/32k.json`
+
+#### Run: 2026-08-21 (Upstream adapter reproduction, Gemini 3.1 Pro Preview) -- SUBMITTED
+
+**Pipeline state:** Upstream AMB provider adapter (`memoryhub.py`, ~130 lines) running against the deployed MemoryHub cluster. Granite embeddings + granite-reranker-english-r2 (GPU), hybrid search with RRF blend. Same retrieval pipeline as the 2026-07-16 internal run. Documents ingested into a fresh `amb-*` tenant via the upstream adapter's `add_memories()` path.
+
+**Answer LLM:** Gemini 3.1 Pro Preview (leaderboard-comparable).
+
+| Provider | Model | Queries | Correct | Accuracy |
+|----------|-------|---------|---------|----------|
+| **MemoryHub (upstream adapter)** | **Gemini 3.1 Pro Preview** | **589** | **493** | **83.7%** |
+
+**Delta from internal v0.3 run:** -1.2pp (83.7% vs 84.9%). The difference is attributable to adapter implementation differences (upstream adapter vs internal harness) and run-to-run variance. Both runs use the same retrieval pipeline and answer LLM.
+
+**Submission:** This result was submitted to the AMB leaderboard as [PR #34](https://github.com/vectorize-io/agent-memory-benchmark/pull/34) with [issue #33](https://github.com/vectorize-io/agent-memory-benchmark/issues/33). Leaderboard placement pending maintainer review.
+
+Result file: upstream fork at `~/Developer/agent-memory-benchmark/outputs/personamem/memoryhub/rag/32k.json`
 
 #### Run: 2026-07-12 (v0.2, SDK provider with chunking, Flash Lite)
 

--- a/demos/2026-07-16-benchmark-meeting-summary.md
+++ b/demos/2026-07-16-benchmark-meeting-summary.md
@@ -2,7 +2,7 @@
 
 ### Where we are
 
-MemoryHub's PersonaMem accuracy is **84.9%** with Granite embeddings, Granite reranker, and Gemini Pro as the answer model. This is a fresh full-pipeline run (589 queries) that passes both Cognee (81.8%) and hybrid-search (84.4%) on the AMB leaderboard. We are 1.7pp behind Hindsight (86.6%) -- the gap to close with fact extraction and reconciliation.
+MemoryHub's PersonaMem accuracy is **83.7%** (submitted) with Granite embeddings, Granite reranker, and Gemini Pro as the answer model. An earlier internal run scored 84.9%; the submitted result uses the upstream adapter. Both scores exceed Cognee (81.8%) among published AMB leaderboard entries. We are behind Hindsight (86.6%) and hybrid-search (84.4%) -- the gap to close with fact extraction and reconciliation. Leaderboard placement is pending maintainer review of [PR #34](https://github.com/vectorize-io/agent-memory-benchmark/pull/34).
 
 On LongMemEval (retrieval benchmark, 500 queries), MemoryHub scores **R@10 = 1.000** and **MRR = 1.000** -- perfect retrieval.
 
@@ -59,12 +59,15 @@ The 85% target is within reach. Reconciliation and fact-augmented retrieval are 
 
 ### Competitive landscape (PersonaMem 32k, all Gemini 3.1 Pro Preview)
 
-| System | Accuracy | Approach |
-|---|---|---|
-| Hindsight | 86.6% | LLM fact extraction into semantic graph |
-| **MemoryHub (Granite)** | **84.9%** | **Granite embed + reranker, hybrid search, no extraction** |
-| hybrid-search | 84.4% | 512-token chunking, dense+sparse embeddings |
-| Cognee | 81.8% | Chunking + graph entity extraction |
-| MemoryHub (MiniLM, July 12) | 81.2% | MiniLM embed, no working reranker |
+Published AMB leaderboard entries shown for context; MemoryHub's results are internal measurements, not published leaderboard positions. The submitted score (83.7%, August 2026) is pending review.
 
-The story: MemoryHub is now competitive with the top systems on raw accuracy, and the remaining 1.7pp gap to Hindsight is attributable to fact extraction (which Hindsight uses and we have built but not yet activated in the benchmark path). The reconciliation pipeline (#347) is the next step toward closing it.
+| System | Accuracy | Approach | Source |
+|---|---|---|---|
+| Hindsight | 86.6% | LLM fact extraction into semantic graph | AMB leaderboard |
+| hybrid-search | 84.4% | 512-token chunking, dense+sparse embeddings | AMB leaderboard |
+| MemoryHub (Granite, internal) | 84.9% | Granite embed + reranker, hybrid search, no extraction | Internal run, 2026-07-16 |
+| **MemoryHub (submitted)** | **83.7%** | **Granite embed + reranker, upstream adapter** | **PR #34, 2026-08-21** |
+| Cognee | 81.8% | Chunking + graph entity extraction | AMB leaderboard |
+| MemoryHub (MiniLM, July 12) | 81.2% | MiniLM embed, no working reranker | Internal run |
+
+The remaining gap to Hindsight is attributable to fact extraction (which Hindsight uses and we have built but not yet activated in the benchmark path). The reconciliation pipeline (#347) is the next step toward closing it.

--- a/demos/blog-deploy-memoryhub-openshift-ai.md
+++ b/demos/blog-deploy-memoryhub-openshift-ai.md
@@ -1,0 +1,308 @@
+# Deploy MemoryHub on OpenShift AI to give your agents persistent memory
+
+As we all know, when you use an AI model, or a simple agent connected to a model,
+the AI doesn't remember anything about the conversations you've had in the past,
+which can make a new conversation cumbersome. That's where agent memory systems
+come in. Memory is what lets your agent know who you are, learn your preferences,
+and adopt rules you give it, such as which package manager you want to use most
+of the time, or how you want to sing for the local opera someday, or key points
+about a book you're writing. Learning all these things about you makes your agent
+more than just a tool. AI can become an integral part of your workflow, so long
+as it can learn your workflow and follow it well.
+
+There are lots of agent memory systems available. Some are popular, and many
+use the LLM Wiki system made famous by Andrej Karpathy in his now-famous gist
+here: https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f
+
+Many of these systems are great, and solve a specific set of problems. If
+you are running an agent on your local laptop, and you want really good agent
+memory, then many of these systems solve that problem exceptionally well.
+
+What about when you are running agents in an enterprise? Think of a healthcare
+process such as prescription fulfillment, where multiple steps might be managed
+by individual agents helping the process go along smoothly, or a factory floor
+where advanced manufacturing is run by AI agents. In those situations, we find
+that the agents need to be able to share memories among themselves, so that they
+can have a sort of "hive mind" and act together to solve problems. Enterprises
+employing these types of agent teams also have governance and compliance requirements
+such as audit, provenance (how did this memory get in here), role-based access
+controls, and the ability for all of this to operate at great scale.
+
+For these needs, there is MemoryHub.
+
+MemoryHub is intended for enterprises who want to run agents at scale, in production,
+and have regulatory and cybersecurity requirements that apply to every layer in
+the AI application set.
+
+A few key features, and then we'll go install it and explore how it works:
+
+## Memory Storage
+MemoryHub stores memories in PostgreSQL+PGVector as a tree-structured memory model.
+This differs from many local-first systems which
+use markdown, markdown+yaml, or some other file-based system. Files are great
+for agent memory and are appropriate in many cases. If your intention is to have
+many agents accessing memories, updating them, and deleting them, and you need
+to keep track of memory versions, provenance, and support administrative actions
+like conflict resolution and deletes, then a database presents itself as the
+obvious choice.
+
+In MemoryHub, each memory is a node with metadata. That metadata includes the weight,
+which controls how prominently it gets considered in the agent's context.
+
+Memories are organized by scope: user, project, campaign, role, organizational,
+and enterprise. An individual developer's preferences live at user scope. A
+team's architectural decisions live at project scope. A company-wide security
+policy lives at enterprise scope. Agents act in the user's security context, so
+they can see what the user is allowed to see. This is enforced by the RBAC controls
+in MemoryHub.
+
+Each memory node can carry typed branches. A rationale branch captures why a
+decision was made. A provenance branch records where the information came from.
+When an agent retrieves a memory, it can optionally follow these branches to understand
+context, not just the fact itself.
+
+Content is classified as experiential (learned from interaction), knowledge
+(imported facts), or behavioral (patterns of how the user works). This
+distinction matters because different content types have different curation
+needs. An experiential memory about a user's preference might change from time to time.
+A knowledge memory about an API endpoint should be checked for staleness.
+
+The interface is MCP-native. Agents connect using the
+[Model Context Protocol](https://modelcontextprotocol.io) they already speak.
+Four action-dispatch tools cover the full surface: `register_session` for
+authentication, `memory` for all read/write operations, `thread` for
+conversation persistence, and `admin_memory` for governance. Any MCP-compatible
+client (Claude Code, LlamaStack, custom agents) can connect without an adapter
+layer.
+
+## Architecture on OpenShift AI
+
+MemoryHub deploys as a set of microservices across dedicated OpenShift
+namespaces:
+
+```mermaid
+graph TB
+    subgraph clients ["Agent Clients"]
+        CC["Claude Code"]
+        LS["LlamaStack"]
+        CA["Custom Agents"]
+        CLI["memoryhub CLI"]
+        SDK["Python SDK"]
+    end
+
+    subgraph mcp_ns ["memory-hub-mcp namespace"]
+        MCP["MCP Server<br/>(FastMCP 3, streamable-HTTP)"]
+        MO["MinIO<br/>(S3 object storage)"]
+        VK["Valkey<br/>(job queues)"]
+    end
+
+    subgraph ui_ns ["memoryhub-ui namespace"]
+        UI["Dashboard<br/>(React + PatternFly 6)"]
+        BFF["Dashboard BFF<br/>(FastAPI + oauth-proxy)"]
+    end
+
+    subgraph auth_ns ["memoryhub-auth namespace"]
+        AUTH["OAuth 2.1 AS<br/>(RSA-2048 JWTs)"]
+    end
+
+    subgraph db_ns ["memoryhub-db namespace"]
+        PG["PostgreSQL + pgvector"]
+    end
+
+    subgraph emb_ns ["embedding-model namespace"]
+        EMB["all-MiniLM-L6-v2<br/>(TEI CPU)"]
+    end
+
+    subgraph rer_ns ["reranker-model namespace"]
+        RER["ms-marco-MiniLM-L12-v2<br/>(TEI CPU)"]
+    end
+
+    CC & LS & CA --> MCP
+    CLI & SDK --> MCP
+    UI --> BFF --> MCP
+    MCP --> PG
+    MCP --> MO
+    MCP --> VK
+    MCP --> EMB
+    MCP --> RER
+    MCP --> AUTH
+    AUTH --> PG
+```
+
+**Figure 1:** MemoryHub deployment architecture on OpenShift AI.
+
+A few architectural decisions are worth calling out:
+
+**Single database for everything.** PostgreSQL with pgvector handles
+relational data, vector similarity search, and graph queries in one place. No
+separate vector database or graph database to operate. Schema changes are
+managed by Alembic migrations that run automatically during deployment.
+
+**Self-hosted models, no GPU required.** The embedding model
+(all-MiniLM-L6-v2, 384 dimensions) and reranker (ms-marco-MiniLM-L12-v2)
+both run on Hugging Face Text Embeddings Inference with CPU. The entire
+inference pipeline stays inside the cluster with no external API calls and no
+GPU scheduling to configure. If you have GPUs available, pass `--gpu-models` to
+the installation script for better throughput.
+
+**Minimal SCC footprint.** The MCP server, auth service, and model
+serving all run under OpenShift's default `restricted-v2` SCC. PostgreSQL,
+MinIO, and Valkey require `anyuid` on their service accounts, which the
+installation script grants automatically. No privileged containers.
+
+**Kustomize-native manifests.** Each subsystem has its own `deploy/` directory
+with kustomize-structured manifests, ready for integration with ArgoCD or
+OpenShift GitOps.
+
+## Prerequisites
+
+- OpenShift 4.x cluster (no GPU required for default CPU deployment)
+- `oc` CLI, authenticated to the cluster
+- Cluster-admin or namespace-create permissions
+- `make` and `git` on your workstation
+
+## Deploy the full stack
+
+Three commands:
+
+```bash
+git clone https://github.com/redhat-ai-americas/memory-hub.git
+cd memory-hub
+make install
+```
+
+`make install` runs a single deployment script that creates the namespaces,
+bootstraps PostgreSQL, runs schema migrations, deploys MinIO and Valkey, starts
+the embedding and reranker models, deploys the MCP server and OAuth
+authorization server, brings up the dashboard, and runs a smoke test. The whole
+process takes about ten minutes on a typical cluster.
+
+The installation script generates API keys automatically and prints them at the end.
+You'll need the API key to connect agents.
+
+If your cluster has GPUs available, deploy with GPU-accelerated models instead:
+
+```bash
+make install ARGS="--gpu-models"
+```
+
+To verify everything is running:
+
+```bash
+oc get pods --context <your-context> -n memory-hub-mcp
+oc get pods --context <your-context> -n memoryhub-db
+oc get pods --context <your-context> -n memoryhub-auth
+oc get pods --context <your-context> -n memoryhub-ui
+```
+
+## Connect your agents
+
+MemoryHub exposes three client interfaces. Pick the one that fits your
+workflow.
+
+### MCP (native agent protocol)
+
+Any MCP-compatible agent can connect directly. For Claude Code:
+
+```bash
+claude mcp add memoryhub -- memoryhub mcp
+```
+
+The agent discovers the tools automatically. A typical interaction looks like
+this: the agent calls `register_session` with an API key, then uses the
+`memory` tool to search, write, read, and update memories. No adapter code
+needed.
+
+### Python SDK
+
+For programmatic access from your own agents or pipelines:
+
+```bash
+pip install memoryhub
+```
+
+```python
+from memoryhub import MemoryHubClient
+
+client = MemoryHubClient(
+    url="https://your-memoryhub-route/mcp/",
+    api_key="mh-dev-..."
+)
+
+# Write a memory
+client.write_sync(
+    "Team prefers FastAPI over Flask for new services",
+    scope="project",
+    weight=0.8
+)
+
+# Search
+results = client.search_sync("web framework preferences")
+for memory in results:
+    print(f"[{memory.weight}] {memory.content}")
+```
+
+### CLI
+
+For quick lookups and scripting:
+
+```bash
+pip install memoryhub-cli
+memoryhub login                             # one-time credential setup
+memoryhub search "deployment patterns"
+memoryhub write "Use Podman, not Docker" --scope user --weight 0.9
+memoryhub read <memory-id>
+```
+
+## Try it locally first
+
+If you want to evaluate MemoryHub before deploying to a cluster, there's a
+personal edition that runs entirely on your workstation:
+
+```bash
+pip install "memoryhub[local]"
+claude mcp add memoryhub -- memoryhub mcp
+```
+
+This installs a local MCP server backed by SQLite and sqlite-vec. It exposes
+the same four-tool MCP surface as the cluster deployment, so agents don't
+need to change how they interact. When you're ready for multi-agent, multi-user
+deployment with full RBAC and background curation, move to the cluster edition.
+
+## Where it stands
+
+Here's where MemoryHub stands on the
+[AMB PersonaMem benchmark](https://huggingface.co/spaces/MARco-o1/AMB),
+which measures how well a memory system retains and retrieves information
+across long conversations. All systems use Gemini 3.1 Pro Preview as the
+answer LLM so the only variable is the memory layer:
+
+| System | PersonaMem 32k | Retrieval Approach |
+|--------|---------------|--------------------|
+| Hindsight | 86.6% | LLM fact extraction into semantic graph |
+| hybrid-search | 84.4% | 512-token chunking, dense+sparse embeddings |
+| **MemoryHub (Granite, GPU)** | **83.7%** | Granite embedding + reranker, hybrid search |
+| Cognee | 81.8% | Chunking + graph entity extraction |
+| **MemoryHub (MiniLM, CPU)** | **81.2%** | all-MiniLM-L6-v2, cosine-only ranking |
+
+Published leaderboard results are shown for other systems; MemoryHub's
+score (83.7%) has been submitted and is pending review
+([PR #34](https://github.com/vectorize-io/agent-memory-benchmark/pull/34)).
+
+The default CPU install (`make install`) uses MiniLM and scores 81.2%.
+The GPU configuration (`make install ARGS="--gpu-models"`) uses Granite
+models whose 8192-token context window lets the reranker score full
+conversation transcripts instead of falling back to cosine-only ranking,
+pushing the score to 83.7%.
+
+We also ran the
+[LongMemEval](https://github.com/xiaowu0162/LongMemEval) retrieval
+benchmark. MemoryHub achieved R@5=0.999, meaning that in our testing the
+relevant memory appeared within the five returned results on nearly
+every query.
+
+The project is Apache 2.0 licensed and available at
+[github.com/redhat-ai-americas/memory-hub](https://github.com/redhat-ai-americas/memory-hub).
+If your team is running agents on OpenShift and wants them to actually learn
+from experience rather than starting from zero every session, it's worth
+deploying.

--- a/session-summaries/2026-08-18-public-benchmarks-epic-planning.md
+++ b/session-summaries/2026-08-18-public-benchmarks-epic-planning.md
@@ -1,0 +1,40 @@
+# Session Summary — 2026-08-18 · public-benchmarks · Epic planning for AMB and AML leaderboard submissions
+
+**Plan:** New epic (no prior plan)   **Commits:** ee20b17 (`feat/soc-demo-openshell`)
+**Deployed:** none   **Model:** Claude Code (Opus 4.6)
+
+## Plan vs. actual
+Planned: Research how to submit MemoryHub benchmark results to AMB PersonaMem leaderboard. Shipped: full epic plan covering both AMB and AML submission venues, with next-session file ready for Phase 1. Slipped: none.
+Scope: expanded from "how do we submit" to a full 5-phase epic covering both leaderboards — user-directed expansion.
+
+## Shipped
+- `ee20b17` — Epic plan file `NEXT_SESSION-public-benchmarks.md` with 5 phases, execution order, and next-session focus on AMB upstream provider adapter
+
+## Verification & confidence
+- Smoke-checked upstream AMB repo state: confirmed no existing MemoryHub provider, confirmed 3 memory systems already on PersonaMem board (Hindsight 86.6%, hybrid-search 84.4%, Cognee 81.8%), confirmed no existing fork
+- Verified our adapter exists at `benchmarks/amb-harness/src/memory_bench/memory/memoryhub.py` (503 lines)
+- Verified our result file exists at `benchmarks/amb-harness/outputs/personamem/granite-pro/rag/32k.json.gz`
+- Confidence: high — this is planning, not code; the factual claims about both venues were verified against live repo state and web research
+
+## Judgment calls & deviations
+- Corrected an initial assumption from web research that AMB PersonaMem only had LLM baselines — the upstream manifest shows 3 memory systems already. The epic file was updated before committing.
+- Combined Phases 1+2 (adapter + PR) into one session focus since the adapter work is mostly trimming an existing 503-line file, not building from scratch.
+- Scoped AML as "build adapter now, park submission until November" rather than waiting entirely — the HTTP adapter work is independent and worth doing while AMB context is fresh.
+
+## Backlog delta
+Filed: none. Closed: none. Deferred: none.
+Memory: none written (the epic file carries the context).
+
+## Drift & forward-collisions
+- Backward — none. This session was pure planning, no code changes that affect existing issues.
+- Forward — #370 (Ablation Matrix B), #389 (S3 hydration), #453 (disabled_signals) identified as Phase 5 score-improvement candidates. No comments posted (these are our own repo issues and the connection is already documented in the epic file).
+
+## For the reviewer
+- Sanity-check: Is combining Phase 1+2 into one session realistic? The adapter cleanup should be straightforward (trim env vars, match upstream conventions), but reproduction against the cluster adds uncertainty (cluster must be healthy, network accessible).
+- Thin verification: AML submission window timing (~November 2026) is inferred from "1 attempt per 3 months" and the Aug 7 deadline. Not confirmed with AML directly.
+- Wants guidance: none
+
+## Risks / watch-fors
+- The upstream AMB repo is run by Vectorize (makers of Hindsight, the #1 entry). PR review dynamics may be slow or have competitive considerations.
+- Our 84.9% was measured with Gemini 3.1 Pro Preview as answer LLM. If the upstream harness pins a different answer LLM, our score could shift.
+- AML's next submission window is unconfirmed — set a reminder to check in late October.

--- a/session-summaries/2026-08-21-public-benchmarks-adapter-and-checkpointing.md
+++ b/session-summaries/2026-08-21-public-benchmarks-adapter-and-checkpointing.md
@@ -1,0 +1,54 @@
+# Session Summary -- 2026-08-21 - public-benchmarks - Adapter, server fix, checkpoint-gated eval
+
+**Plan:** NEXT_SESSION-public-benchmarks.md (Phases 1+2)   **Commits:** c4b3c06..d82e9c3 (feat/soc-demo-openshell + fork main)
+**Deployed:** Server fix deployed (build 33, mcp-rhoai)   **Model:** Opus 4.6
+
+## Plan vs. actual
+Planned: Fork upstream AMB repo, write clean MemoryHub adapter, reproduce 84.9%, submit PR. Shipped: Fork, adapter, server bug fix, checkpoint-gated evaluation system. Slipped: Reproduction run blocked by Gemini credit exhaustion; PR submission deferred.
+Scope: Expanded to include server-side logical_id bug fix and checkpoint-gated batch evaluation (both blockers discovered during execution).
+
+## Shipped
+
+**memory-hub repo:**
+- `c4b3c06` fix: Set logical_id on chunk and fact child nodes (server bug, deployed as build 33)
+
+**agent-memory-benchmark fork (rdwj/agent-memory-benchmark):**
+- `d82e9c3` feat: Add MemoryHub provider adapter and reproduction tooling (130-line adapter, lab notes, PR draft)
+- `fd21357` feat: Checkpoint-gated batch evaluation with smoke test gate (--smoke-test / --batch-size flags)
+- `5ec4f11` feat: Add incremental checkpointing to batch mode runner (superseded by fd21357 but still in history)
+
+**Infrastructure:**
+- Fork created at rdwj/agent-memory-benchmark
+- MemoryHub adapter registered, discoverable via `amb providers`
+- 195 PersonaMem documents ingested on cluster (project: amb-upstream-repro)
+- Server rebuilt and deployed with logical_id fix
+
+## Verification & confidence
+- Provider discovery: verified via `uv run amb providers` and Python import
+- Ingestion: 195 docs in 82.8s, confirmed via server logs
+- Retrieval + answer: 3/3 correct in smoke test with gemini-3.1-pro-preview
+- Checkpoint gating: verified that --batch-size fails without --smoke-test
+- Full 589-query run: NOT completed (Gemini credits depleted at ~540 queries)
+- Confidence: **medium** -- adapter and infrastructure proven end-to-end on small scale; full reproduction pending credits
+
+## Judgment calls & deviations
+- Fixed logical_id server bug in-session rather than filing and deferring (it was a direct blocker for any write that triggers chunking, and the fix was mechanical)
+- Built checkpoint-gated evaluation after three runs lost data (escalated from "incremental save" to "structural gate" at user direction)
+- Used gemini-3.5-flash-lite as answer LLM initially (75.2% result); switched to gemini-3.1-pro-preview to match original 84.9% but credits ran out
+
+## Backlog delta
+Memory `feedback_implement_checkpointing_not_notes` -- benchmark checkpointing must be in code, not conventions. Memory `feedback_keep_upstream_fork_local` -- clone upstream repos on fast connections before sessions.
+
+## Drift & forward-collisions
+- Backward -- none identified
+- Forward -- none identified
+
+## For the reviewer
+- Sanity-check: The 75.2% flash-lite result vs 84.9% pro-preview raises the question of which model to submit with. The retrieval quality is identical; the gap is entirely in the answer LLM. Need to decide: submit with the cheaper model (lower score, reproducible by anyone) or the expensive model (higher score, harder to reproduce)?
+- Thin verification: Full 589-query reproduction not completed. The 3-query smoke test is too small to confirm retrieval quality matches the original run.
+- Wants guidance: Should we submit the adapter PR without results (let upstream run it themselves), or wait until we have a full verified run?
+
+## Risks / watch-fors
+- Gemini credits are depleted across all models. Next session needs credits topped up before any benchmark work.
+- The fork's `uv.lock` was modified by dependency resolution and included in the commit. This is expected (adding `memoryhub>=0.15` to pyproject.toml triggers a lockfile update) but the diff is large.
+- Context token count doubled (53k vs 26k in original). Root cause not fully investigated. Could affect score comparison even with the same answer model.

--- a/session-summaries/2026-08-21-public-benchmarks-reproduction-and-pr.md
+++ b/session-summaries/2026-08-21-public-benchmarks-reproduction-and-pr.md
@@ -1,0 +1,49 @@
+# Session Summary -- 2026-08-21 -- public-benchmarks -- Reproduction run and upstream PR submission
+
+**Plan:** NEXT_SESSION-public-benchmarks.md   **Commits:** dc73114..57b064f (agent-memory-benchmark fork), none on memory-hub
+**Deployed:** none   **Model:** Opus 4.6
+
+## Plan vs. actual
+Planned: verify credits, smoke test, full 589-query reproduction run, submit upstream PR.
+Shipped: all four steps completed. Score landed at 83.7%, submitted as PR #34 to vectorize-io/agent-memory-benchmark.
+Slipped: none. One DNS blip at query 265 handled by checkpoint resume.
+
+## Shipped
+- Full PersonaMem 32k reproduction: 83.7% (493/589) with gemini-3.1-pro-preview (`outputs/personamem/memoryhub/rag/32k.json.gz`, 14MB compressed)
+- Upstream issue vectorize-io/agent-memory-benchmark#33 (provider introduction)
+- Upstream PR vectorize-io/agent-memory-benchmark#34 (adapter + results + manifest, from clean `memoryhub-provider` branch cherry-picked off upstream/main)
+- Removed GOOGLE_API_KEY fallback from fork's cli.py, hindsight.py, ogham.py (`dc73114`)
+- Added lint script `scripts/lint-no-google-api-key.sh` in fork
+- CLAUDE.md note: use GEMINI_API_KEY exclusively for this project
+- Memory: `feedback_publish_what_we_get` -- commit to publishing benchmark results rather than gate-keeping on a target score
+
+## Verification & confidence
+- 589/589 queries completed and checkpointed (118 batches of 5)
+- Smoke test 3/3 correct before full run
+- Results file verified: 493 correct, 0.8370 accuracy
+- Compressed output matches upstream format (14MB, comparable to Hindsight's 12MB)
+- PR branch created from upstream/main with selective cherry-pick; diff verified to contain only MemoryHub-specific files
+- Confidence: high -- results are real, pipeline ran end-to-end, checkpoint system handled a mid-run DNS failure
+
+## Judgment calls & deviations
+- Score 83.7% vs original 84.9%: 1.2 point delta, attributed to the 2x context token gap (160k avg vs 26k original). Per the "publish what we get" decision, submitted as-is rather than investigating further.
+- Context truncation in submitted results: truncated context field to 80k chars per query (matching Hindsight's ~72k) to get compressed size under GitHub's 100MB limit. Full results preserved locally.
+- GOOGLE_API_KEY removal: applied across the fork (not just our adapter) because cli.py was setting GOOGLE_API_KEY globally, causing the SDK to pick the wrong account. Fork-only change, not in the upstream PR.
+
+## Backlog delta
+Filed: vectorize-io/agent-memory-benchmark#33 (external, provider intro)
+Memory: `feedback_publish_what_we_get`
+Deferred: context token gap investigation (2x vs original) -- noted in PR, not blocking
+
+## Drift & forward-collisions
+- Backward: none on memory-hub repo. This session's work was entirely in the AMB fork.
+- Forward: Phase 2 (AMB Leaderboard PR) is now submitted as vectorize-io/agent-memory-benchmark#34. NEXT_SESSION-public-benchmarks.md Phase 2 "Submit PR" is done pending maintainer review.
+
+## For the reviewer
+- Sanity-check: the 83.7% vs 84.9% delta. The 2x context token gap (160k avg tokens) is the likely cause. Worth investigating if we do a score improvement sprint (Phase 5), but not blocking the submission.
+- Thin verification: the GOOGLE_API_KEY removal was tested only by running the smoke test + full run against the memoryhub provider. Other providers (hindsight, ogham) were not tested with the change.
+- Wants guidance: none.
+
+## Risks / watch-fors
+- Upstream PR review has no SLA. Plan says "ping after 2 weeks if stalled." Other open PRs (#24, #25, #29) have been waiting weeks to months.
+- The 160k avg context tokens is notably high and may draw questions from reviewers. The root cause (K=70 retrieval depth with large verbatim memories) is a MemoryHub architectural characteristic, not a bug.


### PR DESCRIPTION
## Summary
Documentation and session tracking for the public benchmarks epic:

- `benchmarks/README.md` with methodology and reproduction instructions
- Updated `RESULTS.md` with submitted scores
- Epic plan (`NEXT_SESSION-public-benchmarks.md`)
- Updated benchmark claims in `README.md`
- Benchmark meeting summary and blog post updates
- Session summaries for benchmarking sessions

Split from #543 per reviewer feedback to separate topics into focused PRs.

## Test plan
- [ ] Files are limited to benchmarks/, docs, and session summaries
- [ ] No merge conflicts with main
- [ ] No src/ code changes included